### PR TITLE
Bug: Google Calendar OAuth fails with "Could not determine account email"

### DIFF
--- a/apps/api/src/services/calendar-providers/google.ts
+++ b/apps/api/src/services/calendar-providers/google.ts
@@ -26,6 +26,8 @@ const GOOGLE_CALENDAR_API = 'https://www.googleapis.com/calendar/v3';
 const SCOPES = [
   'https://www.googleapis.com/auth/calendar.readonly',
   'https://www.googleapis.com/auth/calendar.events',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile'
 ].join(' ');
 
 export class GoogleCalendarProvider implements CalendarProvider {

--- a/docs/calendar/google-calendar-setup.md
+++ b/docs/calendar/google-calendar-setup.md
@@ -1,0 +1,134 @@
+# Google Calendar Setup Guide
+
+## Overview
+Open Sunsama uses Google OAuth 2.0 to connect to your Google Calendar.
+This guide walks you through setting up Google Calendar integration for local development.
+
+## Prerequisites
+- A Google account (recommended: create a separate test account)
+- Access to [Google Cloud Console](https://console.cloud.google.com)
+
+## Step 1 — Create a Google Cloud Project
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com)
+2. Click **Select Project** → **New Project**
+3. Name: `open-sunsama-dev`
+4. Click **Create**
+
+## Step 2 — Enable Required APIs
+
+1. Go to **APIs & Services** → **Enable APIs & Services**
+2. Search and enable:
+   - **Google Calendar API**
+   - **People API**
+
+## Step 3 — Configure OAuth Consent Screen
+
+1. Go to **APIs & Services** → **OAuth Consent Screen**
+2. Select **External** → **Create**
+3. Fill in:
+   - App name: `Open Sunsama Dev`
+   - User support email: your email
+   - Developer contact email: your email
+4. Click **Save & Continue**
+5. On **Scopes** page → click **Save & Continue** (skip for now)
+6. On **Test Users** page:
+   - Click **Add Users**
+   - Add your Google account email
+   - Click **Save**
+
+## Step 4 — Create OAuth Credentials
+
+1. Go to **APIs & Services** → **Credentials**
+2. Click **Create Credentials** → **OAuth Client ID**
+3. Application type: **Web application**
+4. Name: `open-sunsama-local`
+5. Under **Authorized redirect URIs** add exactly:
+http://localhost:3001/calendar/oauth/google/callback
+6. Click **Create**
+7. Copy your **Client ID** and **Client Secret**
+
+## Step 5 — Configure Environment Variables
+
+Add to your `apps/api/.env`:
+
+```env
+GOOGLE_CLIENT_ID=your_client_id_here
+GOOGLE_CLIENT_SECRET=your_client_secret_here
+CALENDAR_ENCRYPTION_KEY=your_64_char_hex_key
+JWT_SECRET=your_jwt_secret
+```
+
+Generate required keys:
+```bash
+# JWT Secret
+openssl rand -base64 32
+
+# Calendar Encryption Key
+openssl rand -hex 32
+```
+
+## Step 6 — Restart the App
+
+```bash
+# Stop the dev server
+Ctrl + C
+
+# Copy env to api app
+cp .env apps/api/.env
+
+# Start again
+bun run dev
+```
+
+## Common Errors & Fixes
+
+### Error 400: redirect_uri_mismatch
+**Cause:** Redirect URI in Google Console doesn't match exactly.
+
+**Fix:** Make sure you added exactly this URI with no trailing slash:
+http://localhost:3001/calendar/oauth/google/callback
+
+### Error 403: access_denied
+**Cause:** Your Google account is not added as a test user.
+
+**Fix:** 
+1. Go to Google Cloud Console
+2. APIs & Services → OAuth Consent Screen
+3. Test Users → Add Users
+4. Add your Google account email
+5. Save and try again
+
+### Error: Invalid key length
+**Cause:** `CALENDAR_ENCRYPTION_KEY` or `JWT_SECRET` is missing or too short.
+
+**Fix:** Generate proper keys:
+```bash
+# JWT Secret (min 32 chars)
+openssl rand -base64 32
+
+# Calendar Encryption Key (exactly 64 hex chars)
+openssl rand -hex 32
+```
+
+### Error: Database URL not found
+**Cause:** `.env` file not copied to `apps/api/`
+
+**Fix:**
+```bash
+cp .env apps/api/.env
+```
+
+### Error: Connection to localhost:5432 refused
+**Cause:** PostgreSQL is not running.
+
+**Fix:**
+```bash
+brew services start postgresql@15
+```
+
+## Security Notes
+
+- Use a separate Google account for testing
+- `CALENDAR_ENCRYPTION_KEY` encrypts OAuth tokens stored in database
+- `JWT_SECRET` signs authentication tokens


### PR DESCRIPTION
## Description
Fixes Google Calendar OAuth integration failing with "Could not determine account email" error after successful authentication. The OAuth scope list was missing `userinfo.email` and `userinfo.profile` scopes, preventing the app from fetching the authenticated user's profile from Google's userinfo endpoint.

Also adds a comprehensive setup guide for Google Calendar integration to help future contributors avoid common configuration errors during local development.

## Related Issue
Fixes #4

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)
N/A

## Testing Instructions
1. Follow docs/google-calendar-setup.md to create Google Cloud credentials
2. Add credentials to apps/api/.env
3. Start the app with bun run dev
4. Go to http://localhost:3000
5. Click Connect Google Calendar
6. Complete OAuth flow
7. Should successfully authenticate and display calendars

## Additional Notes
Root cause was missing OAuth scopes:

Before:
```
const SCOPES = [
  https://www.googleapis.com/auth/calendar.readonly
  https://www.googleapis.com/auth/calendar.events
]
```

After:
```
const SCOPES = [
  https://www.googleapis.com/auth/calendar.readonly
  https://www.googleapis.com/auth/calendar.events
  https://www.googleapis.com/auth/userinfo.email
  https://www.googleapis.com/auth/userinfo.profile
]
```

Errors fixed and documented:
- Error: Could not determine account email
- Error 400: redirect_uri_mismatch
- Error 403: access_denied
- Error: Invalid key length

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands Google OAuth scopes to include `userinfo.email`/`userinfo.profile`, which changes the consent surface area and can affect OAuth behavior. Otherwise the change is small and localized plus documentation only.
> 
> **Overview**
> Fixes Google Calendar OAuth occasionally failing with *"Could not determine account email"* by requesting additional Google OAuth scopes (`userinfo.email` and `userinfo.profile`) in the `GoogleCalendarProvider` auth URL.
> 
> Adds a new `docs/calendar/google-calendar-setup.md` guide covering Google Cloud project/OAuth configuration, required env vars, and common local dev OAuth errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0afc9dbc7cb9319a1e37fe00617a5d0e80ad693b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->