### PR TITLE
Bug: Missing .env setup instructions and drizzle.config.ts not loading root .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,19 @@ cd open-sunsama
 # Install dependencies
 bun install
 
-# Configure environment
+# Step 1 - Configure root .env (shared config)
 cp .env.example .env
-# Edit .env with your DATABASE_URL
+
+# Step 2 - Configure API .env (api specific config)
+cp apps/api/.env.example apps/api/.env
+
+# Generate required secrets
+# Run these commands and paste output into both .env files:
+#   JWT_SECRET          → openssl rand -base64 32
+#   CALENDAR_ENCRYPTION_KEY → openssl rand -hex 32
+
+# For Google Calendar integration
+# Follow the setup guide: docs/google-calendar-setup.md
 
 # Run database migrations
 bun run db:push

--- a/packages/database/drizzle.config.ts
+++ b/packages/database/drizzle.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from 'drizzle-kit';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load root .env (shared config)
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 export default defineConfig({
   schema: './src/schema/index.ts',

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.9.5",
+    "dotenv": "^17.4.1",
     "drizzle-orm": "^0.45.1",
     "drizzle-zod": "^0.5.1",
     "postgres": "^3.4.8",


### PR DESCRIPTION
## Bug Description
Two related issues found during local setup:

1. drizzle.config.ts does not load root .env file, causing db:push 
to fail with "DATABASE_URL required" unless manually exported in terminal

2. README setup instructions only mention one .env file, but project 
requires both root .env and apps/api/.env to be configured

## Steps to Reproduce

Issue 1:
1. Add DATABASE_URL to root .env
2. Run: cd packages/database && bun run db:push
3. See error: DATABASE_URL required

Issue 2:
1. Follow README self-hosted setup
2. Run: cp .env.example .env
3. Fill in DATABASE_URL
4. Run: bun run dev
5. See error: DATABASE_URL not found in API logs

## Expected Behavior
- db:push reads DATABASE_URL from root .env automatically
- README clearly explains both .env files needed

## Actual Behavior
- db:push fails without manual export
- README only mentions root .env, apps/api/.env not documented

## Fix
- Load root .env in drizzle.config.ts
- Update README to clarify two .env files needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts local setup/docs and Drizzle CLI config loading, with minimal runtime impact outside database tooling.
> 
> **Overview**
> Fixes local DB tooling setup by making `packages/database/drizzle.config.ts` explicitly load the root `.env` so `drizzle-kit` commands can read `DATABASE_URL` without manual exports.
> 
> Updates the README self-hosted quick start to document **two required env files** (root and `apps/api/.env`) and adds guidance for generating shared secrets and Google Calendar setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ebf6068a2188043b606f84ee738404bffb0afa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->