### PR TITLE
perf(web): make cross-column DnD truly instant + predicate-based cache routing

### DIFF
--- a/apps/web/src/hooks/useKanbanRangePrefetch.ts
+++ b/apps/web/src/hooks/useKanbanRangePrefetch.ts
@@ -28,6 +28,26 @@ function dayCacheKey(dateString: string) {
   return taskKeys.list({ scheduledDate: dateString, limit: 200 });
 }
 
+/**
+ * Cheap reference check by id+updatedAt to avoid re-seeding caches that
+ * already hold the equivalent data.
+ */
+function tasksAreEqual(a: Task[], b: Task[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (!x || !y) return false;
+    if (x.id !== y.id) return false;
+    const xu = x.updatedAt;
+    const yu = y.updatedAt;
+    const xt = xu instanceof Date ? xu.getTime() : String(xu);
+    const yt = yu instanceof Date ? yu.getTime() : String(yu);
+    if (xt !== yt) return false;
+  }
+  return true;
+}
+
 interface RangePrefetchOptions {
   /**
    * Center date for the prefetch window. Defaults to today.
@@ -101,12 +121,28 @@ export function useKanbanRangePrefetch(options: RangePrefetchOptions = {}) {
   });
 
   const data = query.data;
+  const seededFingerprintRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     if (!data) return;
     // If the API truncated the range we cannot trust the per-day projections;
     // skip seeding and let DayColumn fall back to its own per-day fetches.
     if (data.truncated) return;
+
+    // Cheap fingerprint of the response. If the same set of (id, updatedAt)
+    // tuples comes back again — typical when React Query revalidates and
+    // the data hasn't actually changed — we skip the seeding loop entirely
+    // so we don't churn the per-day cache references and re-render every
+    // mounted DayColumn.
+    let fingerprint = centerString + ":";
+    for (const t of data.tasks) {
+      fingerprint += t.id;
+      const u = t.updatedAt;
+      fingerprint +=
+        "@" + (u instanceof Date ? u.getTime() : String(u)) + "|";
+    }
+    if (fingerprint === seededFingerprintRef.current) return;
+    seededFingerprintRef.current = fingerprint;
 
     const byDate = new Map<string, Task[]>();
     for (const task of data.tasks) {
@@ -141,6 +177,11 @@ export function useKanbanRangePrefetch(options: RangePrefetchOptions = {}) {
         dayState?.dataUpdatedAt &&
         dayState.dataUpdatedAt >= rangeFetchedAt
       ) {
+        continue;
+      }
+
+      // Skip writes that wouldn't actually change the cache contents.
+      if (existing && tasksAreEqual(existing, tasks)) {
         continue;
       }
 

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -23,6 +23,120 @@ export const taskKeys = {
 };
 
 /**
+ * Filter shape used as the third element of `taskKeys.list(...)`. Different
+ * call-sites pass different `limit` / sort options, but the only fields we
+ * care about for routing optimistic moves are `scheduledDate`,
+ * `scheduledDateFrom/To`, and `backlog`.
+ */
+type ListFilter = {
+  scheduledDate?: string | null;
+  scheduledDateFrom?: string;
+  scheduledDateTo?: string;
+  backlog?: boolean;
+  completed?: boolean;
+  priority?: string;
+};
+
+/**
+ * Decide whether a list query's filter would include a task scheduled to
+ * `targetDate` (null = backlog). Returns:
+ *   - "dest" when the filter scopes to that date / backlog / matching range
+ *   - "skip" when the filter rules the task out (e.g. completed-only)
+ *   - "neutral" when the filter is broad ("all") — the task may live there
+ *     too but the cache might also be holding tasks for OTHER dates, so we
+ *     should treat it as a source if it currently has the task and as a
+ *     destination if it doesn't (we'll insert in either case so the
+ *     consumer sees the new state).
+ */
+function classifyListForTarget(
+  filter: ListFilter | undefined,
+  targetDate: string | null
+): "dest" | "skip" | "neutral" {
+  if (!filter) return "neutral";
+  if (filter.completed === true) return "skip";
+
+  if (filter.backlog === true) {
+    return targetDate === null ? "dest" : "skip";
+  }
+
+  // `scheduledDate: null` is the explicit-backlog form used by some mobile
+  // call sites — semantically equivalent to `backlog: true`.
+  if (filter.scheduledDate === null) {
+    return targetDate === null ? "dest" : "skip";
+  }
+
+  if (filter.scheduledDate !== undefined) {
+    return filter.scheduledDate === targetDate ? "dest" : "skip";
+  }
+
+  if (
+    filter.scheduledDateFrom !== undefined &&
+    filter.scheduledDateTo !== undefined
+  ) {
+    if (targetDate === null) return "skip";
+    return targetDate >= filter.scheduledDateFrom &&
+      targetDate <= filter.scheduledDateTo
+      ? "dest"
+      : "skip";
+  }
+
+  return "neutral";
+}
+
+/**
+ * Apply an "insert this task into every matching destination cache, drop
+ * it from every other cache that currently holds it" reconciliation across
+ * all task-list caches. Used by `useMoveTask`, `useUpdateTask` (when
+ * `scheduledDate` changes), and `useReorderTasks` for cross-column drags.
+ */
+function applyOptimisticMove(
+  queryClient: ReturnType<typeof useQueryClient>,
+  previousQueries: Array<[readonly unknown[], Task[] | undefined]>,
+  taskId: string,
+  nextTask: Task,
+  targetDate: string | null
+) {
+  let insertedAnywhere = false;
+
+  previousQueries.forEach(([key, list]) => {
+    if (!list) return;
+    const filter = key[2] as ListFilter | undefined;
+    const classification = classifyListForTarget(filter, targetDate);
+    const hadTask = list.some((t) => t.id === taskId);
+
+    if (classification === "dest") {
+      insertedAnywhere = true;
+      if (hadTask) {
+        queryClient.setQueryData<Task[]>(
+          key,
+          list.map((t) => (t.id === taskId ? nextTask : t))
+        );
+      } else {
+        queryClient.setQueryData<Task[]>(key, [...list, nextTask]);
+      }
+    } else if (classification === "skip" && hadTask) {
+      queryClient.setQueryData<Task[]>(
+        key,
+        list.filter((t) => t.id !== taskId)
+      );
+    } else if (classification === "neutral" && hadTask) {
+      // The cache is broad — replace the task in place so its fields are
+      // up to date.
+      queryClient.setQueryData<Task[]>(
+        key,
+        list.map((t) => (t.id === taskId ? nextTask : t))
+      );
+    }
+  });
+
+  // If no existing cache classified as a destination, the destination
+  // DayColumn / Sidebar will fetch on its own when it mounts. We don't
+  // synthesize a phantom cache because we can't predict the consumer's
+  // exact query key (limits etc.).
+  return insertedAnywhere;
+}
+
+/**
  * Fetch all tasks with optional filters
  * Uses a high limit (200) for single-day queries to prevent truncation
  */
@@ -218,38 +332,63 @@ export function useUpdateTask() {
       return await api.tasks.update(id, data);
     },
     onMutate: async ({ id, data }) => {
-      // Cancel outgoing refetches to avoid overwriting optimistic update
       await queryClient.cancelQueries({ queryKey: taskKeys.lists() });
       await queryClient.cancelQueries({ queryKey: taskKeys.detail(id) });
 
-      // Snapshot previous values for rollback
       const previousTask = queryClient.getQueryData<Task>(taskKeys.detail(id));
       const previousQueries = queryClient.getQueriesData<Task[]>({
         queryKey: taskKeys.lists(),
       });
 
-      // Optimistically update the task detail cache
-      if (previousTask) {
-        queryClient.setQueryData<Task>(taskKeys.detail(id), {
-          ...previousTask,
-          ...data,
-          updatedAt: new Date(),
-        });
+      // Build the optimistic next-task representation. We strip undefined
+      // values from `data` so callers passing `{ priority: undefined }` to
+      // mean "no change" don't accidentally clobber the existing field.
+      const cleanedPatch: Partial<Task> = {};
+      for (const [k, v] of Object.entries(data)) {
+        if (v !== undefined) {
+          (cleanedPatch as Record<string, unknown>)[k] = v;
+        }
       }
 
-      // Optimistically update all list caches
-      queryClient.setQueriesData<Task[]>(
-        { queryKey: taskKeys.lists() },
-        (old) => {
-          if (!old) return old;
-          return old.map((task) => {
-            if (task.id === id) {
-              return { ...task, ...data, updatedAt: new Date() };
-            }
-            return task;
-          });
-        }
-      );
+      const baseTask: Task | undefined =
+        previousTask ??
+        (previousQueries
+          .map(([, list]) => list?.find((t) => t.id === id))
+          .find((t): t is Task => t !== undefined));
+
+      const nextTask: Task | null = baseTask
+        ? ({ ...baseTask, ...cleanedPatch, updatedAt: new Date() } as Task)
+        : null;
+
+      if (nextTask) {
+        queryClient.setQueryData<Task>(taskKeys.detail(id), nextTask);
+      }
+
+      // If scheduledDate is part of the patch, the task moves between list
+      // caches — drop it from its source list and inject it into the
+      // destination list. Otherwise just update it in place wherever it
+      // currently lives.
+      const isMovingDate =
+        Object.prototype.hasOwnProperty.call(data, "scheduledDate");
+
+      if (isMovingDate && nextTask) {
+        const targetDate = data.scheduledDate ?? null;
+        applyOptimisticMove(
+          queryClient,
+          previousQueries,
+          id,
+          nextTask,
+          targetDate
+        );
+      } else if (nextTask) {
+        queryClient.setQueriesData<Task[]>(
+          { queryKey: taskKeys.lists() },
+          (old) => {
+            if (!old) return old;
+            return old.map((task) => (task.id === id ? nextTask : task));
+          }
+        );
+      }
 
       return { previousTask, previousQueries };
     },
@@ -549,20 +688,37 @@ export function useMoveTask() {
         queryKey: taskKeys.lists(),
       });
 
-      queryClient.setQueriesData<Task[]>(
-        { queryKey: taskKeys.lists() },
-        (old) => {
-          if (!old) return old;
-          return old.map((task) => {
-            if (task.id !== id) return task;
-            return {
-              ...task,
-              scheduledDate: targetDate,
-              ...(position !== undefined ? { position } : {}),
-            };
-          });
+      // Find the task wherever it currently lives.
+      let movedTask: Task | undefined;
+      for (const [, list] of previousQueries) {
+        if (!list) continue;
+        const found = list.find((t) => t.id === id);
+        if (found) {
+          movedTask = found;
+          break;
         }
-      );
+      }
+      const detailTask = queryClient.getQueryData<Task>(taskKeys.detail(id));
+      const sourceTask = movedTask ?? detailTask;
+
+      const updatedTask = sourceTask
+        ? {
+            ...sourceTask,
+            scheduledDate: targetDate,
+            ...(position !== undefined ? { position } : {}),
+          }
+        : null;
+
+      if (updatedTask) {
+        applyOptimisticMove(
+          queryClient,
+          previousQueries,
+          id,
+          updatedTask,
+          targetDate
+        );
+        queryClient.setQueryData(taskKeys.detail(id), updatedTask);
+      }
 
       return { previousQueries };
     },
@@ -594,8 +750,13 @@ export function useMoveTask() {
 }
 
 /**
- * Reorder tasks within a date or backlog
- * Uses optimistic updates for smooth drag-and-drop experience
+ * Reorder tasks within a date or backlog.
+ *
+ * The server's reorder endpoint also handles moving tasks between dates —
+ * any task in `taskIds` whose `scheduledDate` differs from `date` is moved
+ * server-side. To make cross-column DnD feel instant we mirror that on the
+ * client: tasks that aren't already in the destination cache are pulled
+ * from whichever source cache currently holds them.
  */
 export function useReorderTasks() {
   const queryClient = useQueryClient();
@@ -607,48 +768,107 @@ export function useReorderTasks() {
     }: {
       date: string; // "backlog" for backlog tasks, or "YYYY-MM-DD" for scheduled tasks
       taskIds: string[];
-    }): Promise<void> => {
+    }): Promise<Task[]> => {
       const api = getApi();
       const input: ReorderTasksInput = { date, taskIds };
-      await api.tasks.reorder(input);
+      return await api.tasks.reorder(input);
     },
     onMutate: async ({ date, taskIds }) => {
-      // Determine the correct query key based on whether it's backlog or a date
       const isBacklog = date === "backlog";
-      const queryKey = isBacklog
-        ? taskKeys.list({ backlog: true })
-        : taskKeys.list({ scheduledDate: date });
+      const targetScheduledDate: string | null = isBacklog ? null : date;
 
-      // Cancel any outgoing refetches to avoid overwriting optimistic update
-      await queryClient.cancelQueries({ queryKey });
+      await queryClient.cancelQueries({ queryKey: taskKeys.lists() });
       await queryClient.cancelQueries({
         queryKey: ["tasks", "search", "infinite"],
       });
 
-      // Snapshot the previous value
-      const previousTasks = queryClient.getQueryData<Task[]>(queryKey);
+      const previousQueries = queryClient.getQueriesData<Task[]>({
+        queryKey: taskKeys.lists(),
+      });
       const previousInfiniteQueries = queryClient.getQueriesData({
         queryKey: ["tasks", "search", "infinite"],
       });
 
-      // Optimistically update the cache with new positions
-      if (previousTasks) {
-        const reorderedTasks = taskIds
-          .map((id, index) => {
-            const task = previousTasks.find((t) => t.id === id);
-            return task ? { ...task, position: index } : null;
-          })
-          .filter((t): t is Task => t !== null);
+      // Build a lookup of every task currently visible in any list cache so
+      // we can resolve tasks that the destination cache may not yet know
+      // about (i.e. ones being dragged in from another column).
+      const taskById = new Map<string, Task>();
+      for (const [, list] of previousQueries) {
+        if (!list) continue;
+        for (const t of list) {
+          if (!taskById.has(t.id)) taskById.set(t.id, t);
+        }
+      }
+      const taskIdSet = new Set(taskIds);
 
-        // Include any tasks not in taskIds (e.g., completed tasks) at the end
-        const tasksNotInOrder = previousTasks.filter(
-          (t) => !taskIds.includes(t.id)
-        );
-        const finalTasks = [...reorderedTasks, ...tasksNotInOrder];
-
-        queryClient.setQueryData(queryKey, finalTasks);
+      // For each task being reordered: walk every list cache and route the
+      // updated record into the matching destination caches, drop it from
+      // any other cache that still has it. We also rebuild every
+      // destination cache so the *order* matches `taskIds` exactly.
+      const updatedById = new Map<string, Task>();
+      for (let i = 0; i < taskIds.length; i++) {
+        const id = taskIds[i];
+        if (!id) continue;
+        const existing = taskById.get(id);
+        if (!existing) continue;
+        const next: Task = {
+          ...existing,
+          position: i,
+          scheduledDate: targetScheduledDate,
+        };
+        updatedById.set(id, next);
       }
 
+      previousQueries.forEach(([key, list]) => {
+        if (!list) return;
+        const filter = key[2] as ListFilter | undefined;
+        const classification = classifyListForTarget(
+          filter,
+          targetScheduledDate
+        );
+
+        if (classification === "dest") {
+          // Rebuild this cache: ordered taskIds first, then any tasks the
+          // cache already had that aren't part of the reorder (e.g.
+          // completed tasks pinned at the end).
+          const ordered: Task[] = [];
+          for (const id of taskIds) {
+            const t = updatedById.get(id);
+            if (t) ordered.push(t);
+          }
+          const tail = list.filter((t) => !taskIdSet.has(t.id));
+          queryClient.setQueryData<Task[]>(key, [...ordered, ...tail]);
+        } else if (classification === "skip") {
+          // This cache rules out the destination — make sure none of the
+          // moved tasks linger here.
+          const filtered = list.filter((t) => !taskIdSet.has(t.id));
+          if (filtered.length !== list.length) {
+            queryClient.setQueryData<Task[]>(key, filtered);
+          }
+        } else {
+          // Neutral / broad cache — replace tasks in place so their fields
+          // are accurate.
+          let mutated = false;
+          const next = list.map((t) => {
+            const replacement = updatedById.get(t.id);
+            if (replacement) {
+              mutated = true;
+              return replacement;
+            }
+            return t;
+          });
+          if (mutated) {
+            queryClient.setQueryData<Task[]>(key, next);
+          }
+        }
+      });
+
+      // Update detail caches too.
+      for (const [id, t] of updatedById) {
+        queryClient.setQueryData(taskKeys.detail(id), t);
+      }
+
+      // Mirror the change in any infinite-search caches.
       const positionByTaskId = new Map(
         taskIds.map((taskId, index) => [taskId, index])
       );
@@ -671,7 +891,7 @@ export function useReorderTasks() {
                 return {
                   ...task,
                   position,
-                  scheduledDate: date === "backlog" ? null : date,
+                  scheduledDate: targetScheduledDate,
                 };
               }),
             })),
@@ -679,16 +899,19 @@ export function useReorderTasks() {
         }
       );
 
-      // Return context with previous value for rollback
-      return { previousTasks, date, queryKey, previousInfiniteQueries };
+      return {
+        previousQueries,
+        previousInfiniteQueries,
+        targetScheduledDate,
+        taskIds,
+      };
     },
     onError: (error, _variables, context) => {
-      // Rollback to previous value on error
-      if (context?.previousTasks && context?.queryKey) {
-        queryClient.setQueryData(context.queryKey, context.previousTasks);
-      }
-      context?.previousInfiniteQueries?.forEach(([queryKey, data]) => {
-        queryClient.setQueryData(queryKey, data);
+      context?.previousQueries?.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+      context?.previousInfiniteQueries?.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
       });
       toast({
         variant: "destructive",
@@ -696,13 +919,30 @@ export function useReorderTasks() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSuccess: (_data, _variables, context) => {
-      // The server may renumber positions across all tasks in this bucket
-      // (including completed ones), and our optimistic math only renumbers
-      // the ones the user dragged. Refetch the affected list so the cache
-      // reflects the server's authoritative position values.
-      if (context?.queryKey) {
-        queryClient.invalidateQueries({ queryKey: context.queryKey });
+    onSuccess: (serverTasks, _variables, context) => {
+      // The server returns the canonical task list for the destination
+      // bucket. Distribute it to every cache that classifies as a
+      // destination for the target date / backlog, then update detail
+      // caches.
+      if (!Array.isArray(serverTasks)) return;
+      const targetDate = context?.targetScheduledDate ?? null;
+      const allListKeys = queryClient.getQueriesData<Task[]>({
+        queryKey: taskKeys.lists(),
+      });
+      allListKeys.forEach(([key, list]) => {
+        const filter = key[2] as ListFilter | undefined;
+        if (classifyListForTarget(filter, targetDate) !== "dest") return;
+        // Preserve any tasks that the cache had which aren't part of the
+        // server response (e.g. completed tasks the reorder doesn't touch
+        // when called with only pending taskIds).
+        const movedIds = new Set(serverTasks.map((t) => t.id));
+        const tail = (list ?? []).filter(
+          (t) => !movedIds.has(t.id) && !context?.taskIds.includes(t.id)
+        );
+        queryClient.setQueryData<Task[]>(key, [...serverTasks, ...tail]);
+      });
+      for (const t of serverTasks) {
+        queryClient.setQueryData(taskKeys.detail(t.id), t);
       }
     },
   });

--- a/packages/api-client/src/react.ts
+++ b/packages/api-client/src/react.ts
@@ -153,8 +153,8 @@ export interface OpenSunsamaHooks {
   ) => ReturnType<typeof useMutation<void, ApiError, string>>;
 
   useReorderTasks: (
-    options?: UseMutationOptions<void, ApiError, ReorderTasksInput>
-  ) => ReturnType<typeof useMutation<void, ApiError, ReorderTasksInput>>;
+    options?: UseMutationOptions<Task[], ApiError, ReorderTasksInput>
+  ) => ReturnType<typeof useMutation<Task[], ApiError, ReorderTasksInput>>;
 
   useCompleteTask: (
     options?: UseMutationOptions<Task, ApiError, string>

--- a/packages/api-client/src/tasks.ts
+++ b/packages/api-client/src/tasks.ts
@@ -70,10 +70,13 @@ export interface TasksApi {
   delete(id: string, options?: RequestOptions): Promise<void>;
 
   /**
-   * Reorder tasks within a specific date
+   * Reorder tasks within a specific date.
+   * Also handles moving tasks between dates — the server updates each
+   * affected task's `scheduledDate` to the supplied date.
    * @param input Reorder data with date and task IDs in order
+   * @returns The full set of tasks belonging to the target date after reorder
    */
-  reorder(input: ReorderTasksInput, options?: RequestOptions): Promise<void>;
+  reorder(input: ReorderTasksInput, options?: RequestOptions): Promise<Task[]>;
 
   /**
    * Mark a task as complete
@@ -245,8 +248,13 @@ export function createTasksApi(client: OpenSunsamaClient): TasksApi {
     async reorder(
       input: ReorderTasksInput,
       options?: RequestOptions
-    ): Promise<void> {
-      await client.post<ApiResponseWrapper<void>>("tasks/reorder", input, options);
+    ): Promise<Task[]> {
+      const response = await client.post<ApiResponseWrapper<Task[]>>(
+        "tasks/reorder",
+        input,
+        options
+      );
+      return response.data ?? [];
     },
 
     async complete(id: string, options?: RequestOptions): Promise<Task> {


### PR DESCRIPTION
## Summary

Code review of #7 found that the optimistic-update path for tasks moving between columns was buggy: it built destination cache keys without `limit` (e.g. `taskKeys.list({ scheduledDate: 'X' })`) but the consumers (DayColumn, sidebar, mobile backlog) all use keys WITH `limit` (`{ scheduledDate, limit: 200 }`, `{ backlog: true, limit: 500 }`, `{ scheduledDate: null, limit: 500 }`). The mismatch meant the optimistic insert went into a phantom cache no one read, so dragging a task between days emptied the source column but the task didn't appear in the destination until the staleTime-gated refetch fired.

This PR replaces all exact-key matching with a predicate-based router so cache-key shape no longer matters.

### Changes

- New `classifyListForTarget(filter, targetDate)` — given any list-filter shape, returns `"dest"` / `"skip"` / `"neutral"` based on whether a task scheduled to `targetDate` belongs in that list. Handles `backlog: true`, `scheduledDate: null` (mobile backlog), `scheduledDate: 'YYYY-MM-DD'`, and `scheduledDateFrom/To` range filters. Skips `completed: true` lists.
- New `applyOptimisticMove(...)` — walks every cached task list, inserts/replaces in destinations, removes from skips, updates in place in neutral caches.
- `useUpdateTask` now uses `applyOptimisticMove` whenever the patch contains `scheduledDate`. Also strips `undefined` keys from the patch so `{ priority: undefined }` doesn't clobber the existing field.
- `useMoveTask` uses `applyOptimisticMove`.
- `useReorderTasks` uses the same predicate to find matching destination caches and rebuilds each with `[ordered, ...tail]`. The api-client `tasks.reorder` now returns `Promise<Task[]>` (server already responded with the canonical list — we just weren't capturing it). `onSuccess` distributes that response to every dest-classified cache, so no follow-up refetch is needed.
- `useKanbanRangePrefetch` now fingerprints the response and skips re-seeding when nothing changed, eliminating a re-render storm on every revalidation that #7 introduced.

### Bugs fixed

1. Cross-column DnD: source emptied but destination didn't show the task until ~60s refetch
2. Same bug for keyboard shortcuts that move between days (D=defer, Z=next monday, move-to-backlog) via `useUpdateTask`
3. `useUpdateTask` `{ priority: undefined }` patches clobbered existing fields
4. Range prefetch caused all DayColumns to re-render on every successful refetch even when data was unchanged
5. Mobile backlog sheet (`{scheduledDate: null}`) wasn't recognised as a backlog cache

## Test plan

- [x] `bun run typecheck` passes (whole workspace)
- [x] `bun run build` succeeds
- [x] No new ESLint errors (89 pre-existing → 89 still)
- [ ] Manual: drag task across columns — source clears, destination shows it instantly
- [ ] Manual: keyboard shortcut "D" defers a task — moves between columns instantly
- [ ] Manual: drag from kanban to mobile backlog (or `scheduledDate: null` view) — works
- [ ] Manual: kanban range refetch doesn't cause column flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)