### PR TITLE
fix(web): handle stale-deploy chunk loads + prefetch-on-intent for modals

### DIFF
--- a/apps/web/src/components/kanban/add-task-inline.tsx
+++ b/apps/web/src/components/kanban/add-task-inline.tsx
@@ -2,7 +2,12 @@ import * as React from "react";
 import { Plus, ArrowUp, ArrowDown } from "lucide-react";
 import { Button, ShortcutHint, Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui";
 import { cn } from "@/lib/utils";
-import { AddTaskModal, type AddPosition } from "./add-task-modal.lazy";
+import {
+  AddTaskModal,
+  prefetchAddTaskModal,
+  type AddPosition,
+} from "./add-task-modal.lazy";
+import { prefetchRichTextEditor } from "@/components/ui/rich-text-editor.lazy";
 
 const POSITION_STORAGE_KEY = "open-sunsama:add-task-position";
 
@@ -50,7 +55,14 @@ export function AddTaskInline({ scheduledDate, className, compact }: AddTaskInli
             "justify-start gap-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/50 group",
             compact ? "h-7 px-2 text-xs" : "flex-1 h-9 gap-2"
           )}
-          onClick={() => setIsModalOpen(true)}
+          onClick={() => {
+            void prefetchAddTaskModal();
+            void prefetchRichTextEditor();
+            setIsModalOpen(true);
+          }}
+          onMouseEnter={() => {
+            void prefetchAddTaskModal();
+          }}
         >
           <Plus className={compact ? "h-3.5 w-3.5" : "h-4 w-4"} />
           <span>Add task</span>

--- a/apps/web/src/components/kanban/add-task-modal.lazy.tsx
+++ b/apps/web/src/components/kanban/add-task-modal.lazy.tsx
@@ -38,6 +38,27 @@ export function prefetchAddTaskModal(): Promise<unknown> {
   return importAddTaskModal();
 }
 
+/**
+ * A bare-bones loading shell rendered while the underlying modal chunk
+ * downloads on first interaction. We render an empty Radix-style overlay
+ * so the user has visual feedback that the click registered (instead of
+ * "click did nothing") on slow networks.
+ */
+function AddTaskModalLoadingShell({ open }: { open: boolean }) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/40 backdrop-blur-sm"
+      aria-hidden="true"
+    >
+      <div className="rounded-lg border bg-background p-6 shadow-lg">
+        <div className="h-2 w-32 animate-pulse rounded bg-muted" />
+        <div className="mt-3 h-2 w-24 animate-pulse rounded bg-muted/60" />
+      </div>
+    </div>
+  );
+}
+
 export function AddTaskModal(props: AddTaskModalProps) {
   const seenOpenRef = React.useRef(false);
   if (props.open) seenOpenRef.current = true;
@@ -45,7 +66,7 @@ export function AddTaskModal(props: AddTaskModalProps) {
   if (!seenOpenRef.current) return null;
 
   return (
-    <React.Suspense fallback={null}>
+    <React.Suspense fallback={<AddTaskModalLoadingShell open={props.open} />}>
       <LazyAddTaskModal {...props} />
     </React.Suspense>
   );

--- a/apps/web/src/components/kanban/task-card.tsx
+++ b/apps/web/src/components/kanban/task-card.tsx
@@ -7,6 +7,7 @@ import { useCompleteTask, useUpdateTask } from "@/hooks/useTasks";
 import { useSubtasks, useUpdateSubtask } from "@/hooks/useSubtasks";
 import { TaskContextMenu } from "./task-context-menu";
 import { TaskCardContent } from "./task-card-content";
+import { prefetchTaskModal } from "./task-modal.lazy";
 
 interface TaskCardProps {
   task: Task;
@@ -108,9 +109,24 @@ export function SortableTaskCard({
   const handleClick = (e: React.MouseEvent) => {
     if (!dragging) {
       e.stopPropagation();
+      // Kick off the modal chunk download synchronously with the click —
+      // by the time React commits the open state, the chunk is in flight.
+      void prefetchTaskModal();
       onSelect(task);
     }
   };
+
+  // Prefetch on hover so even slow connections feel instant when the user
+  // commits to clicking. `prefetchTaskModal` is idempotent and cached.
+  const handleHoverChangeWithPrefetch = React.useCallback(
+    (hovered: boolean) => {
+      if (hovered) {
+        void prefetchTaskModal();
+      }
+      setIsHovered(hovered);
+    },
+    []
+  );
 
   return (
     <TaskContextMenu task={task} onEdit={() => onSelect(task)}>
@@ -134,7 +150,7 @@ export function SortableTaskCard({
           isDragging={externalDragging}
           onToggleComplete={handleToggleComplete}
           onClick={handleClick}
-          onHoverChange={setIsHovered}
+          onHoverChange={handleHoverChangeWithPrefetch}
           subtasks={subtasks}
           onToggleSubtask={handleToggleSubtask}
           subtasksHidden={task.subtasksHidden}
@@ -190,9 +206,20 @@ export function TaskCard({
   const handleClick = (e: React.MouseEvent) => {
     if (!externalDragging) {
       e.stopPropagation();
+      void prefetchTaskModal();
       onSelect(task);
     }
   };
+
+  const handleHoverChangeWithPrefetch = React.useCallback(
+    (hovered: boolean) => {
+      if (hovered) {
+        void prefetchTaskModal();
+      }
+      setIsHovered(hovered);
+    },
+    []
+  );
 
   return (
     <TaskCardContent
@@ -202,7 +229,7 @@ export function TaskCard({
       isDragging={externalDragging}
       onToggleComplete={handleToggleComplete}
       onClick={handleClick}
-      onHoverChange={setIsHovered}
+      onHoverChange={handleHoverChangeWithPrefetch}
       subtasks={subtasks}
       onToggleSubtask={handleToggleSubtask}
       subtasksHidden={task.subtasksHidden}

--- a/apps/web/src/components/kanban/task-modal.lazy.tsx
+++ b/apps/web/src/components/kanban/task-modal.lazy.tsx
@@ -46,6 +46,27 @@ export function prefetchTaskModal(): Promise<unknown> {
   return importTaskModal();
 }
 
+/**
+ * Loading shell shown while the modal chunk downloads on first interaction.
+ * Prevents the "click did nothing" feeling on slow networks — the user sees
+ * a dimmed overlay immediately, then Tiptap takes over once both chunks land.
+ */
+function TaskModalLoadingShell({ open }: { open: boolean }) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/40 backdrop-blur-sm"
+      aria-hidden="true"
+    >
+      <div className="w-[min(640px,90vw)] rounded-lg border bg-background p-6 shadow-lg">
+        <div className="h-3 w-48 animate-pulse rounded bg-muted" />
+        <div className="mt-3 h-2 w-full max-w-md animate-pulse rounded bg-muted/60" />
+        <div className="mt-2 h-2 w-3/4 animate-pulse rounded bg-muted/40" />
+      </div>
+    </div>
+  );
+}
+
 export function TaskModal(props: TaskModalProps) {
   // The modal is dormant most of the time. We sidestep both the module
   // download and the React reconciliation cost by not mounting anything
@@ -60,7 +81,7 @@ export function TaskModal(props: TaskModalProps) {
   }
 
   return (
-    <React.Suspense fallback={null}>
+    <React.Suspense fallback={<TaskModalLoadingShell open={props.open} />}>
       <LazyTaskModal {...props} />
     </React.Suspense>
   );

--- a/apps/web/src/lib/chunk-error-recovery.ts
+++ b/apps/web/src/lib/chunk-error-recovery.ts
@@ -1,0 +1,97 @@
+/**
+ * Recovers from chunk-load failures.
+ *
+ * When the app deploys a new version, any tab that's been open since the
+ * previous deploy holds references to the old hashed chunk filenames. The
+ * first time a `React.lazy(import("..."))` boundary fires after the deploy,
+ * the request 404s and React.lazy throws — without recovery the user sees a
+ * blank screen.
+ *
+ * Vite emits a `vite:preloadError` window event for these. We listen once
+ * (pre-app-mount) and trigger a single soft reload — but only if we haven't
+ * already attempted one in this session, to avoid an infinite reload loop
+ * if the chunk genuinely never resolves.
+ *
+ * Reference: https://vite.dev/guide/build.html#load-error-handling
+ */
+
+const RELOAD_FLAG = "open_sunsama_chunk_reload_v1";
+
+function shouldAttemptReload(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(RELOAD_FLAG) !== "1";
+  } catch {
+    // Private mode etc — allow the reload, fall back to URL flag.
+    return true;
+  }
+}
+
+function markReloadAttempted(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(RELOAD_FLAG, "1");
+  } catch {
+    // ignore
+  }
+}
+
+function clearReloadFlagIfStale(): void {
+  // If the user successfully loaded the page, clear the flag so a future
+  // chunk error after the next deploy can trigger another reload. Run after
+  // a brief delay to ensure we're past initial chunk loads.
+  if (typeof window === "undefined") return;
+  window.setTimeout(() => {
+    try {
+      window.sessionStorage.removeItem(RELOAD_FLAG);
+    } catch {
+      // ignore
+    }
+  }, 10_000);
+}
+
+let installed = false;
+
+export function installChunkErrorRecovery(): void {
+  if (installed) return;
+  if (typeof window === "undefined") return;
+  installed = true;
+
+  clearReloadFlagIfStale();
+
+  const handleChunkError = (event: Event) => {
+    if (!shouldAttemptReload()) {
+      // We already tried reloading once this session — let the error
+      // propagate to React's error boundary (if any) so the user sees a
+      // real error instead of looping.
+      return;
+    }
+    markReloadAttempted();
+    // Best-effort: prevent any default visible error before reload.
+    event.preventDefault?.();
+    window.location.reload();
+  };
+
+  window.addEventListener("vite:preloadError", handleChunkError as EventListener);
+
+  // Belt-and-suspenders: also catch unhandled `ChunkLoadError`/`Loading chunk`
+  // promise rejections from `React.lazy` failures that didn't go through the
+  // Vite preload path (e.g., a dynamic import that races the polyfill).
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason as unknown;
+    const message =
+      reason instanceof Error
+        ? reason.message
+        : typeof reason === "string"
+          ? reason
+          : "";
+    if (
+      typeof message === "string" &&
+      (message.includes("Loading chunk") ||
+        message.includes("Failed to fetch dynamically imported module") ||
+        message.includes("Importing a module script failed"))
+    ) {
+      handleChunkError(event);
+    }
+  });
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,9 +12,15 @@ import { AuthProvider } from "@/hooks/useAuth";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { useTimezoneSync } from "@/hooks/useTimezoneSync";
 import { persister, shouldPersistQueryFn } from "@/lib/query-persister";
+import { installChunkErrorRecovery } from "@/lib/chunk-error-recovery";
 import { routeTree } from "./routeTree.gen.tsx";
 
 import "./index.css";
+
+// Recover from stale-deploy chunk loads (vite:preloadError) before any
+// component tree mounts so a failed `React.lazy(...)` triggers exactly one
+// soft reload instead of crashing the app.
+installChunkErrorRecovery();
 
 /**
  * Component that syncs user timezone with the server


### PR DESCRIPTION
## Summary

Code review of PR #9 surfaced two real bugs introduced by the lazy-modal split:

### 1. Stale-deploy crashes
When the app deploys a new version, any tab open since the previous deploy holds the old hashed chunk filenames. The first time a `React.lazy(...)` boundary fires after the deploy, the request 404s and the entire React tree crashes — there is no ErrorBoundary anywhere in the tree.

Vite emits a `vite:preloadError` window event for these. Added a tiny `installChunkErrorRecovery()` helper invoked at module load (before React mounts) that:

- listens for `vite:preloadError` AND `unhandledrejection` matching the standard chunk-load failure messages
- triggers exactly one soft `window.location.reload()` per session, gated by `sessionStorage` so we don't loop forever if the chunk genuinely never resolves
- clears the gate flag 10s after a successful reload so a future deploy can recover too

### 2. "Click did nothing"
`TaskModal` and `AddTaskModal` Suspense fallbacks were `null`. A user who hit Add Task before the idle prefetch landed got a blank moment with no visual feedback. Added bare-bones loading shells (a backdrop + a couple of pulsing skeleton bars) that render while the chunk streams in. They swap atomically with the real modal — no flash.

### 3. Prefetch-on-intent (UX win)
- `task-card` prefetches the TaskModal chunk on hover and on click.
- `add-task-inline` prefetches AddTaskModal on hover, and AddTaskModal + RichTextEditor on click.

The `prefetch*` helpers cache the import promise at module scope so 50 cards hovered in a row still produce exactly one network request. By the time React commits the open state, the chunks are usually already resolved and Suspense never even shows the shell.

## Test plan

- [x] `bun run typecheck` clean (whole workspace)
- [x] `bun run build` succeeds
- [x] No new ESLint errors (89 baseline preserved)
- [x] No `import "./tiptap..."` side-effect imports in any entry chunk
- [ ] Manual: deploy then refresh — clicking Add Task on a stale tab triggers a single reload instead of a white screen
- [ ] Manual: open Add Task on a fast network — no visible loading shell, modal mounts inline
- [ ] Manual: open Add Task on a throttled network — loading shell renders briefly, then real modal appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)