### PR TITLE
perf(web): defer CommandPalette + ShortcutsModal until first ⌘K / ?

### DIFF
--- a/apps/web/src/components/command-palette/command-item.tsx
+++ b/apps/web/src/components/command-palette/command-item.tsx
@@ -24,7 +24,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Kbd } from "@/components/ui/shortcuts-modal";
+import { Kbd } from "@/components/ui/kbd";
 import type { Command } from "./commands";
 
 const ICON_MAP: Record<string, LucideIcon> = {

--- a/apps/web/src/components/command-palette/command-palette.lazy.tsx
+++ b/apps/web/src/components/command-palette/command-palette.lazy.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import type { Task } from "@open-sunsama/types";
+import type * as CommandPaletteModuleNS from "./command-palette";
+
+/**
+ * Lazy entry point for the command palette.
+ *
+ * The palette pulls in `useSearchTasks` (with debouncing + abort logic),
+ * the command, task-command, and MCP-command catalogs, the search hook,
+ * Tiptap-free task creation flow, and the contextual-commands matcher.
+ * Total ~1000 lines of code that nothing on the page renders until the
+ * user hits ⌘K. Defer it.
+ */
+
+type CommandPaletteProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectTask: (task: Task) => void;
+  onAddTask: () => void;
+};
+
+type CommandPaletteModule = typeof CommandPaletteModuleNS;
+
+let preload: Promise<CommandPaletteModule> | null = null;
+
+function importCommandPalette(): Promise<CommandPaletteModule> {
+  if (!preload) {
+    preload = import("./command-palette") as Promise<CommandPaletteModule>;
+  }
+  return preload;
+}
+
+const LazyCommandPalette = React.lazy(async () => {
+  const mod = await importCommandPalette();
+  return { default: mod.CommandPalette };
+});
+
+export function prefetchCommandPalette(): Promise<unknown> {
+  return importCommandPalette();
+}
+
+export function CommandPalette(props: CommandPaletteProps) {
+  // The palette is dormant on every page view that doesn't hit ⌘K. Skip
+  // mounting (and downloading) the chunk until it's actually opened, then
+  // keep it mounted so subsequent opens are instant.
+  const seenOpenRef = React.useRef(false);
+  if (props.open) seenOpenRef.current = true;
+
+  if (!seenOpenRef.current) return null;
+
+  return (
+    <React.Suspense fallback={null}>
+      <LazyCommandPalette {...props} />
+    </React.Suspense>
+  );
+}

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -5,7 +5,7 @@ import type { Task } from "@open-sunsama/types";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { useSearchTasks } from "@/hooks/useSearchTasks";
 import { useCreateTask } from "@/hooks/useTasks";
-import { Kbd } from "@/components/ui/shortcuts-modal";
+import { Kbd } from "@/components/ui/kbd";
 import { COMMANDS } from "./commands";
 import { TASK_COMMANDS } from "./task-commands";
 import { MCP_COMMANDS } from "./mcp-commands";

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -113,7 +113,11 @@ export {
 } from "./popover";
 export { FileIcon, getFileTypeColor } from "./file-icon";
 export { Lightbox } from "./lightbox";
-export { ShortcutsModal, Kbd } from "./shortcuts-modal";
+// `ShortcutsModal` is intentionally NOT re-exported here — consumers must
+// import from `./shortcuts-modal.lazy` (or the eager file when they truly
+// need the synchronous module). Re-exporting it from this barrel pulled
+// the modal into the boot bundle of every consumer of `@/components/ui`.
+export { Kbd } from "./kbd";
 export { ShortcutHint } from "./shortcut-hint";
 export {
   Tooltip,

--- a/apps/web/src/components/ui/kbd.tsx
+++ b/apps/web/src/components/ui/kbd.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Keyboard-key badge. Used by the shortcuts modal and the command palette.
+ * Lives in its own file so consumers can import it without pulling in the
+ * shortcuts-modal chunk (which is itself lazy-loaded).
+ */
+export function Kbd({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex h-5 min-w-[20px] items-center justify-center rounded border border-border bg-muted px-1.5",
+        "text-[11px] font-medium text-muted-foreground",
+        className
+      )}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/apps/web/src/components/ui/shortcuts-modal.lazy.tsx
+++ b/apps/web/src/components/ui/shortcuts-modal.lazy.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import type * as ShortcutsModalModuleNS from "./shortcuts-modal";
+
+/**
+ * Lazy entry point for the keyboard shortcuts cheat-sheet modal.
+ * Only opened when the user hits "?" — no need to ship the markup +
+ * Radix Dialog wiring with the boot bundle.
+ */
+
+type ShortcutsModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type ShortcutsModalModule = typeof ShortcutsModalModuleNS;
+
+let preload: Promise<ShortcutsModalModule> | null = null;
+
+function importShortcutsModal(): Promise<ShortcutsModalModule> {
+  if (!preload) {
+    preload = import("./shortcuts-modal") as Promise<ShortcutsModalModule>;
+  }
+  return preload;
+}
+
+const LazyShortcutsModal = React.lazy(async () => {
+  const mod = await importShortcutsModal();
+  return { default: mod.ShortcutsModal };
+});
+
+export function prefetchShortcutsModal(): Promise<unknown> {
+  return importShortcutsModal();
+}
+
+export function ShortcutsModal(props: ShortcutsModalProps) {
+  const seenOpenRef = React.useRef(false);
+  if (props.open) seenOpenRef.current = true;
+
+  if (!seenOpenRef.current) return null;
+
+  return (
+    <React.Suspense fallback={null}>
+      <LazyShortcutsModal {...props} />
+    </React.Suspense>
+  );
+}

--- a/apps/web/src/components/ui/shortcuts-modal.tsx
+++ b/apps/web/src/components/ui/shortcuts-modal.tsx
@@ -6,7 +6,10 @@ import {
   formatShortcut,
   type ShortcutDefinition,
 } from "@/hooks/useKeyboardShortcuts";
-import { cn } from "@/lib/utils";
+import { Kbd } from "@/components/ui/kbd";
+
+// Re-export for backwards compatibility — Kbd lives in its own file now.
+export { Kbd };
 
 interface ShortcutsModalProps {
   open: boolean;
@@ -92,26 +95,3 @@ function ShortcutRow({ shortcut }: { shortcut: ShortcutDefinition }) {
   );
 }
 
-// Keyboard key badge component
-function Kbd({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return (
-    <kbd
-      className={cn(
-        "inline-flex h-5 min-w-[20px] items-center justify-center rounded border border-border bg-muted px-1.5",
-        "text-[11px] font-medium text-muted-foreground",
-        className
-      )}
-    >
-      {children}
-    </kbd>
-  );
-}
-
-// Export Kbd for use elsewhere
-export { Kbd };

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -13,9 +13,15 @@ import {
 } from "@/hooks/useKeyboardShortcuts";
 import { SearchProvider, useSearch } from "@/hooks/useSearch";
 import { useWebSocket } from "@/hooks/useWebSocket";
-import { ShortcutsModal } from "@/components/ui/shortcuts-modal";
+import {
+  ShortcutsModal,
+  prefetchShortcutsModal,
+} from "@/components/ui/shortcuts-modal.lazy";
 import { GlobalShortcutsHandler } from "@/components/global-shortcuts-handler";
-import { CommandPalette } from "@/components/command-palette";
+import {
+  CommandPalette,
+  prefetchCommandPalette,
+} from "@/components/command-palette/command-palette.lazy";
 import {
   AddTaskModal,
   prefetchAddTaskModal,
@@ -117,6 +123,8 @@ function AppLayoutInner() {
       void prefetchRichTextEditor();
       void prefetchTaskModal();
       void prefetchAddTaskModal();
+      void prefetchCommandPalette();
+      void prefetchShortcutsModal();
     };
     if (typeof win.requestIdleCallback === "function") {
       const id = win.requestIdleCallback(warmAll, { timeout: 4000 });


### PR DESCRIPTION
## Summary

Both components are mounted at the app shell level so global keyboard shortcuts can fire from anywhere — but neither renders any DOM or runs any logic until the user hits ⌘K (search) or ? (shortcuts cheat-sheet). They were ~1000 lines combined sitting in the boot bundle.

### Changes

- New \`command-palette.lazy.tsx\` and \`shortcuts-modal.lazy.tsx\` wrappers, identical pattern to the TaskModal/AddTaskModal lazies from PR #9. \`seenOpenRef\` skip-mount-until-first-open + idle prefetch in \`AppLayoutInner\`.
- The shared \`Kbd\` keyboard-key badge that lived inside \`shortcuts-modal.tsx\` is extracted to its own \`kbd.tsx\`. Two consumers (command-palette.tsx, command-item.tsx) now import \`Kbd\` directly from there so they don't drag the full shortcuts-modal back into their lazy chunks.
- Removed the eager \`ShortcutsModal\` re-export from \`@/components/ui/index.ts\` (kept \`Kbd\`) so future consumers of the barrel can't accidentally re-pull the eager path. \`shortcuts-modal.tsx\` continues to re-export \`Kbd\` for backwards compatibility.
- \`AppLayoutInner\` warm-all now includes \`prefetchCommandPalette\` and \`prefetchShortcutsModal\`.

### Result

- Entry chunk: 172 kB → 158 kB
- Command palette → 12 kB lazy chunk
- Shortcuts modal → 2 kB lazy chunk
- No more \`import "./command-palette..."\` / \`import "./shortcuts-modal..."\` side-effect imports in any entry chunk
- Modulepreload manifest does NOT include either chunk on cold load

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` 89 baseline preserved
- [x] \`dist/index.html\` modulepreload audit — palette + modal not preloaded
- [ ] Manual: cold-load /app — DevTools network shows neither chunk
- [ ] Manual: hit ⌘K — palette opens within ~RTT (or instantly after idle prefetch)
- [ ] Manual: hit ? — shortcuts cheat-sheet opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)