### PR TITLE
fix(web): tighten lazy palette/shortcuts UX — loading shells + intent prefetch

### DIFF
--- a/apps/web/src/components/command-palette/command-palette.lazy.tsx
+++ b/apps/web/src/components/command-palette/command-palette.lazy.tsx
@@ -39,6 +39,34 @@ export function prefetchCommandPalette(): Promise<unknown> {
   return importCommandPalette();
 }
 
+/**
+ * Loading shell shown while the palette chunk downloads on first ⌘K. We
+ * mimic the palette's positioning + dialog framing so the user sees an
+ * immediate response instead of a "did the keystroke register?" pause on
+ * slow connections.
+ */
+function CommandPaletteLoadingShell({ open }: { open: boolean }) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-background/40 pt-[15vh] backdrop-blur-sm"
+      aria-hidden="true"
+    >
+      <div className="w-[min(640px,90vw)] rounded-lg border bg-popover p-4 shadow-lg">
+        <div className="flex items-center gap-2">
+          <div className="h-4 w-4 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-32 animate-pulse rounded bg-muted/70" />
+        </div>
+        <div className="mt-3 space-y-2">
+          <div className="h-2 w-3/4 animate-pulse rounded bg-muted/40" />
+          <div className="h-2 w-2/3 animate-pulse rounded bg-muted/40" />
+          <div className="h-2 w-1/2 animate-pulse rounded bg-muted/40" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function CommandPalette(props: CommandPaletteProps) {
   // The palette is dormant on every page view that doesn't hit ⌘K. Skip
   // mounting (and downloading) the chunk until it's actually opened, then
@@ -49,7 +77,7 @@ export function CommandPalette(props: CommandPaletteProps) {
   if (!seenOpenRef.current) return null;
 
   return (
-    <React.Suspense fallback={null}>
+    <React.Suspense fallback={<CommandPaletteLoadingShell open={props.open} />}>
       <LazyCommandPalette {...props} />
     </React.Suspense>
   );

--- a/apps/web/src/components/global-shortcuts-handler.tsx
+++ b/apps/web/src/components/global-shortcuts-handler.tsx
@@ -7,6 +7,8 @@ import {
 } from "@/hooks/useKeyboardShortcuts";
 import { useSearch } from "@/hooks/useSearch";
 import { toast } from "@/hooks/use-toast";
+import { prefetchCommandPalette } from "@/components/command-palette/command-palette.lazy";
+import { prefetchShortcutsModal } from "@/components/ui/shortcuts-modal.lazy";
 
 interface GlobalShortcutsHandlerProps {
   onAddTask: () => void;
@@ -29,6 +31,9 @@ export function GlobalShortcutsHandler({ onAddTask }: GlobalShortcutsHandlerProp
       // Show shortcuts modal (Shift + ?)
       if (SHORTCUTS.showShortcuts && matchesShortcut(event, SHORTCUTS.showShortcuts)) {
         event.preventDefault();
+        // Kick the chunk download in flight before React commits the open
+        // state — by the time Suspense suspends, the module is loading.
+        void prefetchShortcutsModal();
         setShowShortcutsModal(true);
         return;
       }
@@ -36,6 +41,7 @@ export function GlobalShortcutsHandler({ onAddTask }: GlobalShortcutsHandlerProp
       // Search/Command Palette (Cmd+K)
       if (SHORTCUTS.search && matchesShortcut(event, SHORTCUTS.search)) {
         event.preventDefault();
+        void prefetchCommandPalette();
         openSearch();
         return;
       }

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -16,6 +16,7 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useSearch } from "@/hooks/useSearch";
 import { useTheme } from "@/hooks/useTheme";
+import { prefetchCommandPalette } from "@/components/command-palette/command-palette.lazy";
 import { cn, getAvatarUrl } from "@/lib/utils";
 import {
   Button,
@@ -99,7 +100,16 @@ export function Header({ className }: HeaderProps) {
 
         {/* Search Button */}
         <button
-          onClick={openSearch}
+          onClick={() => {
+            void prefetchCommandPalette();
+            openSearch();
+          }}
+          onMouseEnter={() => {
+            void prefetchCommandPalette();
+          }}
+          onFocus={() => {
+            void prefetchCommandPalette();
+          }}
           className="hidden lg:flex items-center gap-1.5 px-2 py-1 rounded border border-border/40 bg-muted/30 hover:bg-muted transition-colors text-xs text-muted-foreground mr-2"
         >
           <Search className="h-3.5 w-3.5" />

--- a/apps/web/src/components/ui/shortcuts-modal.lazy.tsx
+++ b/apps/web/src/components/ui/shortcuts-modal.lazy.tsx
@@ -32,6 +32,25 @@ export function prefetchShortcutsModal(): Promise<unknown> {
   return importShortcutsModal();
 }
 
+function ShortcutsModalLoadingShell({ open }: { open: boolean }) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/40 backdrop-blur-sm"
+      aria-hidden="true"
+    >
+      <div className="w-[min(560px,90vw)] rounded-lg border bg-popover p-6 shadow-lg">
+        <div className="h-3 w-40 animate-pulse rounded bg-muted" />
+        <div className="mt-4 space-y-2">
+          <div className="h-2 w-full animate-pulse rounded bg-muted/40" />
+          <div className="h-2 w-5/6 animate-pulse rounded bg-muted/40" />
+          <div className="h-2 w-4/6 animate-pulse rounded bg-muted/40" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ShortcutsModal(props: ShortcutsModalProps) {
   const seenOpenRef = React.useRef(false);
   if (props.open) seenOpenRef.current = true;
@@ -39,7 +58,7 @@ export function ShortcutsModal(props: ShortcutsModalProps) {
   if (!seenOpenRef.current) return null;
 
   return (
-    <React.Suspense fallback={null}>
+    <React.Suspense fallback={<ShortcutsModalLoadingShell open={props.open} />}>
       <LazyShortcutsModal {...props} />
     </React.Suspense>
   );


### PR DESCRIPTION
## Summary

Code review of PR #13 caught the same "click did nothing" UX gap we already fixed for TaskModal/AddTaskModal in PR #10:

### Bug 1 — Suspense fallbacks were null

If a user hits ⌘K (or `?`) before the idle prefetch lands — e.g. on a slow network or within the first ~1.5 s of mount — they saw a blank page until the chunk arrived. Added matching loading shells (backdrop + dialog-shaped pulsing skeleton) so the click registers visibly.

### Bug 2 — No prefetch on intent

The header's Search button wired \`onClick={openSearch}\` with no prefetch on hover/focus, and the global keyboard shortcut handler called the open-state setter without kicking the import in flight first.

Wired \`prefetchCommandPalette\` and \`prefetchShortcutsModal\` synchronously to:
- Header Search button — \`onClick\`, \`onMouseEnter\`, \`onFocus\`.
- Global shortcut handler — fires in the keydown handler before \`setShowShortcutsModal(true)\` / \`openSearch()\`.

The prefetch helpers are idempotent (cached promise), so triple-firing on rapid hover/focus/click is free.

## Result

By the time React commits the modal's open state, the chunk is already in flight or already loaded — Suspense rarely needs to show the shell at all.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` 89 baseline preserved
- [x] \`bun run build\` succeeds, no new entry-chunk side-effect imports
- [ ] Manual: throttle network to Slow 3G, hit ⌘K — see loading shell instead of blank, then real palette mounts
- [ ] Manual: hover Search button — DevTools Network shows palette chunk fetched immediately
- [ ] Manual: hit ⌘K on a fresh tab (before idle prefetch) — chunks load fast enough that no shell flicker is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)