### PR TITLE
perf(web): extract React Query key factories — entry chunk -15kB

### DIFF
--- a/apps/web/src/hooks/useCalendars.ts
+++ b/apps/web/src/hooks/useCalendars.ts
@@ -8,17 +8,10 @@ import type {
 } from "@open-sunsama/types";
 import { getApiClient } from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
+import { calendarKeys } from "@/lib/query-keys";
 
-/**
- * Query key factory for calendar data
- */
-export const calendarKeys = {
-  all: ["calendars"] as const,
-  accounts: () => [...calendarKeys.all, "accounts"] as const,
-  calendars: () => [...calendarKeys.all, "list"] as const,
-  events: (from: string, to: string) =>
-    [...calendarKeys.all, "events", from, to] as const,
-};
+// Canonical key factory lives in lib/query-keys; re-exported for callers.
+export { calendarKeys };
 
 /**
  * Fetch all connected calendar accounts

--- a/apps/web/src/hooks/useSubtasks.ts
+++ b/apps/web/src/hooks/useSubtasks.ts
@@ -1,21 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Subtask } from "@open-sunsama/types";
 import { useSubtasksBatcher } from "./useSubtasksBatcher";
+import { subtaskKeys } from "@/lib/query-keys";
 
 // Re-export types for convenience
 export type { Subtask };
 export type { CreateSubtaskInput, UpdateSubtaskInput } from "@open-sunsama/types";
 
-/**
- * Query key factory for subtasks
- */
-export const subtaskKeys = {
-  all: ["subtasks"] as const,
-  lists: () => [...subtaskKeys.all, "list"] as const,
-  list: (taskId: string) => [...subtaskKeys.lists(), taskId] as const,
-  details: () => [...subtaskKeys.all, "detail"] as const,
-  detail: (id: string) => [...subtaskKeys.details(), id] as const,
-};
+// Re-export the canonical key factory.
+export { subtaskKeys };
 
 /**
  * Fetch subtasks for a task.

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -9,18 +9,13 @@ import type {
 import { getApi } from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
-import { timeBlockKeys } from "./useTimeBlocks";
+import { taskKeys, timeBlockKeys } from "@/lib/query-keys";
 
-/**
- * Query key factory for tasks
- */
-export const taskKeys = {
-  all: ["tasks"] as const,
-  lists: () => [...taskKeys.all, "list"] as const,
-  list: (filters: TaskFilterInput) => [...taskKeys.lists(), filters] as const,
-  details: () => [...taskKeys.all, "detail"] as const,
-  detail: (id: string) => [...taskKeys.details(), id] as const,
-};
+// Canonical task keys live in lib/query-keys so the WebSocket listener
+// (mounted at the app shell) can import only the keys without dragging
+// every task mutation into the boot bundle. Re-exported here for callers
+// that already import from this module.
+export { taskKeys };
 
 /**
  * Filter shape used as the third element of `taskKeys.list(...)`. Different

--- a/apps/web/src/hooks/useTimeBlocks.ts
+++ b/apps/web/src/hooks/useTimeBlocks.ts
@@ -1,18 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import type { TimeBlockFilterInput } from "@open-sunsama/types";
 import { getApi } from "@/lib/api";
+import { timeBlockKeys } from "@/lib/query-keys";
 
-/**
- * Query key factory for time blocks
- */
-export const timeBlockKeys = {
-  all: ["timeBlocks"] as const,
-  lists: () => [...timeBlockKeys.all, "list"] as const,
-  list: (filters: TimeBlockFilterInput) =>
-    [...timeBlockKeys.lists(), filters] as const,
-  details: () => [...timeBlockKeys.all, "detail"] as const,
-  detail: (id: string) => [...timeBlockKeys.details(), id] as const,
-};
+// Re-export so existing `import { timeBlockKeys } from "./useTimeBlocks"`
+// callers keep working while the canonical source lives in lib/query-keys.
+export { timeBlockKeys };
 
 /**
  * Fetch all time blocks with optional filters

--- a/apps/web/src/hooks/useTimer.ts
+++ b/apps/web/src/hooks/useTimer.ts
@@ -7,7 +7,11 @@ import {
   type TimerStartedEvent,
   type TimerStoppedEvent,
 } from "@/lib/websocket";
-import { taskKeys } from "@/hooks/useTasks";
+import { taskKeys, timerKeys } from "@/lib/query-keys";
+
+// Re-export so existing `import { timerKeys } from "@/hooks/useTimer"`
+// callers keep working while the canonical source lives in lib/query-keys.
+export { timerKeys };
 
 interface TimerState {
   isRunning: boolean;
@@ -28,13 +32,6 @@ interface UseTimerReturn {
   stop: () => void;
   reset: () => void;
 }
-
-/**
- * Query key factory for timer queries
- */
-export const timerKeys = {
-  active: () => ["tasks", "timer", "active"] as const,
-};
 
 const STORAGE_KEY_PREFIX = "focus-timer-";
 

--- a/apps/web/src/hooks/useWebSocket.ts
+++ b/apps/web/src/hooks/useWebSocket.ts
@@ -7,11 +7,13 @@ import {
   type UserEvent,
 } from "@/lib/websocket";
 import { useAuth } from "@/hooks/useAuth";
-import { taskKeys } from "@/hooks/useTasks";
-import { timerKeys } from "@/hooks/useTimer";
-import { timeBlockKeys } from "@/hooks/useTimeBlocks";
-import { subtaskKeys } from "@/hooks/useSubtasks";
-import { calendarKeys } from "@/hooks/useCalendars";
+import {
+  taskKeys,
+  timerKeys,
+  timeBlockKeys,
+  subtaskKeys,
+  calendarKeys,
+} from "@/lib/query-keys";
 
 /**
  * Debounced invalidation queue.

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -1,0 +1,56 @@
+/**
+ * Centralised React Query key factories.
+ *
+ * Each domain hook (`useTasks`, `useTimer`, `useTimeBlocks`, …) used to
+ * own + export its own `*Keys` factory. That meant `useWebSocket`, which
+ * only needs the keys to invalidate caches on incoming events, was
+ * pulling the full mutation/state code of every domain hook into its
+ * dependency tree — and `useWebSocket` is mounted at the app shell,
+ * which then sucked all of those modules into the boot bundle.
+ *
+ * Pulling the key factories into this leaf-level file lets the entry
+ * chunk import only the tiny key shapes while the heavy mutation code
+ * stays behind whatever route or component actually uses it.
+ *
+ * Domain hooks re-export their own key from here for backwards
+ * compatibility so consumers like `useTasks.taskKeys` keep working.
+ */
+
+import type { TaskFilterInput, TimeBlockFilterInput } from "@open-sunsama/types";
+
+export const taskKeys = {
+  all: ["tasks"] as const,
+  lists: () => [...taskKeys.all, "list"] as const,
+  list: (filters: TaskFilterInput) => [...taskKeys.lists(), filters] as const,
+  details: () => [...taskKeys.all, "detail"] as const,
+  detail: (id: string) => [...taskKeys.details(), id] as const,
+};
+
+export const timerKeys = {
+  active: () => ["tasks", "timer", "active"] as const,
+};
+
+export const timeBlockKeys = {
+  all: ["timeBlocks"] as const,
+  lists: () => [...timeBlockKeys.all, "list"] as const,
+  list: (filters: TimeBlockFilterInput) =>
+    [...timeBlockKeys.lists(), filters] as const,
+  details: () => [...timeBlockKeys.all, "detail"] as const,
+  detail: (id: string) => [...timeBlockKeys.details(), id] as const,
+};
+
+export const subtaskKeys = {
+  all: ["subtasks"] as const,
+  lists: () => [...subtaskKeys.all, "list"] as const,
+  list: (taskId: string) => [...subtaskKeys.lists(), taskId] as const,
+  details: () => [...subtaskKeys.all, "detail"] as const,
+  detail: (id: string) => [...subtaskKeys.details(), id] as const,
+};
+
+export const calendarKeys = {
+  all: ["calendars"] as const,
+  accounts: () => [...calendarKeys.all, "accounts"] as const,
+  calendars: () => [...calendarKeys.all, "list"] as const,
+  events: (from: string, to: string) =>
+    [...calendarKeys.all, "events", from, to] as const,
+};


### PR DESCRIPTION
## Summary

\`useWebSocket\` is mounted at the app shell, runs on every authenticated visit, and only needs the \`*Keys\` factories to invalidate caches when events arrive. Previously each domain hook (\`useTasks\`, \`useTimer\`, \`useTimeBlocks\`, \`useSubtasks\`, \`useCalendars\`) owned + exported its own key factory, so importing \`taskKeys\` from \`useTasks\` dragged 940 lines of mutation/state code into \`useWebSocket\`'s static graph — and from there into the boot bundle.

## Changes

- New \`apps/web/src/lib/query-keys.ts\` containing all five key factories.
- Each domain hook now imports its key from \`@/lib/query-keys\` and re-exports it. Callers that imported \`taskKeys\` from \`@/hooks/useTasks\` (or via the hooks barrel) keep working unchanged — same shape, same module path.
- \`useWebSocket\` imports all five keys directly from \`@/lib/query-keys\` instead of from each domain hook.

## Result

Entry chunk: 158 kB → 143 kB (-15 kB). The mutation code stays behind whatever route or component actually uses it.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` 89 baseline preserved
- [x] \`bun run build\` succeeds; entry chunk 143 kB confirmed
- [x] Verifier: shapes byte-identical so React Query cache lookups match
- [ ] Manual: ⌘K, open task modal, complete a task, drag a card — every cache invalidation still hits the right entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)