### PR TITLE
fix(web): break chunk-level cycles around timeBlock + subtask hooks

### DIFF
--- a/apps/web/src/hooks/useSubtaskMutations.ts
+++ b/apps/web/src/hooks/useSubtaskMutations.ts
@@ -6,7 +6,7 @@ import type {
 } from "@open-sunsama/types";
 import { getApi } from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
-import { subtaskKeys } from "./useSubtasks";
+import { subtaskKeys } from "@/lib/query-keys";
 
 /**
  * Create a subtask. Optimistically inserts a placeholder so the new row

--- a/apps/web/src/hooks/useTimeBlockMutations.ts
+++ b/apps/web/src/hooks/useTimeBlockMutations.ts
@@ -8,7 +8,7 @@ import type {
 } from "@open-sunsama/types";
 import { getApi } from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
-import { timeBlockKeys } from "./useTimeBlocks";
+import { timeBlockKeys } from "@/lib/query-keys";
 
 /**
  * Create a new time block
@@ -184,11 +184,8 @@ export function useAutoSchedule() {
   });
 }
 
-// Re-export timer-related mutations
-export {
-  useStartTimeBlock,
-  useStopTimeBlock,
-  useResizeTimeBlock,
-  useCascadeResizeTimeBlock,
-  useMoveTimeBlock,
-} from "./useTimeBlockTimer";
+// Timer-related mutations are owned by ./useTimeBlockTimer and are
+// re-exported from ./useTimeBlocks (the public barrel for this domain).
+// We deliberately do NOT re-export them from here — useTimeBlockTimer
+// imports useUpdateTimeBlock from this file, and re-exporting through
+// here would create a chunk-level cycle.

--- a/apps/web/src/hooks/useTimeBlockTimer.ts
+++ b/apps/web/src/hooks/useTimeBlockTimer.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { TimeBlock } from "@open-sunsama/types";
 import { toast } from "@/hooks/use-toast";
-import { timeBlockKeys } from "./useTimeBlocks";
+import { timeBlockKeys } from "@/lib/query-keys";
 import { useUpdateTimeBlock } from "./useTimeBlockMutations";
 import { useApiClient } from "@/lib/api";
 

--- a/apps/web/src/hooks/useTimeBlocks.ts
+++ b/apps/web/src/hooks/useTimeBlocks.ts
@@ -51,16 +51,25 @@ export function useTimeBlock(id: string) {
   });
 }
 
-// Re-export all mutations for backwards compatibility
+// Re-export mutations for backwards compatibility. We import each one
+// from its actual source module rather than chaining through
+// useTimeBlockMutations — useTimeBlockMutations itself re-exports the
+// timer mutations from useTimeBlockTimer, while useTimeBlockTimer imports
+// useUpdateTimeBlock from useTimeBlockMutations. Going through the chain
+// produces a chunk-level cycle that Rollup warns about. Splitting the
+// re-export so this file references each defining module directly cuts
+// the cycle.
 export {
   useCreateTimeBlock,
   useUpdateTimeBlock,
   useDeleteTimeBlock,
   useQuickSchedule,
   useAutoSchedule,
+} from "./useTimeBlockMutations";
+export {
   useStartTimeBlock,
   useStopTimeBlock,
   useResizeTimeBlock,
   useCascadeResizeTimeBlock,
   useMoveTimeBlock,
-} from "./useTimeBlockMutations";
+} from "./useTimeBlockTimer";


### PR DESCRIPTION
## Summary

Code review of PR #15 noticed the build kept emitting "circular dependency between chunks" warnings around the time-block and subtask hooks. Pre-existing, but easy to fix now that the query keys live in their own leaf module.

The cycles:

1. \`useSubtaskMutations\` imports \`subtaskKeys\` from \`./useSubtasks\`, while \`useSubtasks\` re-exports the mutations from \`useSubtaskMutations\`. Cross-import → cycle.
2. \`useTimeBlockMutations\` re-exports the timer mutations from \`./useTimeBlockTimer\`, while \`useTimeBlockTimer\` imports \`useUpdateTimeBlock\` from \`useTimeBlockMutations\`. Same shape.
3. \`useTimeBlockTimer\` and \`useTimeBlockMutations\` both imported \`timeBlockKeys\` from \`./useTimeBlocks\`, while \`useTimeBlocks\` re-exports both modules. Same chain.

## Fixes

- All three "mutations" / "timer" files now import their key directly from \`@/lib/query-keys\` instead of through the public \`useSubtasks\` / \`useTimeBlocks\` barrel.
- \`useTimeBlockMutations\` no longer re-exports the timer mutations. \`useTimeBlocks\` (the public barrel for the domain) re-exports them directly from \`useTimeBlockTimer\`. So the chain \`useTimeBlocks → useTimeBlockMutations → useTimeBlockTimer → useTimeBlockMutations\` is replaced with the cycle-free \`useTimeBlocks → {useTimeBlockMutations, useTimeBlockTimer}\` and \`useTimeBlockTimer → useTimeBlockMutations\` (one-way).

## Result

Build emits zero "circular chunk" warnings around these modules. All existing import paths still resolve unchanged.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` 89 baseline preserved
- [x] \`bun run build\` succeeds with no circular-chunk warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)