### PR TITLE
perf(web): defer AppUpdateBanner — web users skip the desktop-only chunk

### DIFF
--- a/apps/web/src/components/app-update-banner.lazy.tsx
+++ b/apps/web/src/components/app-update-banner.lazy.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { isDesktop } from "@/lib/desktop";
+import type * as AppUpdateBannerModuleNS from "./app-update-banner";
+
+/**
+ * Lazy entry point for the desktop auto-update banner.
+ *
+ * The real component pulls in `useAppUpdate` (which dynamically imports
+ * `@tauri-apps/plugin-updater` + `@tauri-apps/plugin-process`) and a stack
+ * of icons. None of that is needed on the web — `isDesktop()` is false
+ * and the banner is a no-op. This wrapper short-circuits to `null` for
+ * web users so the chunk is never even fetched.
+ *
+ * On desktop, the chunk is loaded behind a `React.lazy` boundary and
+ * mounted once. Suspense fallback is `null` because the banner itself
+ * renders `null` until an update is detected — there's nothing to show.
+ */
+
+type AppUpdateBannerModule = typeof AppUpdateBannerModuleNS;
+
+let preload: Promise<AppUpdateBannerModule> | null = null;
+
+function importBanner(): Promise<AppUpdateBannerModule> {
+  if (!preload) {
+    preload = import("./app-update-banner") as Promise<AppUpdateBannerModule>;
+  }
+  return preload;
+}
+
+const LazyAppUpdateBanner = React.lazy(async () => {
+  const mod = await importBanner();
+  return { default: mod.AppUpdateBanner };
+});
+
+export function AppUpdateBanner() {
+  // Web users will never see the banner; don't even fetch the chunk.
+  // Computed once via useState so HMR re-renders don't toggle it.
+  const [isDesktopApp] = React.useState(() => isDesktop());
+
+  if (!isDesktopApp) return null;
+
+  return (
+    <React.Suspense fallback={null}>
+      <LazyAppUpdateBanner />
+    </React.Suspense>
+  );
+}

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -30,7 +30,7 @@ import {
   TaskModal,
   prefetchTaskModal,
 } from "@/components/kanban/task-modal.lazy";
-import { AppUpdateBanner } from "@/components/app-update-banner";
+import { AppUpdateBanner } from "@/components/app-update-banner.lazy";
 import { prefetchRichTextEditor } from "@/components/ui/rich-text-editor.lazy";
 
 /**


### PR DESCRIPTION
## Summary

The desktop auto-update banner was eagerly imported by \`routes/app.tsx\`, so every web visitor downloaded the banner code, the \`useAppUpdate\` hook, the \`lib/updater.ts\` helpers, and a handful of icons — all dead weight on web (since \`useAppUpdate\` short-circuits via \`isDesktop()\` on the first line).

Wrapped it in a \`.lazy.tsx\` shell that:

- short-circuits to \`null\` synchronously on web (\`isDesktop()\` checked once via \`useState\`), so the chunk is never even fetched,
- uses \`React.lazy\` + Suspense \`fallback={null}\` on desktop.

## Result

- Entry chunk: 143 kB → 140 kB.
- Banner moves into a 3 kB lazy chunk that only desktop builds request.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` 89 baseline
- [x] \`bun run build\` succeeds; \`app-update-banner-*.js\` is its own chunk; entry has no static side-effect import of it
- [ ] Manual: cold-load on web — DevTools Network shows no banner chunk fetched
- [ ] Manual: cold-load in Tauri desktop — banner chunk fetched + mounted; visible if an update is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)