### PR TITLE
perf(web,api): inline subtasks in kanban range fetch — kill the second roundtrip

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -14,7 +14,9 @@ import {
   isNotNull,
   desc,
   asc,
+  inArray,
   tasks,
+  subtasks,
   sql,
   notificationPreferences,
 } from "@open-sunsama/database";
@@ -96,9 +98,36 @@ tasksRouter.get(
       .limit(filters.limit)
       .offset(offset);
 
+    // Optionally inline subtasks. The kanban range prefetch turns this on
+    // so the client can hydrate every visible day's task cards plus their
+    // subtask previews in a single round-trip — no follow-up
+    // `subtasks-batch` call needed.
+    let withSubtasks: Array<typeof results[number] & { subtasks?: unknown[] }> =
+      results;
+    if (filters.includeSubtasks === "true" && results.length > 0) {
+      const ids = results.map((t) => t.id);
+      const allSubtasks = await db
+        .select()
+        .from(subtasks)
+        .where(inArray(subtasks.taskId, ids))
+        .orderBy(asc(subtasks.position), asc(subtasks.createdAt));
+
+      const byTaskId = new Map<string, typeof allSubtasks>();
+      for (const id of ids) byTaskId.set(id, []);
+      for (const s of allSubtasks) {
+        const list = byTaskId.get(s.taskId);
+        if (list) list.push(s);
+      }
+
+      withSubtasks = results.map((t) => ({
+        ...t,
+        subtasks: byTaskId.get(t.id) ?? [],
+      }));
+    }
+
     return c.json({
       success: true,
-      data: results,
+      data: withSubtasks,
       meta: {
         page: filters.page,
         limit: filters.limit,

--- a/apps/api/src/validation/tasks.ts
+++ b/apps/api/src/validation/tasks.ts
@@ -55,6 +55,10 @@ export const taskFilterSchema = z.object({
   sortBy: sortBySchema.optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(500).default(50),
+  // Inline-include the subtasks for each task. Used by the kanban range
+  // prefetch so we don't have to fire a follow-up `subtasks-batch` request
+  // for tasks the client already has in hand.
+  includeSubtasks: z.enum(['true', 'false']).optional(),
 });
 
 /**

--- a/apps/web/src/hooks/useKanbanRangePrefetch.ts
+++ b/apps/web/src/hooks/useKanbanRangePrefetch.ts
@@ -1,10 +1,15 @@
 import * as React from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Task } from "@open-sunsama/types";
+import type { Task, Subtask } from "@open-sunsama/types";
 import { addDays, format, subDays } from "date-fns";
 import { getApi } from "@/lib/api";
-import { taskKeys } from "@/hooks/useTasks";
+import { taskKeys, subtaskKeys } from "@/lib/query-keys";
 import { useAuth } from "@/hooks/useAuth";
+
+// The shape the server returns when `includeSubtasks=true` is set. The
+// canonical Task type doesn't carry a `subtasks` field — we strip it back
+// out before seeding the per-day caches so consumers see plain Tasks.
+type TaskWithSubtasks = Task & { subtasks?: Subtask[] };
 
 /**
  * The number of days to prefetch in each direction around the current
@@ -105,16 +110,32 @@ export function useKanbanRangePrefetch(options: RangePrefetchOptions = {}) {
 
   const query = useQuery({
     queryKey,
-    queryFn: async (): Promise<{ tasks: Task[]; truncated: boolean }> => {
+    queryFn: async (): Promise<{
+      tasks: Task[];
+      subtasksByTaskId: Map<string, Subtask[]>;
+      truncated: boolean;
+    }> => {
       const api = getApi();
       const response = await api.tasks.list({
         scheduledDateFrom: fromString,
         scheduledDateTo: toString,
         limit: RANGE_FETCH_LIMIT,
+        includeSubtasks: true,
       });
-      const tasks = response.data ?? [];
-      const total = response.meta?.total ?? tasks.length;
-      return { tasks, truncated: total > tasks.length };
+      const raw = (response.data ?? []) as TaskWithSubtasks[];
+      const total = response.meta?.total ?? raw.length;
+
+      // Strip subtasks off the task object before we put it in the per-day
+      // cache. We seed the subtask caches separately below.
+      const tasks: Task[] = [];
+      const subtasksByTaskId = new Map<string, Subtask[]>();
+      for (const t of raw) {
+        const { subtasks: embedded, ...rest } = t;
+        tasks.push(rest as Task);
+        if (embedded) subtasksByTaskId.set(t.id, embedded);
+      }
+
+      return { tasks, subtasksByTaskId, truncated: total > tasks.length };
     },
     enabled: isAuthenticated,
     staleTime: 30_000,
@@ -186,6 +207,19 @@ export function useKanbanRangePrefetch(options: RangePrefetchOptions = {}) {
       }
 
       queryClient.setQueryData(cacheKey, tasks);
+    }
+
+    // Seed the per-task subtask caches too, so the kanban's subtask
+    // batcher never has to fire — `useSubtasks(taskId)` will read from
+    // these fresh cache entries (within the 60s default staleTime).
+    for (const [taskId, list] of data.subtasksByTaskId) {
+      const cacheKey = subtaskKeys.list(taskId);
+      const existing = queryClient.getQueryData<Subtask[]>(cacheKey);
+      // Don't clobber a list that contains an in-flight optimistic insert.
+      if (existing && existing.some((s) => s.id.startsWith("optimistic-"))) {
+        continue;
+      }
+      queryClient.setQueryData(cacheKey, list);
     }
   }, [data, queryClient, queryKey, bufferDays, centerString]);
 

--- a/packages/api-client/src/tasks.ts
+++ b/packages/api-client/src/tasks.ts
@@ -154,7 +154,12 @@ export interface TasksApi {
  * Maps frontend filter names to API query parameter names
  */
 function filtersToSearchParams(
-  filters?: TaskFilterInput & { priority?: string; limit?: number; page?: number }
+  filters?: TaskFilterInput & {
+    priority?: string;
+    limit?: number;
+    page?: number;
+    includeSubtasks?: boolean;
+  }
 ): Record<string, string | number | boolean | undefined> {
   if (!filters) return {};
 
@@ -176,6 +181,11 @@ function filtersToSearchParams(
     limit: filters.limit,
     // Page number for pagination
     page: filters.page,
+    // Inline-include subtasks per task in the response
+    includeSubtasks:
+      filters.includeSubtasks !== undefined
+        ? String(filters.includeSubtasks)
+        : undefined,
   };
 }
 

--- a/packages/types/src/task.ts
+++ b/packages/types/src/task.ts
@@ -243,6 +243,13 @@ export interface TaskFilterInput {
 
   /** Filter by priority level */
   priority?: TaskPriority;
+
+  /**
+   * If true, the server inlines each task's subtasks into the response as
+   * a `subtasks: Subtask[]` field on each task. Used by the kanban range
+   * prefetch to avoid a follow-up `subtasks-batch` request.
+   */
+  includeSubtasks?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

After the optimisations in #11/#12, the kanban cold-start sequence was:

1. \`GET /tasks?from=X&to=Y\` — range fetch (one request)
2. \`POST /tasks/subtasks-batch\` — batched subtask fetch (one request)

Both fire in parallel, but the subtask batch can't *start* until React mounts the first \`DayColumn\`, which can't happen until step 1 returns. So in practice the network looks like a 2-RTT waterfall: range → render → subtasks → render again with subtasks.

This change eliminates step 2 entirely on cold start.

## Changes

- **API**: \`GET /tasks\` accepts \`?includeSubtasks=true\`. When set, the server JOIN-fetches subtasks for the returned task IDs via \`inArray\` and inlines them into each task as \`task.subtasks: Subtask[]\`. Ownership stays safe — we only fetch subtasks whose parent task already passed the \`tasks.userId\` filter.
- **api-client**: \`tasks.list({ includeSubtasks: true, ... })\` plumbs the flag through \`filtersToSearchParams\`. \`TaskFilterInput.includeSubtasks\` added to \`@open-sunsama/types\`.
- **\`useKanbanRangePrefetch\`**: passes \`includeSubtasks: true\` and on resolution splits the response — strips \`subtasks\` off each task before seeding the per-day caches, then seeds \`subtaskKeys.list(taskId)\` via \`setQueryData\` for each task. The seeded caches are within React Query's 60s \`staleTime\`, so any \`useSubtasks(taskId)\` mounted by a DayColumn reads from cache without firing the batcher.

## Result

Kanban cold start fires **one HTTP request instead of two**. The subtask batcher remains in place as the fallback for any \`useSubtasks\` call that *isn't* covered by the range prefetch (e.g. opening a task modal whose ID isn't in the visible window).

## Test plan

- [x] \`bun run typecheck\` clean (whole workspace)
- [x] \`bun run lint\` 89 baseline preserved
- [x] \`bun run build\` succeeds
- [x] Verifier: ownership-safe, optimistic-insert preservation, fingerprint check prevents re-seeding
- [ ] Manual: open /app — DevTools Network shows one \`GET /tasks?…&includeSubtasks=true\` and no \`POST /tasks/subtasks-batch\` request
- [ ] Manual: optimistic subtask insert during a concurrent range refetch is preserved (not clobbered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)