### PR TITLE
fix(web): calendar event timezone + multi-day rendering

### DIFF
--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -62,9 +62,15 @@ export function CalendarView({
   const { data: timeBlocks = [], isLoading: isLoadingBlocks } =
     useTimeBlocksForDate(dateString);
 
-  // Fetch external calendar events for selected date
-  const fromDate = format(startOfDay(selectedDate), "yyyy-MM-dd'T'HH:mm:ss");
-  const toDate = format(endOfDay(selectedDate), "yyyy-MM-dd'T'HH:mm:ss");
+  // Fetch external calendar events for the selected day. We use the user's
+  // LOCAL day boundaries converted to UTC ISO strings — `format(...,
+  // "yyyy-MM-dd'T'HH:mm:ss")` was emitting a timezone-less string that the
+  // server then mis-interpreted as UTC, shifting the query window by the
+  // user's UTC offset and causing events near the day boundary to be
+  // dropped or wrongly attributed. `.toISOString()` yields the same local
+  // instant in UTC, which the server parses correctly.
+  const fromDate = startOfDay(selectedDate).toISOString();
+  const toDate = endOfDay(selectedDate).toISOString();
   const { data: calendarEvents = [] } = useCalendarEvents(fromDate, toDate);
 
   // Mutations

--- a/apps/web/src/components/calendar/external-event.tsx
+++ b/apps/web/src/components/calendar/external-event.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { format, differenceInMinutes } from "date-fns";
+import {
+  format,
+  differenceInMinutes,
+  startOfDay,
+  endOfDay,
+  isSameDay,
+} from "date-fns";
 import type { CalendarEvent } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import { ExternalLink, CalendarDays } from "lucide-react";
@@ -16,6 +22,12 @@ import {
 
 interface ExternalEventProps {
   event: CalendarEvent;
+  /**
+   * The day this timeline is rendering. Used to clamp multi-day events
+   * to the visible window — without this a Mon→Wed event would render at
+   * Y = "23:00 of Tuesday" on Tuesday's view (off-screen at the bottom).
+   */
+  displayDate: Date;
   onClick?: () => void;
   className?: string;
 }
@@ -48,6 +60,7 @@ function getEventColor(event: CalendarEvent): string {
  */
 export function ExternalEvent({
   event,
+  displayDate,
   onClick,
   className,
 }: ExternalEventProps) {
@@ -55,9 +68,22 @@ export function ExternalEvent({
   const endTime = new Date(event.endTime);
   const color = getEventColor(event);
 
-  // Calculate position and size
-  const top = calculateYFromTime(startTime);
-  const durationMins = differenceInMinutes(endTime, startTime);
+  // Clamp the rendered slice of a multi-day event to the displayed day.
+  // If the event started yesterday it should render flush against the top
+  // of today's column; if it ends tomorrow it should render flush against
+  // the bottom. We also surface "continues from earlier" / "continues
+  // tomorrow" indicators via title-row affordances.
+  const dayStart = startOfDay(displayDate);
+  const dayEnd = endOfDay(displayDate);
+  const continuesFromPriorDay = startTime < dayStart;
+  const continuesToNextDay = endTime > dayEnd;
+
+  const renderStart = continuesFromPriorDay ? dayStart : startTime;
+  const renderEnd = continuesToNextDay ? dayEnd : endTime;
+
+  // Calculate position and size based on the clamped slice.
+  const top = calculateYFromTime(renderStart);
+  const durationMins = differenceInMinutes(renderEnd, renderStart);
   const height = (durationMins / 60) * HOUR_HEIGHT;
 
   // Determine if event is too short to show full content
@@ -145,11 +171,23 @@ export function ExternalEvent({
           <div className="space-y-1">
             <p className="font-medium">{event.title}</p>
             <p className="text-xs text-muted-foreground">
-              {format(startTime, "h:mm a")} - {format(endTime, "h:mm a")}
+              {format(startTime, "MMM d, h:mm a")} -{" "}
+              {isSameDay(startTime, endTime)
+                ? format(endTime, "h:mm a")
+                : format(endTime, "MMM d, h:mm a")}
             </p>
+            {(continuesFromPriorDay || continuesToNextDay) && (
+              <p className="text-xs text-muted-foreground/80 italic">
+                {continuesFromPriorDay && continuesToNextDay
+                  ? "Continues across days"
+                  : continuesFromPriorDay
+                    ? "Continues from earlier"
+                    : "Continues tomorrow"}
+              </p>
+            )}
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <div 
-                className="h-2 w-2 rounded-full" 
+              <div
+                className="h-2 w-2 rounded-full"
                 style={{ backgroundColor: color }}
               />
               <span>{calendarName}</span>

--- a/apps/web/src/components/calendar/timeline.tsx
+++ b/apps/web/src/components/calendar/timeline.tsx
@@ -1,5 +1,12 @@
 import * as React from "react";
-import { format, isSameDay, setHours, addMinutes } from "date-fns";
+import {
+  format,
+  isSameDay,
+  setHours,
+  addMinutes,
+  startOfDay,
+  endOfDay,
+} from "date-fns";
 import type { TimeBlock as TimeBlockType, CalendarEvent } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui";
@@ -103,16 +110,55 @@ export function Timeline({
     );
   }, [timeBlocks, date]);
 
-  // Filter and separate external calendar events for this day
+  // Filter and separate external calendar events for this day.
+  //
+  // A multi-day event (e.g. a 3-day conference May 1 → May 3) should appear
+  // on every day it overlaps, not just the start day — the previous code
+  // checked `isSameDay(startTime, date)` which dropped it from the
+  // intermediate days. Use a real overlap check instead.
+  //
+  // All-day events are stored at UTC midnight (Google's convention), so
+  // their startTime in a non-UTC viewer timezone may render as the
+  // previous evening. We treat the date portion of the UTC string as the
+  // event's "calendar date" and check membership against that span.
   const { timedEvents, allDayEvents } = React.useMemo(() => {
-    const dayEvents = calendarEvents.filter((event) =>
-      isSameDay(new Date(event.startTime), date)
-    );
-    
-    return {
-      timedEvents: dayEvents.filter((event) => !event.isAllDay),
-      allDayEvents: dayEvents.filter((event) => event.isAllDay),
-    };
+    const dayStart = startOfDay(date);
+    const dayEnd = endOfDay(date);
+    // The user's local "calendar date" — the date string they think of as
+    // "today" in the UI. We compare it against the UTC-stored date span of
+    // each all-day event. This works because all-day events are stored
+    // detached from any wall-clock timezone (per iCal/Google convention),
+    // so a "May 2" all-day event is "May 2" regardless of viewer TZ.
+    const targetCalendarDate = format(date, "yyyy-MM-dd");
+
+    const timed: CalendarEvent[] = [];
+    const allDay: CalendarEvent[] = [];
+
+    for (const event of calendarEvents) {
+      const start = new Date(event.startTime);
+      const end = new Date(event.endTime);
+
+      if (event.isAllDay) {
+        // The iCal/Google convention stores an all-day event with
+        // start = midnight UTC of the calendar date and end = exclusive
+        // next-day midnight. The event covers [startDateStr, endDateStr).
+        const startDateStr = start.toISOString().slice(0, 10);
+        const endDateStr = end.toISOString().slice(0, 10);
+        if (
+          targetCalendarDate >= startDateStr &&
+          targetCalendarDate < endDateStr
+        ) {
+          allDay.push(event);
+        }
+      } else {
+        // Timed event: include if it overlaps the user's local day window.
+        if (start < dayEnd && end > dayStart) {
+          timed.push(event);
+        }
+      }
+    }
+
+    return { timedEvents: timed, allDayEvents: allDay };
   }, [calendarEvents, date]);
 
   // Handle click on empty time slot
@@ -240,7 +286,11 @@ export function Timeline({
             {/* External calendar events (rendered behind time blocks) */}
             {!isLoading &&
               timedEvents.map((event) => (
-                <ExternalEvent key={event.id} event={event} />
+                <ExternalEvent
+                  key={event.id}
+                  event={event}
+                  displayDate={date}
+                />
               ))}
 
             {/* Time blocks */}


### PR DESCRIPTION
## Summary

End-to-end audit of the calendar view found three more bugs sitting downstream of the calendar-events sync fix in #21.

## 1. Timezone bug in the date-range query — calendar-view.tsx

The client was sending a timezone-less ISO string:
\`\`\`ts
const fromDate = format(startOfDay(selectedDate), "yyyy-MM-dd'T'HH:mm:ss");
\`\`\`

On the server, \`new Date(from)\` interprets that as local time on the server (UTC in production), shifting the query window by the user's UTC offset. A user in EST viewing May 2 was actually getting events for May 1 19:00 UTC → May 2 18:59 UTC. Events near the local-day boundary were dropped, and events from the previous day leaked in.

**Fix:** \`.toISOString()\` encodes the user's local-day boundary as a real UTC instant; the server parses it correctly.

## 2. Multi-day events dropped from intermediate days — timeline.tsx

The Timeline filter was \`isSameDay(new Date(event.startTime), date)\` which only matched a multi-day event on its START day. A 3-day conference (Mon → Wed) only appeared on Monday.

**Fix:** Real overlap check.
- Timed events: \`start < dayEnd && end > dayStart\`.
- All-day events: compare the user's calendar date against the event's UTC date span (matching Google's iCal convention of storing all-day events at UTC midnight with an exclusive next-day end).

## 3. Multi-day timed events rendered off-screen — external-event.tsx

\`calculateYFromTime\` reads \`getHours()\` and converts to a Y position relative to the rendered day. So an event that started yesterday at 23:00 would render at Y = 23×64 = 1472 on today's column — way below the visible timeline, even though the new filter correctly classifies it as overlapping today.

**Fix:** Added \`displayDate\` prop to \`ExternalEvent\`. Clamps the rendered slice to \`[startOfDay(displayDate), endOfDay(displayDate)]\`. The tooltip surfaces "Continues from earlier / Continues tomorrow / Continues across days" when the event extends beyond the visible day.

## Verification — 3 parallel verifiers

All 3 verifiers agree the timezone, rendering, and integration paths are correct across 21 traced scenarios. Only finding was a misleading variable name (\`targetDateUtcString\` was actually a local-date string) — renamed to \`targetCalendarDate\` with a clearer comment.

## Test plan

- [x] \`bun run typecheck\` clean (whole workspace)
- [x] \`bun run lint\` 89 baseline preserved
- [x] 3 verifier subagents PASS
- [ ] Manual: connect Google with a multi-calendar account; verify events from BOTH calendars appear (combined with #21)
- [ ] Manual: change device TZ to PST/JST; confirm events render on the right day
- [ ] Manual: add a multi-day event in Google; confirm it appears on every day of the span

🤖 Generated with [Claude Code](https://claude.com/claude-code)