### PR TITLE
fix(web): calendar event click — open in-app detail sheet, not Google + new task popup

### DIFF
--- a/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
+++ b/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
@@ -1,0 +1,222 @@
+import * as React from "react";
+import { format, isSameDay } from "date-fns";
+import {
+  CalendarDays,
+  Clock,
+  ExternalLink as ExternalLinkIcon,
+  MapPin,
+  Plus,
+  AlignLeft,
+} from "lucide-react";
+import type { CalendarEvent } from "@open-sunsama/types";
+import {
+  Button,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui";
+
+interface CalendarEventDetailSheetProps {
+  event: CalendarEvent | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Optional handler invoked when the user clicks "Create task from
+   * event". The parent typically opens the AddTaskModal pre-filled with
+   * the event title and a scheduledDate matching the event's start.
+   */
+  onCreateTask?: (event: CalendarEvent) => void;
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const cleanHex = hex.replace("#", "");
+  const r = parseInt(cleanHex.substring(0, 2), 16);
+  const g = parseInt(cleanHex.substring(2, 4), 16);
+  const b = parseInt(cleanHex.substring(4, 6), 16);
+  if (
+    Number.isNaN(r) ||
+    Number.isNaN(g) ||
+    Number.isNaN(b)
+  ) {
+    return `rgba(107, 114, 128, ${alpha})`;
+  }
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function formatEventTime(event: CalendarEvent): string {
+  const start = new Date(event.startTime);
+  const end = new Date(event.endTime);
+
+  if (event.isAllDay) {
+    // All-day events are stored at UTC midnight; their "calendar date"
+    // is the UTC date portion. End is exclusive (next-day midnight).
+    const startDateStr = start.toISOString().slice(0, 10);
+    const endDateStr = end.toISOString().slice(0, 10);
+    if (startDateStr === endDateStr) {
+      // 0-day span — degenerate; show start only.
+      return format(start, "EEEE, MMMM d, yyyy");
+    }
+    // Convert to a real Date object in local TZ for the formatter, then
+    // back the end date off by 1 day so it reads as the inclusive last day.
+    const inclusiveEnd = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+    if (startDateStr === inclusiveEnd.toISOString().slice(0, 10)) {
+      return format(start, "EEEE, MMMM d, yyyy");
+    }
+    return `${format(start, "MMM d, yyyy")} → ${format(inclusiveEnd, "MMM d, yyyy")}`;
+  }
+
+  if (isSameDay(start, end)) {
+    return `${format(start, "EEEE, MMMM d, yyyy")} · ${format(start, "h:mm a")} – ${format(end, "h:mm a")}`;
+  }
+  return `${format(start, "MMM d, h:mm a")} → ${format(end, "MMM d, h:mm a")}`;
+}
+
+/**
+ * Read-only detail sheet for an external calendar event.
+ *
+ * This deliberately replaces the previous behaviour of opening the
+ * provider's web UI on click. The user wanted to interact with their
+ * events inside the app — see the details, navigate to the source if
+ * they want, or convert to a task — without bouncing out to Google.
+ *
+ * Editing/deleting requires a write-back path to the upstream provider,
+ * which is shipped in a follow-up. For now the sheet exposes:
+ *
+ *   - title, time range, location, description, attending status
+ *   - the source calendar (with its provider color)
+ *   - "Open in Google / Outlook / iCloud" — explicit secondary action
+ *   - "Create task from event" — explicit primary action that hands
+ *     the event off to the AddTaskModal pre-filled
+ */
+export function CalendarEventDetailSheet({
+  event,
+  open,
+  onOpenChange,
+  onCreateTask,
+}: CalendarEventDetailSheetProps) {
+  // Render nothing until first open so the sheet doesn't allocate DOM
+  // before a user actually clicks an event.
+  const seenOpenRef = React.useRef(false);
+  if (open) seenOpenRef.current = true;
+  if (!seenOpenRef.current) return null;
+
+  const color = event?.calendar?.color ?? "#6B7280";
+  const calendarName = event?.calendar?.name ?? "External calendar";
+
+  const handleOpenInProvider = () => {
+    if (event?.htmlLink) {
+      window.open(event.htmlLink, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  const handleCreateTask = () => {
+    if (event && onCreateTask) {
+      onCreateTask(event);
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-md overflow-y-auto">
+        <SheetHeader className="space-y-3">
+          <div className="flex items-start gap-2">
+            <div
+              className="mt-1 h-3 w-3 flex-shrink-0 rounded-full"
+              style={{ backgroundColor: color }}
+              aria-hidden
+            />
+            <SheetTitle className="text-base font-semibold leading-snug">
+              {event?.title || "Untitled event"}
+            </SheetTitle>
+          </div>
+          <div
+            className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium"
+            style={{ backgroundColor: hexToRgba(color, 0.1) }}
+          >
+            <CalendarDays
+              className="h-3 w-3"
+              style={{ color }}
+              aria-hidden
+            />
+            <span style={{ color: hexToRgba(color, 1) }}>{calendarName}</span>
+            {event?.responseStatus && (
+              <span className="ml-auto text-muted-foreground">
+                {event.responseStatus === "accepted" && "Going"}
+                {event.responseStatus === "declined" && "Declined"}
+                {event.responseStatus === "tentative" && "Maybe"}
+                {event.responseStatus === "needsAction" && "Awaiting reply"}
+              </span>
+            )}
+          </div>
+        </SheetHeader>
+
+        {event && (
+          <div className="mt-6 space-y-5">
+            {/* Time */}
+            <div className="flex items-start gap-3 text-sm">
+              <Clock className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+              <div className="text-foreground/90">{formatEventTime(event)}</div>
+            </div>
+
+            {/* Location */}
+            {event.location && (
+              <div className="flex items-start gap-3 text-sm">
+                <MapPin className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                <div className="text-foreground/90 break-words">
+                  {event.location}
+                </div>
+              </div>
+            )}
+
+            {/* Description */}
+            {event.description && (
+              <div className="flex items-start gap-3 text-sm">
+                <AlignLeft className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                <div
+                  className="prose prose-sm max-w-none text-foreground/90"
+                  // Description from external calendars is HTML in some
+                  // providers (Google in particular). We render it as
+                  // text — full HTML rendering would require sanitising
+                  // through the same path as Tiptap content does and
+                  // isn't worth the surface area for read-only display.
+                >
+                  {event.description}
+                </div>
+              </div>
+            )}
+
+            <div className="border-t pt-5 space-y-2">
+              <Button
+                onClick={handleCreateTask}
+                disabled={!onCreateTask}
+                className="w-full justify-start"
+                variant="default"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Create task from event
+              </Button>
+              {event.htmlLink && (
+                <Button
+                  onClick={handleOpenInProvider}
+                  className="w-full justify-start"
+                  variant="outline"
+                >
+                  <ExternalLinkIcon className="mr-2 h-4 w-4" />
+                  Open in calendar provider
+                </Button>
+              )}
+            </div>
+
+            {/* Footer note: editing comes in a follow-up */}
+            <p className="pt-2 text-[11px] text-muted-foreground/70">
+              Editing and deleting events sync back to your calendar
+              provider — coming soon.
+            </p>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -6,7 +6,7 @@ import {
   startOfDay,
   endOfDay,
 } from "date-fns";
-import type { Task, TimeBlock } from "@open-sunsama/types";
+import type { Task, TimeBlock, CalendarEvent } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import {
   useTasks,
@@ -21,6 +21,11 @@ import { Timeline } from "./timeline";
 import { UnscheduledTasksPanel } from "./unscheduled-tasks";
 import { DragOverlay } from "./drag-overlay";
 import { CalendarViewToolbar } from "./calendar-view-toolbar";
+import { CalendarEventDetailSheet } from "./calendar-event-detail-sheet";
+import {
+  AddTaskModal,
+  prefetchAddTaskModal,
+} from "@/components/kanban/add-task-modal.lazy";
 
 interface CalendarViewProps {
   initialDate?: Date;
@@ -221,6 +226,52 @@ export function CalendarView({
 
   const isLoading = isLoadingTasks || isLoadingBlocks;
 
+  // External calendar event interaction. Clicking an event opens an
+  // in-app detail sheet — replacing the previous (broken) behaviour
+  // where the click both opened the provider's web UI in a new tab AND
+  // bubbled to the timeline's create-time-block dialog.
+  const [selectedExternalEvent, setSelectedExternalEvent] =
+    React.useState<CalendarEvent | null>(null);
+  const [externalEventSheetOpen, setExternalEventSheetOpen] =
+    React.useState(false);
+
+  const handleExternalEventClick = React.useCallback((event: CalendarEvent) => {
+    setSelectedExternalEvent(event);
+    setExternalEventSheetOpen(true);
+  }, []);
+
+  const handleExternalEventSheetOpenChange = React.useCallback(
+    (next: boolean) => {
+      setExternalEventSheetOpen(next);
+      if (!next) {
+        // Defer the state clear so the closing animation can finish.
+        setTimeout(() => setSelectedExternalEvent(null), 200);
+      }
+    },
+    []
+  );
+
+  // "Create task from event" hands the user off to the AddTaskModal
+  // pre-filled with the event's title and date.
+  const [taskFromEventOpen, setTaskFromEventOpen] = React.useState(false);
+  const [taskFromEventSeed, setTaskFromEventSeed] = React.useState<{
+    title: string;
+    scheduledDate: string;
+  } | null>(null);
+
+  const handleCreateTaskFromEvent = React.useCallback(
+    (event: CalendarEvent) => {
+      const start = new Date(event.startTime);
+      setTaskFromEventSeed({
+        title: event.title,
+        scheduledDate: format(start, "yyyy-MM-dd"),
+      });
+      void prefetchAddTaskModal();
+      setTaskFromEventOpen(true);
+    },
+    []
+  );
+
   return (
     <div className={cn("flex h-full flex-col", className)}>
       {/* Header / Toolbar - Responsive */}
@@ -258,6 +309,7 @@ export function CalendarView({
           onTimelineMouseMove={handleTimelineMouseMove}
           onTimelineMouseUp={handleTimelineMouseUp}
           onTimelineMouseLeave={handleTimelineMouseLeave}
+          onExternalEventClick={handleExternalEventClick}
           {...(onBlockClick ? { onBlockClick } : {})}
           {...(onEditBlock ? { onEditBlock } : {})}
           {...(onViewTask ? { onViewTask } : {})}
@@ -267,6 +319,25 @@ export function CalendarView({
 
       {/* Drag Overlay */}
       <DragOverlay dragState={dragState} dropPreview={dropPreview} />
+
+      {/* External calendar event detail sheet */}
+      <CalendarEventDetailSheet
+        event={selectedExternalEvent}
+        open={externalEventSheetOpen}
+        onOpenChange={handleExternalEventSheetOpenChange}
+        onCreateTask={handleCreateTaskFromEvent}
+      />
+
+      {/* Add task modal pre-filled from a calendar event */}
+      <AddTaskModal
+        open={taskFromEventOpen}
+        onOpenChange={(next) => {
+          setTaskFromEventOpen(next);
+          if (!next) setTaskFromEventSeed(null);
+        }}
+        scheduledDate={taskFromEventSeed?.scheduledDate}
+        initialTitle={taskFromEventSeed?.title}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/calendar/external-event.tsx
+++ b/apps/web/src/components/calendar/external-event.tsx
@@ -8,7 +8,7 @@ import {
 } from "date-fns";
 import type { CalendarEvent } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
-import { ExternalLink, CalendarDays } from "lucide-react";
+import { CalendarDays } from "lucide-react";
 import {
   calculateYFromTime,
   HOUR_HEIGHT,
@@ -90,11 +90,13 @@ export function ExternalEvent({
   const isCompact = height < 48;
   const isVeryCompact = height < 28;
 
-  const handleClick = () => {
-    // Open external link in new tab if available
-    if (event.htmlLink) {
-      window.open(event.htmlLink, "_blank", "noopener,noreferrer");
-    }
+  const handleClick = (e: React.MouseEvent) => {
+    // Stop the event from bubbling up to the timeline's "click empty
+    // slot to create a time block" handler — without this, clicking an
+    // event ALSO opened the create-time-block dialog.
+    e.stopPropagation();
+    // Delegate to the parent — typically opens an in-app detail sheet
+    // rather than redirecting to the provider's web UI.
     onClick?.();
   };
 
@@ -121,10 +123,11 @@ export function ExternalEvent({
             onClick={handleClick}
             role="button"
             tabIndex={0}
-            aria-label={`External event: ${event.title} from ${format(startTime, "h:mm a")} to ${format(endTime, "h:mm a")}`}
+            aria-label={`Calendar event: ${event.title} from ${format(startTime, "h:mm a")} to ${format(endTime, "h:mm a")}`}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
-                handleClick();
+                e.stopPropagation();
+                onClick?.();
               }
             }}
           >
@@ -146,9 +149,10 @@ export function ExternalEvent({
                 )}>
                   {event.title}
                 </p>
-                {event.htmlLink && !isCompact && (
-                  <ExternalLink className="h-3 w-3 flex-shrink-0 text-muted-foreground ml-auto" />
-                )}
+                {/* `htmlLink` is intentionally not surfaced here as a
+                    "click to open" affordance — clicking the event opens
+                    the in-app detail sheet. The detail sheet has an
+                    explicit "Open in Google Calendar" action. */}
               </div>
 
               {/* Time range - muted text, hide if too compact */}
@@ -222,10 +226,8 @@ export function AllDayEvent({
   const color = getEventColor(event);
   const calendarName = event.calendar?.name || "External Calendar";
 
-  const handleClick = () => {
-    if (event.htmlLink) {
-      window.open(event.htmlLink, "_blank", "noopener,noreferrer");
-    }
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
     onClick?.();
   };
 
@@ -249,15 +251,13 @@ export function AllDayEvent({
             tabIndex={0}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
-                handleClick();
+                e.stopPropagation();
+                onClick?.();
               }
             }}
           >
             <CalendarDays className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
             <span className="truncate text-foreground/80">{event.title}</span>
-            {event.htmlLink && (
-              <ExternalLink className="h-3 w-3 flex-shrink-0 text-muted-foreground ml-auto" />
-            )}
           </div>
         </TooltipTrigger>
         <TooltipContent side="bottom">

--- a/apps/web/src/components/calendar/timeline.tsx
+++ b/apps/web/src/components/calendar/timeline.tsx
@@ -38,6 +38,8 @@ interface TimelineProps {
   onBlockDragStart?: (block: TimeBlockType, e: React.MouseEvent) => void;
   onBlockResizeStart?: (block: TimeBlockType, edge: "top" | "bottom", e: React.MouseEvent) => void;
   onViewTask?: (taskId: string) => void;
+  /** Fired when the user clicks an external (Google/Outlook/iCloud) event */
+  onExternalEventClick?: (event: CalendarEvent) => void;
   onTimelineMouseMove?: (e: React.MouseEvent) => void;
   onTimelineMouseUp?: () => void;
   onTimelineMouseLeave?: () => void;
@@ -72,6 +74,7 @@ export function Timeline({
   onBlockDragStart,
   onBlockResizeStart,
   onViewTask,
+  onExternalEventClick,
   onTimelineMouseMove,
   onTimelineMouseUp,
   onTimelineMouseLeave,
@@ -163,8 +166,16 @@ export function Timeline({
 
   // Handle click on empty time slot
   const handleTimeSlotClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    // Don't trigger if clicking on a time block
-    if ((e.target as HTMLElement).closest('[data-time-block]')) {
+    // Don't trigger if clicking on a time block, an external calendar
+    // event, or any all-day banner — those have their own click handlers
+    // and the time-slot click would otherwise also open the "create time
+    // block" dialog as a side-effect.
+    const target = e.target as HTMLElement;
+    if (
+      target.closest('[data-time-block]') ||
+      target.closest('[data-external-event]') ||
+      target.closest('[data-all-day-event]')
+    ) {
       return;
     }
 
@@ -202,7 +213,15 @@ export function Timeline({
           <p className="text-xs font-medium text-muted-foreground mb-1">All day</p>
           <div className="flex flex-wrap gap-1">
             {allDayEvents.map((event) => (
-              <AllDayEvent key={event.id} event={event} />
+              <AllDayEvent
+                key={event.id}
+                event={event}
+                onClick={
+                  onExternalEventClick
+                    ? () => onExternalEventClick(event)
+                    : undefined
+                }
+              />
             ))}
           </div>
         </div>
@@ -290,6 +309,11 @@ export function Timeline({
                   key={event.id}
                   event={event}
                   displayDate={date}
+                  onClick={
+                    onExternalEventClick
+                      ? () => onExternalEventClick(event)
+                      : undefined
+                  }
                 />
               ))}
 

--- a/apps/web/src/components/kanban/add-task-modal.lazy.tsx
+++ b/apps/web/src/components/kanban/add-task-modal.lazy.tsx
@@ -16,6 +16,7 @@ type AddTaskModalProps = {
   scheduledDate?: string | null;
   addPosition?: AddPosition;
   onAddPositionChange?: (position: AddPosition) => void;
+  initialTitle?: string;
 };
 
 type AddTaskModalModule = typeof AddTaskModalModuleNS;

--- a/apps/web/src/components/kanban/add-task-modal.tsx
+++ b/apps/web/src/components/kanban/add-task-modal.tsx
@@ -35,6 +35,11 @@ interface AddTaskModalProps {
   scheduledDate?: string | null;
   addPosition?: AddPosition;
   onAddPositionChange?: (position: AddPosition) => void;
+  /**
+   * Pre-populate the title field on open. Used by the calendar event
+   * detail sheet's "Create task from event" action.
+   */
+  initialTitle?: string;
 }
 
 export function AddTaskModal({
@@ -43,12 +48,21 @@ export function AddTaskModal({
   scheduledDate,
   addPosition = "bottom",
   onAddPositionChange,
+  initialTitle,
 }: AddTaskModalProps) {
-  const [title, setTitle] = React.useState("");
+  const [title, setTitle] = React.useState(initialTitle ?? "");
   const [description, setDescription] = React.useState("");
   const [estimatedMins, setEstimatedMins] = React.useState<string>("");
   const [priority, setPriority] = React.useState<TaskPriority>("P2");
   const [subtasks, setSubtasks] = React.useState<Subtask[]>([]);
+
+  // When opening with a pre-filled title (e.g. "Create task from event"),
+  // sync the title state every time the modal opens.
+  React.useEffect(() => {
+    if (open && initialTitle !== undefined) {
+      setTitle(initialTitle);
+    }
+  }, [open, initialTitle]);
 
   const createTask = useCreateTask();
   const createSubtask = useCreateSubtask();


### PR DESCRIPTION
## Reported bug

> When I click on a calendar event, it is currently doing two things:
> 1. It redirects me to the Google Calendar event.
> 2. It gives me a pop-up on the current web page to create a new task.
>
> This is wrong. It should be editing the existing calendar event.

## Root cause

Two bugs cooperating:

1. \`ExternalEvent\` / \`AllDayEvent\`'s click handlers called \`window.open(event.htmlLink)\` as the default action — every click bounced to the provider.
2. The click event then bubbled up to the timeline's empty-slot handler, which only stopped on \`[data-time-block]\` — it didn't know about \`[data-external-event]\` or \`[data-all-day-event]\`. So the create-time-block dialog opened as a side-effect.

The two added up to: redirect to Google + popup appears.

## Fix (Phase 1 of 3)

This PR fixes the click bug and replaces the broken behaviour with a proper in-app detail sheet. **Editing/deleting events** (writing back to Google/Outlook/iCloud) is the next phase — the sheet has a "coming soon" footer pointing at the follow-up.

- **\`external-event.tsx\`**: both event components now \`e.stopPropagation()\` on click and delegate to the parent-supplied \`onClick\` rather than opening Google directly. Keyboard handlers do the same. The "external link" icon is removed from the event chip — the link lives in the detail sheet now.
- **\`timeline.tsx\`**: \`handleTimeSlotClick\` bails on \`[data-external-event]\` and \`[data-all-day-event]\` in addition to \`[data-time-block]\`. Defence in depth on top of the stopPropagation.
- **\`calendar-event-detail-sheet.tsx\`** (new): read-only slide-over showing title, time range, location, description, source calendar (with provider color), and response status. Two explicit actions:
  - **"Create task from event"** — pre-fills AddTaskModal with the event's title and date.
  - **"Open in calendar provider"** — explicit secondary button (replaces the implicit click-to-redirect).
- **\`calendar-view.tsx\`**: wires the sheet, manages selected-event state, hands the event off to AddTaskModal when the user picks "Create task from event".
- **\`add-task-modal.tsx\` + lazy wrapper**: new \`initialTitle\` prop so external callers can pre-fill the title field on open.

## User stories addressed

- US1 ✅ Click event → in-app sheet (no redirect, no popup)
- US2 ✅ Sheet shows: title, time, location, description, calendar (with color), response status
- US3 ✅ Sheet has explicit "Open in calendar provider" button
- US4 ✅ Sheet has "Create task from event" with pre-filled title/date
- US5/US6 ⏳ Edit + delete (Phase 3)
- US7 ✅ Mobile-friendly (Sheet primitive responsive)

## Roadmap

- ✅ **Phase 1** (this PR): fix click bug + read-only event detail sheet
- ⏳ **Phase 2**: Day / 3-Day / Week / Month view modes
- ⏳ **Phase 3**: write-back edit + delete

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` 89 baseline
- [x] \`bun run build\` succeeds
- [x] Verifier PASS (7/7 traced scenarios)
- [ ] Manual: click an external event — sheet opens, no Google tab, no time-block dialog
- [ ] Manual: "Create task from event" — opens AddTaskModal with title pre-filled, scheduledDate matching event start
- [ ] Manual: "Open in calendar provider" — opens htmlLink in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)