### PR TITLE
feat(web): calendar view modes — Day, 3-Day, Week, Month

### DIFF
--- a/apps/web/src/components/calendar/calendar-view-toolbar.tsx
+++ b/apps/web/src/components/calendar/calendar-view-toolbar.tsx
@@ -1,17 +1,20 @@
-import {
-  format,
-  isToday,
-} from "date-fns";
-import {
-  ChevronLeft,
-  ChevronRight,
-  Calendar as CalendarIcon,
-} from "lucide-react";
+import { format, isToday } from "date-fns";
+import { ChevronLeft, ChevronRight, Calendar as CalendarIcon } from "lucide-react";
 import { Button } from "@/components/ui";
-import type { TimeBlock } from "@open-sunsama/types";
+import type { TimeBlock, CalendarViewMode } from "@open-sunsama/types";
+import { cn } from "@/lib/utils";
 
 interface CalendarViewToolbarProps {
   selectedDate: Date;
+  /**
+   * The full window the calendar is displaying. For "day" mode this is
+   * just the selected date; for "3-day" / "week" / "month" it's the
+   * range. Used to label the toolbar (e.g. "Aug 1 – 7" for a week).
+   */
+  rangeStart: Date;
+  rangeEnd: Date;
+  viewMode: CalendarViewMode;
+  onViewModeChange: (mode: CalendarViewMode) => void;
   timeBlocks: TimeBlock[];
   onPreviousDay: () => void;
   onNextDay: () => void;
@@ -19,25 +22,77 @@ interface CalendarViewToolbarProps {
   className?: string;
 }
 
+const VIEW_MODE_LABELS: Record<CalendarViewMode, string> = {
+  day: "Day",
+  "3-day": "3 days",
+  week: "Week",
+  month: "Month",
+};
+
+const VIEW_MODES: CalendarViewMode[] = ["day", "3-day", "week", "month"];
+
+function describeRange(
+  rangeStart: Date,
+  rangeEnd: Date,
+  viewMode: CalendarViewMode
+): { primary: string; secondary: string } {
+  if (viewMode === "day") {
+    return {
+      primary: format(rangeStart, "EEEE"),
+      secondary: format(rangeStart, "MMM d, yyyy"),
+    };
+  }
+
+  if (viewMode === "month") {
+    return {
+      primary: format(rangeStart, "MMMM"),
+      secondary: format(rangeStart, "yyyy"),
+    };
+  }
+
+  // 3-day / week — show the visible window.
+  const sameMonth = rangeStart.getMonth() === rangeEnd.getMonth();
+  const sameYear = rangeStart.getFullYear() === rangeEnd.getFullYear();
+
+  let secondary: string;
+  if (sameMonth && sameYear) {
+    secondary = `${format(rangeStart, "MMM d")} – ${format(rangeEnd, "d, yyyy")}`;
+  } else if (sameYear) {
+    secondary = `${format(rangeStart, "MMM d")} – ${format(rangeEnd, "MMM d, yyyy")}`;
+  } else {
+    secondary = `${format(rangeStart, "MMM d, yyyy")} – ${format(rangeEnd, "MMM d, yyyy")}`;
+  }
+
+  return {
+    primary: viewMode === "week" ? "This week" : "3 days",
+    secondary,
+  };
+}
+
 export function CalendarViewToolbar({
   selectedDate,
+  rangeStart,
+  rangeEnd,
+  viewMode,
+  onViewModeChange,
   timeBlocks,
   onPreviousDay,
   onNextDay,
   onToday,
 }: CalendarViewToolbarProps) {
   const isTodaySelected = isToday(selectedDate);
+  const { primary, secondary } = describeRange(rangeStart, rangeEnd, viewMode);
 
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between border-b px-3 sm:px-4 py-2 sm:py-3 bg-background gap-2 sm:gap-4">
       <div className="flex items-center justify-between sm:justify-start gap-2 sm:gap-4">
-        {/* Date Navigation - Touch-friendly on mobile */}
+        {/* Date Navigation */}
         <div className="flex items-center gap-1">
           <Button
             variant="outline"
             size="icon"
             onClick={onPreviousDay}
-            aria-label="Previous day"
+            aria-label="Previous range"
             className="h-10 w-10 sm:h-9 sm:w-9"
           >
             <ChevronLeft className="h-5 w-5 sm:h-4 sm:w-4" />
@@ -53,36 +108,55 @@ export function CalendarViewToolbar({
             variant="outline"
             size="icon"
             onClick={onNextDay}
-            aria-label="Next day"
+            aria-label="Next range"
             className="h-10 w-10 sm:h-9 sm:w-9"
           >
             <ChevronRight className="h-5 w-5 sm:h-4 sm:w-4" />
           </Button>
         </div>
 
-        {/* Selected Date Display - Compact on mobile */}
+        {/* Selected Range Display */}
         <div className="flex items-center gap-2">
           <CalendarIcon className="h-5 w-5 text-muted-foreground hidden sm:block" />
           <div>
             <h2 className="text-base sm:text-lg font-semibold leading-none">
-              {format(selectedDate, "EEE")}<span className="hidden sm:inline">{format(selectedDate, "EEEE").replace(/^.../, "")}</span>
+              {primary}
             </h2>
             <p className="text-xs sm:text-sm text-muted-foreground">
-              {format(selectedDate, "MMM d")}<span className="hidden sm:inline">{format(selectedDate, ", yyyy")}</span>
+              {secondary}
             </p>
           </div>
         </div>
       </div>
 
-      {/* Date indicator badges - hidden on very small screens */}
-      <div className="hidden sm:flex items-center gap-2 justify-end sm:justify-start">
-        {isTodaySelected && (
-          <span className="inline-flex items-center rounded-full bg-primary/10 px-2 sm:px-2.5 py-0.5 text-xs font-medium text-primary">
-            Today
-          </span>
-        )}
-        {timeBlocks.length > 0 && (
-          <span className="inline-flex items-center rounded-full bg-muted px-2 sm:px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+      <div className="flex items-center gap-2 justify-between sm:justify-end">
+        {/* View mode selector — segmented control */}
+        <div
+          className="inline-flex items-center rounded-md border border-border/50 bg-muted/30 p-0.5"
+          role="tablist"
+          aria-label="Calendar view"
+        >
+          {VIEW_MODES.map((mode) => (
+            <button
+              key={mode}
+              role="tab"
+              aria-selected={viewMode === mode}
+              onClick={() => onViewModeChange(mode)}
+              className={cn(
+                "px-2.5 sm:px-3 h-7 sm:h-8 rounded text-xs sm:text-[13px] font-medium transition-colors",
+                viewMode === mode
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {VIEW_MODE_LABELS[mode]}
+            </button>
+          ))}
+        </div>
+
+        {/* Block count badge — only on day view (per-day signal) */}
+        {viewMode === "day" && timeBlocks.length > 0 && (
+          <span className="hidden sm:inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
             {timeBlocks.length} block{timeBlocks.length !== 1 ? "s" : ""}
           </span>
         )}

--- a/apps/web/src/components/calendar/calendar-view-toolbar.tsx
+++ b/apps/web/src/components/calendar/calendar-view-toolbar.tsx
@@ -1,10 +1,16 @@
-import { format, isToday } from "date-fns";
+import { format, isWithinInterval, startOfDay, endOfDay } from "date-fns";
 import { ChevronLeft, ChevronRight, Calendar as CalendarIcon } from "lucide-react";
 import { Button } from "@/components/ui";
 import type { TimeBlock, CalendarViewMode } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 
 interface CalendarViewToolbarProps {
+  /**
+   * The user's anchor date — also what `Today` resets to. The button only
+   * highlights when today is within the visible range, not just when
+   * `selectedDate === today` (which would feel wrong on the week / month
+   * view where the user expects "Today" to mean "today is on screen").
+   */
   selectedDate: Date;
   /**
    * The full window the calendar is displaying. For "day" mode this is
@@ -70,7 +76,7 @@ function describeRange(
 }
 
 export function CalendarViewToolbar({
-  selectedDate,
+  selectedDate: _selectedDate,
   rangeStart,
   rangeEnd,
   viewMode,
@@ -80,7 +86,15 @@ export function CalendarViewToolbar({
   onNextDay,
   onToday,
 }: CalendarViewToolbarProps) {
-  const isTodaySelected = isToday(selectedDate);
+  // "Today" is highlighted when today's date falls anywhere in the visible
+  // range — for day view that collapses back to "selectedDate is today",
+  // but for week / month it correctly stays lit while the user navigates
+  // around the current week / month.
+  const today = new Date();
+  const todayInRange = isWithinInterval(today, {
+    start: startOfDay(rangeStart),
+    end: endOfDay(rangeEnd),
+  });
   const { primary, secondary } = describeRange(rangeStart, rangeEnd, viewMode);
 
   return (
@@ -98,7 +112,7 @@ export function CalendarViewToolbar({
             <ChevronLeft className="h-5 w-5 sm:h-4 sm:w-4" />
           </Button>
           <Button
-            variant={isTodaySelected ? "default" : "outline"}
+            variant={todayInRange ? "default" : "outline"}
             onClick={onToday}
             className="min-w-[60px] sm:min-w-[70px] h-10 sm:h-9 text-sm"
           >

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -5,19 +5,36 @@ import {
   subDays,
   startOfDay,
   endOfDay,
+  startOfWeek,
+  endOfWeek,
+  startOfMonth,
+  endOfMonth,
+  addWeeks,
+  subWeeks,
+  addMonths,
+  subMonths,
 } from "date-fns";
-import type { Task, TimeBlock, CalendarEvent } from "@open-sunsama/types";
+import type {
+  Task,
+  TimeBlock,
+  CalendarEvent,
+  CalendarViewMode,
+} from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import {
   useTasks,
   useTimeBlocksForDate,
+  useTimeBlocksForDateRange,
   useCreateTimeBlock,
   useMoveTimeBlock,
   useCascadeResizeTimeBlock,
 } from "@/hooks";
+import { useAuth } from "@/hooks/useAuth";
 import { useCalendarEvents } from "@/hooks/useCalendars";
 import { useCalendarDnd } from "@/hooks/useCalendarDnd";
 import { Timeline } from "./timeline";
+import { MultiDayView } from "./multi-day-view";
+import { MonthView } from "./month-view";
 import { UnscheduledTasksPanel } from "./unscheduled-tasks";
 import { DragOverlay } from "./drag-overlay";
 import { CalendarViewToolbar } from "./calendar-view-toolbar";
@@ -26,6 +43,78 @@ import {
   AddTaskModal,
   prefetchAddTaskModal,
 } from "@/components/kanban/add-task-modal.lazy";
+
+/**
+ * Persist the calendar view mode in localStorage so the user's choice
+ * survives across reloads even before the server-side preference write
+ * lands. We also seed from `user.preferences.calendarViewMode` if it's
+ * set so the choice can flow across devices via the canonical
+ * preferences sync path.
+ */
+const VIEW_MODE_STORAGE_KEY = "open_sunsama_calendar_view_mode";
+
+function getStoredViewMode(): CalendarViewMode | null {
+  if (typeof window === "undefined") return null;
+  const v = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+  if (v === "day" || v === "3-day" || v === "week" || v === "month") return v;
+  return null;
+}
+
+function storeViewMode(mode: CalendarViewMode): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
+  } catch {
+    // ignore quota errors
+  }
+}
+
+interface VisibleRange {
+  start: Date;
+  end: Date;
+  /** Days the columns iterate over (day=1, 3-day=3, week=7, month=N) */
+  days: Date[];
+}
+
+function computeRange(
+  selectedDate: Date,
+  viewMode: CalendarViewMode,
+  weekStartsOn: 0 | 1
+): VisibleRange {
+  switch (viewMode) {
+    case "day": {
+      const start = startOfDay(selectedDate);
+      const end = endOfDay(selectedDate);
+      return { start, end, days: [start] };
+    }
+    case "3-day": {
+      const start = startOfDay(selectedDate);
+      const end = endOfDay(addDays(start, 2));
+      return {
+        start,
+        end,
+        days: [0, 1, 2].map((i) => addDays(start, i)),
+      };
+    }
+    case "week": {
+      const start = startOfWeek(selectedDate, { weekStartsOn });
+      const end = endOfWeek(selectedDate, { weekStartsOn });
+      return {
+        start,
+        end,
+        days: Array.from({ length: 7 }, (_, i) => addDays(start, i)),
+      };
+    }
+    case "month": {
+      // Server fetch should cover from the first visible cell (the prior
+      // month's tail in the first row) to the last visible cell (the
+      // next month's head in the last row).
+      const start = startOfWeek(startOfMonth(selectedDate), { weekStartsOn });
+      const end = endOfWeek(endOfMonth(selectedDate), { weekStartsOn });
+      return { start, end, days: [] /* not used by month grid */ };
+    }
+  }
+}
 
 interface CalendarViewProps {
   initialDate?: Date;
@@ -49,33 +138,75 @@ export function CalendarView({
   onTimeSlotClick,
   className,
 }: CalendarViewProps) {
-  // Selected date state
+  const { user } = useAuth();
+  const weekStartsOn = (user?.preferences?.weekStartsOn ?? 0) as 0 | 1;
+
+  // Selected date state — anchors the visible range
   const [selectedDate, setSelectedDate] = React.useState<Date>(() =>
     startOfDay(initialDate)
+  );
+
+  // View mode: prefer server-synced preference; fall back to localStorage,
+  // then to "day".
+  const [viewMode, setViewModeRaw] = React.useState<CalendarViewMode>(() => {
+    return (
+      user?.preferences?.calendarViewMode ?? getStoredViewMode() ?? "day"
+    );
+  });
+  // If the user preference loads in later (e.g. on first /auth/me arrival),
+  // sync into local state. This intentionally won't override user-driven
+  // changes that happened after mount because we only run when the
+  // server-canonical value arrives.
+  React.useEffect(() => {
+    const remote = user?.preferences?.calendarViewMode;
+    if (remote && remote !== viewMode && getStoredViewMode() === null) {
+      setViewModeRaw(remote);
+    }
+    // Intentionally omit `viewMode` from deps — we only want to react to
+    // the canonical server value arriving, not to user-driven local
+    // changes.
+  }, [user?.preferences?.calendarViewMode, viewMode]);
+
+  const setViewMode = React.useCallback((mode: CalendarViewMode) => {
+    setViewModeRaw(mode);
+    storeViewMode(mode);
+    // TODO: also write the preference back to the server via
+    // `useUpdateUser` once we want it to sync across devices. For now
+    // localStorage is enough for the in-session experience.
+  }, []);
+
+  // The window of days currently visible.
+  const range = React.useMemo(
+    () => computeRange(selectedDate, viewMode, weekStartsOn),
+    [selectedDate, viewMode, weekStartsOn]
   );
 
   // Format date for API calls
   const dateString = format(selectedDate, "yyyy-MM-dd");
 
-  // Fetch tasks for selected date (unscheduled = scheduled for this day but no time block)
+  // Fetch tasks for selected date (only used for unscheduled-tasks panel
+  // in day view). For multi-day / month we don't show that panel.
   const { data: allTasks = [], isLoading: isLoadingTasks } = useTasks({
     scheduledDate: dateString,
     limit: 200,
   });
 
-  // Fetch time blocks for selected date
-  const { data: timeBlocks = [], isLoading: isLoadingBlocks } =
+  // Fetch time blocks for the visible range. Day view stays on the
+  // single-day endpoint to avoid changing its cache key shape; multi-day
+  // and month use the range endpoint.
+  const { data: dayTimeBlocks = [], isLoading: isLoadingDayBlocks } =
     useTimeBlocksForDate(dateString);
+  const { data: rangeTimeBlocks = [], isLoading: isLoadingRangeBlocks } =
+    useTimeBlocksForDateRange(range.start, range.end);
+  const timeBlocks = viewMode === "day" ? dayTimeBlocks : rangeTimeBlocks;
+  const isLoadingBlocks =
+    viewMode === "day" ? isLoadingDayBlocks : isLoadingRangeBlocks;
 
-  // Fetch external calendar events for the selected day. We use the user's
-  // LOCAL day boundaries converted to UTC ISO strings — `format(...,
-  // "yyyy-MM-dd'T'HH:mm:ss")` was emitting a timezone-less string that the
-  // server then mis-interpreted as UTC, shifting the query window by the
-  // user's UTC offset and causing events near the day boundary to be
-  // dropped or wrongly attributed. `.toISOString()` yields the same local
-  // instant in UTC, which the server parses correctly.
-  const fromDate = startOfDay(selectedDate).toISOString();
-  const toDate = endOfDay(selectedDate).toISOString();
+  // Fetch external calendar events for the visible range. `.toISOString()`
+  // encodes the user's local-day boundary as a real UTC instant so the
+  // server parses it back to the same instant.
+  const fromDate = range.start.toISOString();
+  const toDate = range.end.toISOString();
   const { data: calendarEvents = [] } = useCalendarEvents(fromDate, toDate);
 
   // Mutations
@@ -131,9 +262,24 @@ export function CalendarView({
     },
   });
 
-  // Navigation handlers
-  const goToPreviousDay = () => setSelectedDate((d) => subDays(d, 1));
-  const goToNextDay = () => setSelectedDate((d) => addDays(d, 1));
+  // Navigation handlers — step size depends on view mode.
+  // Day → ±1 day; 3-Day → ±3 days; Week → ±1 week; Month → ±1 month.
+  const goToPreviousDay = React.useCallback(() => {
+    setSelectedDate((d) => {
+      if (viewMode === "day") return subDays(d, 1);
+      if (viewMode === "3-day") return subDays(d, 3);
+      if (viewMode === "week") return subWeeks(d, 1);
+      return subMonths(d, 1); // "month"
+    });
+  }, [viewMode]);
+  const goToNextDay = React.useCallback(() => {
+    setSelectedDate((d) => {
+      if (viewMode === "day") return addDays(d, 1);
+      if (viewMode === "3-day") return addDays(d, 3);
+      if (viewMode === "week") return addWeeks(d, 1);
+      return addMonths(d, 1); // "month"
+    });
+  }, [viewMode]);
   const goToToday = () => setSelectedDate(startOfDay(new Date()));
 
   // Mouse handlers for drag
@@ -272,55 +418,101 @@ export function CalendarView({
     []
   );
 
+  // When the user clicks a day cell in month view, switch to day view
+  // anchored on that date — common UX pattern (Google / Outlook).
+  const handleDayCellClick = React.useCallback((date: Date) => {
+    setSelectedDate(startOfDay(date));
+    setViewMode("day");
+  }, [setViewMode]);
+
   return (
     <div className={cn("flex h-full flex-col", className)}>
-      {/* Header / Toolbar - Responsive */}
+      {/* Header / Toolbar */}
       <CalendarViewToolbar
         selectedDate={selectedDate}
+        rangeStart={range.start}
+        rangeEnd={range.end}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
         timeBlocks={timeBlocks}
         onPreviousDay={goToPreviousDay}
         onNextDay={goToNextDay}
         onToday={goToToday}
       />
 
-      {/* Main Content - Two Panel Layout */}
+      {/* Main Content */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Left Panel - Unscheduled Tasks */}
-        <UnscheduledTasksPanel
-          tasks={unscheduledTasks}
-          isLoading={isLoading}
-          scheduledDate={dateString}
-          onTaskDragStart={handleTaskDragStart}
-          {...(onTaskClick ? { onTaskClick } : {})}
-        />
+        {/* Day view keeps the unscheduled-tasks side panel + DnD-aware
+            Timeline. Multi-day and month views drop the panel — they're
+            read-mostly so the extra real estate goes to the calendar. */}
+        {viewMode === "day" && (
+          <>
+            <UnscheduledTasksPanel
+              tasks={unscheduledTasks}
+              isLoading={isLoading}
+              scheduledDate={dateString}
+              onTaskDragStart={handleTaskDragStart}
+              {...(onTaskClick ? { onTaskClick } : {})}
+            />
+            <Timeline
+              date={selectedDate}
+              timeBlocks={timeBlocks}
+              calendarEvents={calendarEvents}
+              isLoading={isLoading}
+              dragState={dragState}
+              dropPreview={dropPreview}
+              justEndedDrag={justEndedDrag}
+              timelineRef={timelineRef}
+              onBlockDragStart={handleBlockDragStart}
+              onBlockResizeStart={handleBlockResizeStart}
+              onTimelineMouseMove={handleTimelineMouseMove}
+              onTimelineMouseUp={handleTimelineMouseUp}
+              onTimelineMouseLeave={handleTimelineMouseLeave}
+              onExternalEventClick={handleExternalEventClick}
+              {...(onBlockClick ? { onBlockClick } : {})}
+              {...(onEditBlock ? { onEditBlock } : {})}
+              {...(onViewTask ? { onViewTask } : {})}
+              {...(onTimeSlotClick
+                ? {
+                    onTimeSlotClick: (startTime: Date, endTime: Date) =>
+                      onTimeSlotClick(selectedDate, startTime, endTime),
+                  }
+                : {})}
+            />
+          </>
+        )}
 
-        {/* Right Panel - Timeline */}
-        <Timeline
-          date={selectedDate}
-          timeBlocks={timeBlocks}
-          calendarEvents={calendarEvents}
-          isLoading={isLoading}
-          dragState={dragState}
-          dropPreview={dropPreview}
-          justEndedDrag={justEndedDrag}
-          timelineRef={timelineRef}
-          onBlockDragStart={handleBlockDragStart}
-          onBlockResizeStart={handleBlockResizeStart}
-          onTimelineMouseMove={handleTimelineMouseMove}
-          onTimelineMouseUp={handleTimelineMouseUp}
-          onTimelineMouseLeave={handleTimelineMouseLeave}
-          onExternalEventClick={handleExternalEventClick}
-          {...(onBlockClick ? { onBlockClick } : {})}
-          {...(onEditBlock ? { onEditBlock } : {})}
-          {...(onViewTask ? { onViewTask } : {})}
-          {...(onTimeSlotClick ? { onTimeSlotClick: (startTime: Date, endTime: Date) => onTimeSlotClick(selectedDate, startTime, endTime) } : {})}
-        />
+        {(viewMode === "3-day" || viewMode === "week") && (
+          <MultiDayView
+            days={range.days}
+            calendarEvents={calendarEvents}
+            timeBlocks={timeBlocks}
+            isLoading={isLoading}
+            onExternalEventClick={handleExternalEventClick}
+            {...(onBlockClick ? { onBlockClick } : {})}
+          />
+        )}
+
+        {viewMode === "month" && (
+          <MonthView
+            month={selectedDate}
+            weekStartsOn={weekStartsOn}
+            calendarEvents={calendarEvents}
+            timeBlocks={timeBlocks}
+            isLoading={isLoading}
+            onDayClick={handleDayCellClick}
+            onExternalEventClick={handleExternalEventClick}
+            {...(onBlockClick ? { onBlockClick } : {})}
+          />
+        )}
       </div>
 
-      {/* Drag Overlay */}
-      <DragOverlay dragState={dragState} dropPreview={dropPreview} />
+      {/* Drag Overlay (only meaningful in day view) */}
+      {viewMode === "day" && (
+        <DragOverlay dragState={dragState} dropPreview={dropPreview} />
+      )}
 
-      {/* External calendar event detail sheet */}
+      {/* External calendar event detail sheet (shared across views) */}
       <CalendarEventDetailSheet
         event={selectedExternalEvent}
         open={externalEventSheetOpen}

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -153,19 +153,27 @@ export function CalendarView({
       user?.preferences?.calendarViewMode ?? getStoredViewMode() ?? "day"
     );
   });
-  // If the user preference loads in later (e.g. on first /auth/me arrival),
-  // sync into local state. This intentionally won't override user-driven
-  // changes that happened after mount because we only run when the
-  // server-canonical value arrives.
+  // If the server preference loads *after* mount (typical: /auth/me
+  // resolves shortly after the first paint), seed it into local state
+  // exactly once. We use a ref to ensure subsequent local changes are
+  // never overwritten by a stale server value re-arriving — the user's
+  // intent always wins after they've interacted. The current viewMode
+  // is read via a ref so this effect's dep array can stay focused on
+  // the canonical server value.
+  const didSeedFromServerRef = React.useRef(false);
+  const viewModeRef = React.useRef(viewMode);
+  viewModeRef.current = viewMode;
   React.useEffect(() => {
+    if (didSeedFromServerRef.current) return;
     const remote = user?.preferences?.calendarViewMode;
-    if (remote && remote !== viewMode && getStoredViewMode() === null) {
+    if (!remote) return;
+    didSeedFromServerRef.current = true;
+    // Only override if the user hasn't already overridden via local
+    // storage on this device (otherwise their per-device choice stands).
+    if (getStoredViewMode() === null && remote !== viewModeRef.current) {
       setViewModeRaw(remote);
     }
-    // Intentionally omit `viewMode` from deps — we only want to react to
-    // the canonical server value arriving, not to user-driven local
-    // changes.
-  }, [user?.preferences?.calendarViewMode, viewMode]);
+  }, [user?.preferences?.calendarViewMode]);
 
   const setViewMode = React.useCallback((mode: CalendarViewMode) => {
     setViewModeRaw(mode);

--- a/apps/web/src/components/calendar/month-view.tsx
+++ b/apps/web/src/components/calendar/month-view.tsx
@@ -180,8 +180,26 @@ export function MonthView({
               // warning). Use role="button" + keyboard handlers instead.
               <div
                 key={day.toISOString()}
-                onClick={() => onDayClick?.(day)}
+                onClick={(e) => {
+                  // Don't open the day if the click originated inside
+                  // an entry button — that has its own handler. Mouse
+                  // clicks on entry buttons already stopPropagation so
+                  // this is mostly defensive, but it also covers any
+                  // future interactive child.
+                  if (
+                    (e.target as HTMLElement).closest(
+                      "button,a,[role='button']"
+                    ) !== e.currentTarget
+                  ) {
+                    return;
+                  }
+                  onDayClick?.(day);
+                }}
                 onKeyDown={(e) => {
+                  // Keyboard activation (Enter / Space) on an entry
+                  // button bubbles up — only respond when focus is on
+                  // the cell itself, not an interactive descendant.
+                  if (e.target !== e.currentTarget) return;
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
                     onDayClick?.(day);

--- a/apps/web/src/components/calendar/month-view.tsx
+++ b/apps/web/src/components/calendar/month-view.tsx
@@ -1,0 +1,241 @@
+import * as React from "react";
+import {
+  format,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  eachDayOfInterval,
+  isSameMonth,
+  isToday,
+  isSameDay,
+  isWeekend,
+  startOfDay,
+  endOfDay,
+} from "date-fns";
+import type { CalendarEvent, TimeBlock } from "@open-sunsama/types";
+import { cn } from "@/lib/utils";
+
+interface MonthViewProps {
+  /** The "current" month — anchors which days the grid renders */
+  month: Date;
+  weekStartsOn: 0 | 1;
+  calendarEvents: CalendarEvent[];
+  timeBlocks: TimeBlock[];
+  isLoading?: boolean;
+  onDayClick?: (date: Date) => void;
+  onExternalEventClick?: (event: CalendarEvent) => void;
+  onBlockClick?: (block: TimeBlock) => void;
+}
+
+const WEEKDAY_LABELS_SUN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const WEEKDAY_LABELS_MON = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+interface DayCellEntries {
+  events: CalendarEvent[];
+  blocks: TimeBlock[];
+}
+
+function bucketEntriesForDay(
+  date: Date,
+  events: CalendarEvent[],
+  blocks: TimeBlock[]
+): DayCellEntries {
+  const dayStart = startOfDay(date);
+  const dayEnd = endOfDay(date);
+  const targetCalendarDate = format(date, "yyyy-MM-dd");
+
+  const dayEvents: CalendarEvent[] = [];
+  for (const event of events) {
+    const start = new Date(event.startTime);
+    const end = new Date(event.endTime);
+    if (event.isAllDay) {
+      const startDateStr = start.toISOString().slice(0, 10);
+      const endDateStr = end.toISOString().slice(0, 10);
+      if (
+        targetCalendarDate >= startDateStr &&
+        targetCalendarDate < endDateStr
+      ) {
+        dayEvents.push(event);
+      }
+    } else if (start < dayEnd && end > dayStart) {
+      dayEvents.push(event);
+    }
+  }
+
+  const dayBlocks = blocks.filter((b) =>
+    isSameDay(new Date(b.startTime), date)
+  );
+
+  return { events: dayEvents, blocks: dayBlocks };
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const cleanHex = hex.replace("#", "");
+  const r = parseInt(cleanHex.substring(0, 2), 16);
+  const g = parseInt(cleanHex.substring(2, 4), 16);
+  const b = parseInt(cleanHex.substring(4, 6), 16);
+  if (Number.isNaN(r)) return `rgba(107, 114, 128, ${alpha})`;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+const MAX_VISIBLE_PER_DAY = 3;
+
+/**
+ * Full-month grid (6 rows × 7 cols, padded so the first row starts on
+ * the user's `weekStartsOn` weekday). Each cell shows up to 3 entries
+ * (events + time blocks), with a "+N more" affordance that opens the
+ * day in detail.
+ */
+export function MonthView({
+  month,
+  weekStartsOn,
+  calendarEvents,
+  timeBlocks,
+  isLoading = false,
+  onDayClick,
+  onExternalEventClick,
+  onBlockClick,
+}: MonthViewProps) {
+  const days = React.useMemo(() => {
+    const firstOfMonth = startOfMonth(month);
+    const lastOfMonth = endOfMonth(month);
+    return eachDayOfInterval({
+      start: startOfWeek(firstOfMonth, { weekStartsOn }),
+      end: endOfWeek(lastOfMonth, { weekStartsOn }),
+    });
+  }, [month, weekStartsOn]);
+
+  const weekdayLabels = weekStartsOn === 1 ? WEEKDAY_LABELS_MON : WEEKDAY_LABELS_SUN;
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 border-b bg-background flex-shrink-0">
+        {weekdayLabels.map((label) => (
+          <div
+            key={label}
+            className="px-2 py-1.5 text-center text-[11px] uppercase tracking-wide text-muted-foreground border-r last:border-r-0"
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-sm text-muted-foreground animate-pulse">
+            Loading…
+          </p>
+        </div>
+      )}
+
+      {/* Day grid — 6 rows × 7 cols */}
+      {!isLoading && (
+        <div
+          className="grid grid-cols-7 flex-1 overflow-auto auto-rows-fr"
+          style={{ gridAutoRows: "minmax(80px, 1fr)" }}
+        >
+          {days.map((day) => {
+            const inCurrentMonth = isSameMonth(day, month);
+            const today = isToday(day);
+            const weekend = isWeekend(day);
+            const { events, blocks } = bucketEntriesForDay(
+              day,
+              calendarEvents,
+              timeBlocks
+            );
+            const totalEntries = events.length + blocks.length;
+            const visible = [
+              ...blocks.slice(0, MAX_VISIBLE_PER_DAY).map((b) => ({
+                kind: "block" as const,
+                id: b.id,
+                title: b.title,
+                color: b.color ?? "#3B82F6",
+                onClick: onBlockClick ? () => onBlockClick(b) : undefined,
+              })),
+              ...events
+                .slice(0, Math.max(0, MAX_VISIBLE_PER_DAY - blocks.length))
+                .map((e) => ({
+                  kind: "event" as const,
+                  id: e.id,
+                  title: e.title,
+                  color: e.calendar?.color ?? "#6B7280",
+                  onClick: onExternalEventClick
+                    ? () => onExternalEventClick(e)
+                    : undefined,
+                })),
+            ];
+            const hidden = Math.max(0, totalEntries - visible.length);
+
+            return (
+              <button
+                key={day.toISOString()}
+                onClick={() => onDayClick?.(day)}
+                type="button"
+                className={cn(
+                  "border-r border-b last:border-r-0 flex flex-col items-stretch text-left p-1.5 hover:bg-accent/30 transition-colors",
+                  !inCurrentMonth && "bg-muted/20",
+                  weekend && inCurrentMonth && "bg-muted/10"
+                )}
+                aria-label={`${format(day, "MMMM d, yyyy")}${
+                  totalEntries > 0
+                    ? `, ${totalEntries} event${totalEntries === 1 ? "" : "s"}`
+                    : ""
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span
+                    className={cn(
+                      "inline-flex items-center justify-center text-xs sm:text-[13px] font-medium",
+                      today &&
+                        "bg-primary text-primary-foreground rounded-full h-6 w-6",
+                      !today && !inCurrentMonth && "text-muted-foreground/50",
+                      !today && inCurrentMonth && "text-foreground"
+                    )}
+                  >
+                    {format(day, "d")}
+                  </span>
+                </div>
+
+                <div className="mt-1 space-y-0.5 overflow-hidden">
+                  {visible.map((item) => (
+                    <button
+                      key={`${item.kind}-${item.id}`}
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        item.onClick?.();
+                      }}
+                      className="block w-full text-left rounded px-1 py-0.5 text-[10px] sm:text-[11px] truncate cursor-pointer hover:brightness-90"
+                      style={
+                        item.kind === "event"
+                          ? {
+                              backgroundColor: hexToRgba(item.color, 0.15),
+                              borderLeft: `2px solid ${hexToRgba(item.color, 0.6)}`,
+                            }
+                          : {
+                              backgroundColor: hexToRgba(item.color, 0.85),
+                              color: "white",
+                            }
+                      }
+                      title={item.title}
+                    >
+                      {item.title}
+                    </button>
+                  ))}
+                  {hidden > 0 && (
+                    <div className="text-[10px] text-muted-foreground/80 pl-1">
+                      +{hidden} more
+                    </div>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/calendar/month-view.tsx
+++ b/apps/web/src/components/calendar/month-view.tsx
@@ -43,15 +43,19 @@ function bucketEntriesForDay(
 ): DayCellEntries {
   const dayStart = startOfDay(date);
   const dayEnd = endOfDay(date);
-  const targetCalendarDate = format(date, "yyyy-MM-dd");
+  // All-day events are stored at UTC midnight per the iCal convention.
+  // Compare YYYY-MM-DD strings derived using the same calendar-date
+  // semantics on both sides: local components for the cell, UTC
+  // components for the event start/end.
+  const targetCalendarDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 
   const dayEvents: CalendarEvent[] = [];
   for (const event of events) {
     const start = new Date(event.startTime);
     const end = new Date(event.endTime);
     if (event.isAllDay) {
-      const startDateStr = start.toISOString().slice(0, 10);
-      const endDateStr = end.toISOString().slice(0, 10);
+      const startDateStr = `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, "0")}-${String(start.getUTCDate()).padStart(2, "0")}`;
+      const endDateStr = `${end.getUTCFullYear()}-${String(end.getUTCMonth() + 1).padStart(2, "0")}-${String(end.getUTCDate()).padStart(2, "0")}`;
       if (
         targetCalendarDate >= startDateStr &&
         targetCalendarDate < endDateStr
@@ -170,12 +174,23 @@ export function MonthView({
             const hidden = Math.max(0, totalEntries - visible.length);
 
             return (
-              <button
+              // NOTE: must NOT be a <button> — it contains nested entry
+              // <button>s (and putting an interactive element inside a
+              // button is invalid HTML and triggers a React hydration
+              // warning). Use role="button" + keyboard handlers instead.
+              <div
                 key={day.toISOString()}
                 onClick={() => onDayClick?.(day)}
-                type="button"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onDayClick?.(day);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
                 className={cn(
-                  "border-r border-b last:border-r-0 flex flex-col items-stretch text-left p-1.5 hover:bg-accent/30 transition-colors",
+                  "border-r border-b last:border-r-0 flex flex-col items-stretch text-left p-1.5 hover:bg-accent/30 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring focus:ring-inset",
                   !inCurrentMonth && "bg-muted/20",
                   weekend && inCurrentMonth && "bg-muted/10"
                 )}
@@ -231,7 +246,7 @@ export function MonthView({
                     </div>
                   )}
                 </div>
-              </button>
+              </div>
             );
           })}
         </div>

--- a/apps/web/src/components/calendar/multi-day-view.tsx
+++ b/apps/web/src/components/calendar/multi-day-view.tsx
@@ -1,0 +1,433 @@
+import * as React from "react";
+import {
+  format,
+  startOfDay,
+  endOfDay,
+  isSameDay,
+  isToday,
+  isWeekend,
+  differenceInMinutes,
+} from "date-fns";
+import type { CalendarEvent, TimeBlock } from "@open-sunsama/types";
+import { cn } from "@/lib/utils";
+import { ScrollArea } from "@/components/ui";
+import {
+  HOUR_HEIGHT,
+  TIMELINE_START_HOUR,
+  TIMELINE_END_HOUR,
+  calculateYFromTime,
+} from "@/hooks/useCalendarDnd";
+
+interface MultiDayViewProps {
+  /** Ordered list of dates to render as columns */
+  days: Date[];
+  /**
+   * All events visible across the range. The component splits them per
+   * day internally — callers should pass the unfiltered list returned
+   * from `useCalendarEvents`.
+   */
+  calendarEvents: CalendarEvent[];
+  /** Time blocks across the range (may include blocks for any day) */
+  timeBlocks: TimeBlock[];
+  isLoading?: boolean;
+  onExternalEventClick?: (event: CalendarEvent) => void;
+  onBlockClick?: (block: TimeBlock) => void;
+  className?: string;
+}
+
+function generateHours(): number[] {
+  return Array.from(
+    { length: TIMELINE_END_HOUR - TIMELINE_START_HOUR + 1 },
+    (_, i) => i + TIMELINE_START_HOUR
+  );
+}
+
+interface DayColumnEvents {
+  timed: CalendarEvent[];
+  allDay: CalendarEvent[];
+  blocks: TimeBlock[];
+}
+
+function bucketEventsForDay(
+  date: Date,
+  events: CalendarEvent[],
+  blocks: TimeBlock[]
+): DayColumnEvents {
+  const dayStart = startOfDay(date);
+  const dayEnd = endOfDay(date);
+  const targetCalendarDate = format(date, "yyyy-MM-dd");
+
+  const timed: CalendarEvent[] = [];
+  const allDay: CalendarEvent[] = [];
+
+  for (const event of events) {
+    const start = new Date(event.startTime);
+    const end = new Date(event.endTime);
+
+    if (event.isAllDay) {
+      const startDateStr = start.toISOString().slice(0, 10);
+      const endDateStr = end.toISOString().slice(0, 10);
+      if (
+        targetCalendarDate >= startDateStr &&
+        targetCalendarDate < endDateStr
+      ) {
+        allDay.push(event);
+      }
+    } else if (start < dayEnd && end > dayStart) {
+      timed.push(event);
+    }
+  }
+
+  const dayBlocks = blocks.filter((b) =>
+    isSameDay(new Date(b.startTime), date)
+  );
+
+  return { timed, allDay, blocks: dayBlocks };
+}
+
+/**
+ * Compact event chip used inside multi-day columns. We don't reuse the
+ * single-day `ExternalEvent` because that's tuned for the much wider
+ * day-view column — at week-view widths the time row and tooltip
+ * affordances would overflow.
+ */
+function MultiDayEvent({
+  event,
+  displayDate,
+  onClick,
+}: {
+  event: CalendarEvent;
+  displayDate: Date;
+  onClick?: () => void;
+}) {
+  const startTime = new Date(event.startTime);
+  const endTime = new Date(event.endTime);
+  const dayStart = startOfDay(displayDate);
+  const dayEnd = endOfDay(displayDate);
+  const renderStart = startTime < dayStart ? dayStart : startTime;
+  const renderEnd = endTime > dayEnd ? dayEnd : endTime;
+  const top = calculateYFromTime(renderStart);
+  const durationMins = differenceInMinutes(renderEnd, renderStart);
+  const height = (durationMins / 60) * HOUR_HEIGHT;
+  const color = event.calendar?.color ?? "#6B7280";
+
+  return (
+    <div
+      data-external-event
+      className="absolute left-0.5 right-0.5 z-5 my-0.5 rounded border-l-[2px] cursor-pointer hover:brightness-90 transition-all overflow-hidden px-1 py-0.5"
+      style={{
+        top: `${top}px`,
+        height: `${Math.max(height - 2, 16)}px`,
+        backgroundColor: hexToRgba(color, 0.12),
+        borderColor: hexToRgba(color, 0.55),
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick?.();
+      }}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.stopPropagation();
+          onClick?.();
+        }
+      }}
+      aria-label={`${event.title} at ${format(startTime, "h:mm a")}`}
+    >
+      <p className="truncate text-[10px] font-medium text-foreground/85">
+        {event.title}
+      </p>
+      {height >= 28 && (
+        <p className="truncate text-[9px] text-muted-foreground/70">
+          {format(startTime, "h:mm a")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const cleanHex = hex.replace("#", "");
+  const r = parseInt(cleanHex.substring(0, 2), 16);
+  const g = parseInt(cleanHex.substring(2, 4), 16);
+  const b = parseInt(cleanHex.substring(4, 6), 16);
+  if (Number.isNaN(r)) return `rgba(107, 114, 128, ${alpha})`;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function MultiDayBlock({
+  block,
+  displayDate,
+  onClick,
+}: {
+  block: TimeBlock;
+  displayDate: Date;
+  onClick?: () => void;
+}) {
+  const startTime = new Date(block.startTime);
+  const endTime = new Date(block.endTime);
+  const dayStart = startOfDay(displayDate);
+  const dayEnd = endOfDay(displayDate);
+  const renderStart = startTime < dayStart ? dayStart : startTime;
+  const renderEnd = endTime > dayEnd ? dayEnd : endTime;
+  const top = calculateYFromTime(renderStart);
+  const durationMins = differenceInMinutes(renderEnd, renderStart);
+  const height = (durationMins / 60) * HOUR_HEIGHT;
+  const color = block.color ?? "#3B82F6";
+
+  return (
+    <div
+      data-time-block
+      className="absolute left-0.5 right-0.5 z-10 my-0.5 rounded cursor-pointer hover:brightness-90 transition-all overflow-hidden px-1 py-0.5"
+      style={{
+        top: `${top}px`,
+        height: `${Math.max(height - 2, 16)}px`,
+        backgroundColor: hexToRgba(color, 0.85),
+        color: "white",
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick?.();
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={`${block.title} at ${format(startTime, "h:mm a")}`}
+    >
+      <p className="truncate text-[10px] font-semibold leading-tight">
+        {block.title}
+      </p>
+      {height >= 28 && (
+        <p className="truncate text-[9px] text-white/80">
+          {format(startTime, "h:mm")}–{format(endTime, "h:mm a")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Multi-day calendar view (3-Day and Week).
+ * Renders N day columns side-by-side sharing one hour-axis gutter.
+ */
+export function MultiDayView({
+  days,
+  calendarEvents,
+  timeBlocks,
+  isLoading = false,
+  onExternalEventClick,
+  onBlockClick,
+  className,
+}: MultiDayViewProps) {
+  const hours = React.useMemo(() => generateHours(), []);
+  const scrollAreaRef = React.useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to ~2 hours before now on mount
+  React.useEffect(() => {
+    const scrollPosition = Math.max(
+      0,
+      (new Date().getHours() - 2) * HOUR_HEIGHT
+    );
+    const viewport = scrollAreaRef.current?.querySelector(
+      "[data-radix-scroll-area-viewport]"
+    );
+    if (viewport) viewport.scrollTop = scrollPosition;
+  }, []);
+
+  const dayBuckets = React.useMemo(
+    () => days.map((d) => bucketEventsForDay(d, calendarEvents, timeBlocks)),
+    [days, calendarEvents, timeBlocks]
+  );
+
+  // Aggregate all-day events row across columns
+  const hasAnyAllDay = dayBuckets.some((b) => b.allDay.length > 0);
+
+  return (
+    <div className={cn("flex h-full flex-col", className)}>
+      {/* Day-of-week headers */}
+      <div className="flex flex-shrink-0 border-b bg-background">
+        {/* Empty gutter to align with hour axis */}
+        <div className="w-12 sm:w-14 flex-shrink-0 border-r" />
+        {days.map((day) => {
+          const today = isToday(day);
+          const weekend = isWeekend(day);
+          return (
+            <div
+              key={day.toISOString()}
+              className={cn(
+                "flex-1 px-2 py-1.5 text-center border-r last:border-r-0",
+                today && "bg-primary/5",
+                weekend && !today && "bg-muted/30"
+              )}
+            >
+              <p
+                className={cn(
+                  "text-[11px] uppercase tracking-wide",
+                  today
+                    ? "text-primary font-semibold"
+                    : "text-muted-foreground"
+                )}
+              >
+                {format(day, "EEE")}
+              </p>
+              <p
+                className={cn(
+                  "text-base sm:text-lg font-semibold leading-tight",
+                  today && "text-primary"
+                )}
+              >
+                {format(day, "d")}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* All-day banner row */}
+      {hasAnyAllDay && (
+        <div className="flex flex-shrink-0 border-b bg-muted/30">
+          <div className="w-12 sm:w-14 flex-shrink-0 border-r flex items-start justify-end px-2 py-1">
+            <span className="text-[10px] font-medium text-muted-foreground">
+              All day
+            </span>
+          </div>
+          {dayBuckets.map((bucket, i) => (
+            <div
+              key={days[i]!.toISOString()}
+              className="flex-1 border-r last:border-r-0 px-1 py-1 space-y-0.5 min-h-[28px]"
+            >
+              {bucket.allDay.map((event) => {
+                const color = event.calendar?.color ?? "#6B7280";
+                return (
+                  <button
+                    key={event.id}
+                    data-all-day-event
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onExternalEventClick?.(event);
+                    }}
+                    className="block w-full text-left rounded px-1.5 py-0.5 text-[10px] truncate hover:brightness-90 cursor-pointer"
+                    style={{
+                      backgroundColor: hexToRgba(color, 0.15),
+                      borderLeft: `2px solid ${hexToRgba(color, 0.6)}`,
+                    }}
+                    title={event.title}
+                  >
+                    {event.title}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-sm text-muted-foreground animate-pulse">
+            Loading…
+          </p>
+        </div>
+      )}
+
+      {/* Scrollable timeline */}
+      {!isLoading && (
+        <ScrollArea className="flex-1" ref={scrollAreaRef}>
+          <div className="flex relative">
+            {/* Hour axis gutter */}
+            <div
+              className="w-12 sm:w-14 flex-shrink-0 border-r relative"
+              style={{
+                height: `${(TIMELINE_END_HOUR - TIMELINE_START_HOUR + 1) * HOUR_HEIGHT}px`,
+              }}
+            >
+              {hours.map((hour) => (
+                <div
+                  key={hour}
+                  className="absolute left-0 right-0 px-1.5 text-[10px] text-muted-foreground text-right -translate-y-1/2"
+                  style={{
+                    top: `${(hour - TIMELINE_START_HOUR) * HOUR_HEIGHT}px`,
+                  }}
+                >
+                  {hour === 0
+                    ? ""
+                    : format(new Date(2000, 0, 1, hour, 0), "h a")}
+                </div>
+              ))}
+            </div>
+
+            {/* Day columns */}
+            {dayBuckets.map((bucket, i) => {
+              const day = days[i]!;
+              const today = isToday(day);
+              const weekend = isWeekend(day);
+              return (
+                <div
+                  key={day.toISOString()}
+                  className={cn(
+                    "flex-1 relative border-r last:border-r-0",
+                    today && "bg-primary/[0.02]",
+                    weekend && !today && "bg-muted/20"
+                  )}
+                  style={{
+                    height: `${(TIMELINE_END_HOUR - TIMELINE_START_HOUR + 1) * HOUR_HEIGHT}px`,
+                  }}
+                >
+                  {/* Hour grid lines */}
+                  {hours.map((hour) => (
+                    <div
+                      key={hour}
+                      className="absolute left-0 right-0 border-b border-border/30"
+                      style={{
+                        top: `${(hour - TIMELINE_START_HOUR) * HOUR_HEIGHT}px`,
+                        height: HOUR_HEIGHT,
+                      }}
+                    />
+                  ))}
+
+                  {/* Now indicator on today's column */}
+                  {today && (
+                    <div
+                      className="absolute left-0 right-0 z-30 flex items-center pointer-events-none"
+                      style={{ top: calculateYFromTime(new Date()) }}
+                    >
+                      <div className="h-2 w-2 rounded-full bg-red-500 -ml-1 shadow-sm" />
+                      <div className="h-0.5 flex-1 bg-red-500 shadow-sm" />
+                    </div>
+                  )}
+
+                  {/* Time blocks (above events) */}
+                  {bucket.blocks.map((block) => (
+                    <MultiDayBlock
+                      key={block.id}
+                      block={block}
+                      displayDate={day}
+                      onClick={
+                        onBlockClick ? () => onBlockClick(block) : undefined
+                      }
+                    />
+                  ))}
+
+                  {/* External calendar events */}
+                  {bucket.timed.map((event) => (
+                    <MultiDayEvent
+                      key={event.id}
+                      event={event}
+                      displayDate={day}
+                      onClick={
+                        onExternalEventClick
+                          ? () => onExternalEventClick(event)
+                          : undefined
+                      }
+                    />
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/calendar/multi-day-view.tsx
+++ b/apps/web/src/components/calendar/multi-day-view.tsx
@@ -55,7 +55,14 @@ function bucketEventsForDay(
 ): DayColumnEvents {
   const dayStart = startOfDay(date);
   const dayEnd = endOfDay(date);
-  const targetCalendarDate = format(date, "yyyy-MM-dd");
+  // All-day events follow the iCal convention: backend stores them at UTC
+  // midnight for the date the event covers. To compare apples-to-apples,
+  // we project the cell's *local calendar date* to a UTC-midnight string
+  // using the local Y/M/D components, then string-compare against the
+  // event's UTC-derived YYYY-MM-DD. Mixing local-format on one side and
+  // UTC-format on the other would silently drop events for users west
+  // of UTC at the day boundary.
+  const targetCalendarDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 
   const timed: CalendarEvent[] = [];
   const allDay: CalendarEvent[] = [];
@@ -65,8 +72,8 @@ function bucketEventsForDay(
     const end = new Date(event.endTime);
 
     if (event.isAllDay) {
-      const startDateStr = start.toISOString().slice(0, 10);
-      const endDateStr = end.toISOString().slice(0, 10);
+      const startDateStr = `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, "0")}-${String(start.getUTCDate()).padStart(2, "0")}`;
+      const endDateStr = `${end.getUTCFullYear()}-${String(end.getUTCMonth() + 1).padStart(2, "0")}-${String(end.getUTCDate()).padStart(2, "0")}`;
       if (
         targetCalendarDate >= startDateStr &&
         targetCalendarDate < endDateStr
@@ -114,7 +121,7 @@ function MultiDayEvent({
   return (
     <div
       data-external-event
-      className="absolute left-0.5 right-0.5 z-5 my-0.5 rounded border-l-[2px] cursor-pointer hover:brightness-90 transition-all overflow-hidden px-1 py-0.5"
+      className="absolute left-0.5 right-0.5 z-[5] my-0.5 rounded border-l-[2px] cursor-pointer hover:brightness-90 transition-all overflow-hidden px-1 py-0.5"
       style={{
         top: `${top}px`,
         height: `${Math.max(height - 2, 16)}px`,
@@ -242,6 +249,12 @@ export function MultiDayView({
   // Aggregate all-day events row across columns
   const hasAnyAllDay = dayBuckets.some((b) => b.allDay.length > 0);
 
+  // 7-column week view on a 360px phone leaves ~44px per column after the
+  // hour gutter — enough for a single-letter day label and a 2-digit date.
+  // 3-day view at the same width gets ~100px per column. Tighten typography
+  // on the narrow case so headers and event chips stay readable.
+  const isWeek = days.length >= 7;
+
   return (
     <div className={cn("flex h-full flex-col", className)}>
       {/* Day-of-week headers */}
@@ -255,24 +268,33 @@ export function MultiDayView({
             <div
               key={day.toISOString()}
               className={cn(
-                "flex-1 px-2 py-1.5 text-center border-r last:border-r-0",
+                "flex-1 px-1 sm:px-2 py-1.5 text-center border-r last:border-r-0 min-w-0",
                 today && "bg-primary/5",
                 weekend && !today && "bg-muted/30"
               )}
             >
               <p
                 className={cn(
-                  "text-[11px] uppercase tracking-wide",
+                  "uppercase tracking-wide",
+                  isWeek ? "text-[10px] sm:text-[11px]" : "text-[11px]",
                   today
                     ? "text-primary font-semibold"
                     : "text-muted-foreground"
                 )}
               >
-                {format(day, "EEE")}
+                {/* On the week view at narrow widths, show single-letter
+                    weekday (M T W T F S S) so headers don't overflow. */}
+                <span className={cn(isWeek && "sm:hidden")}>
+                  {format(day, "EEEEE")}
+                </span>
+                <span className={cn(isWeek ? "hidden sm:inline" : "")}>
+                  {format(day, "EEE")}
+                </span>
               </p>
               <p
                 className={cn(
-                  "text-base sm:text-lg font-semibold leading-tight",
+                  "font-semibold leading-tight",
+                  isWeek ? "text-sm sm:text-lg" : "text-base sm:text-lg",
                   today && "text-primary"
                 )}
               >
@@ -294,7 +316,7 @@ export function MultiDayView({
           {dayBuckets.map((bucket, i) => (
             <div
               key={days[i]!.toISOString()}
-              className="flex-1 border-r last:border-r-0 px-1 py-1 space-y-0.5 min-h-[28px]"
+              className="flex-1 border-r last:border-r-0 px-1 py-1 space-y-0.5 min-h-[28px] min-w-0"
             >
               {bucket.allDay.map((event) => {
                 const color = event.calendar?.color ?? "#6B7280";
@@ -366,7 +388,7 @@ export function MultiDayView({
                 <div
                   key={day.toISOString()}
                   className={cn(
-                    "flex-1 relative border-r last:border-r-0",
+                    "flex-1 relative border-r last:border-r-0 min-w-0",
                     today && "bg-primary/[0.02]",
                     weekend && !today && "bg-muted/20"
                   )}
@@ -374,14 +396,25 @@ export function MultiDayView({
                     height: `${(TIMELINE_END_HOUR - TIMELINE_START_HOUR + 1) * HOUR_HEIGHT}px`,
                   }}
                 >
-                  {/* Hour grid lines */}
+                  {/* Hour grid lines — drawn at the BOTTOM of each hour
+                      slot to match the single-day Timeline. Drawing at the
+                      top would offset the grid by one row from Timeline. */}
                   {hours.map((hour) => (
                     <div
                       key={hour}
-                      className="absolute left-0 right-0 border-b border-border/30"
+                      className="absolute left-0 right-0 border-b border-border/30 pointer-events-none"
                       style={{
-                        top: `${(hour - TIMELINE_START_HOUR) * HOUR_HEIGHT}px`,
-                        height: HOUR_HEIGHT,
+                        top: `${(hour - TIMELINE_START_HOUR + 1) * HOUR_HEIGHT}px`,
+                      }}
+                    />
+                  ))}
+                  {/* Half-hour grid lines — fainter, mid-hour. */}
+                  {hours.map((hour) => (
+                    <div
+                      key={`${hour}-half`}
+                      className="absolute left-0 right-0 border-b border-border/15 pointer-events-none"
+                      style={{
+                        top: `${(hour - TIMELINE_START_HOUR) * HOUR_HEIGHT + HOUR_HEIGHT / 2}px`,
                       }}
                     />
                   ))}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,6 +30,7 @@ export type {
   User,
   UserPreferences,
   HomeTabPreference,
+  CalendarViewMode,
   CreateUserInput,
   LoginInput,
   AuthResponse,

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -10,6 +10,16 @@
 export type HomeTabPreference = "board" | "tasks" | "calendar";
 
 /**
+ * Granularity of the calendar view.
+ * - "day": single-day timeline (default)
+ * - "3-day": three columns side-by-side, today + next two
+ * - "week": seven-day week (Sun → Sat or Mon → Sun depending on
+ *    `weekStartsOn`)
+ * - "month": full-month grid with event chips
+ */
+export type CalendarViewMode = "day" | "3-day" | "week" | "month";
+
+/**
  * User's display preferences for theme, font, and default home tab.
  * Stored as JSON in the database and synced across devices.
  */
@@ -31,6 +41,15 @@ export interface UserPreferences {
 
   /** Default tab when visiting /app */
   homeTab?: HomeTabPreference;
+
+  /** Default granularity of the /app/calendar view (defaults to "day") */
+  calendarViewMode?: CalendarViewMode;
+
+  /**
+   * 0 = Sunday (US), 1 = Monday (most of the world). Used by the week
+   * and month calendar views to know where to start the row.
+   */
+  weekStartsOn?: 0 | 1;
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 2 of the calendar overhaul. Adds the missing view modes alongside existing Day view, with shared event interaction model so a click in any view opens the in-app detail sheet (no more Google redirect + new-task popup).

- **Day** — unchanged Timeline + unscheduled-tasks panel + DnD.
- **3-Day** — three side-by-side day columns sharing one hour gutter.
- **Week** — same engine, 7 columns, single-letter weekday on phones.
- **Month** — 6×7 grid with prior/next-month spillover dimmed; ≤3 entries per cell with \"+N more\" affordance; click a day to drill into Day view.

Toolbar gets a segmented control (Day | 3 days | Week | Month). \"Today\" highlights when today is in the visible range, not only when it equals the anchor date. View choice persists to localStorage and seeds from \`user.preferences.calendarViewMode\` once on first server-pref arrival (per-device override wins after that).

## Bug fixes from verifier loop

- All-day event date comparison was mixing UTC-derived event date with local-formatted cell date — silently dropped events for users west of UTC at the day boundary. Both sides now extract YYYY-MM-DD with consistent semantics (local for cell, UTC for event start/end per iCal convention).
- MonthView cells used to be \`<button>\` containing nested entry \`<button>\`s — invalid HTML and a hydration warning. Now \`<div role=\"button\">\` with keyboard guards so a keypress on an entry doesn't double-fire the day-click.
- Replaced invalid Tailwind \`z-5\` with \`z-[5]\`.
- Hour grid lines in MultiDayView now match the single-day Timeline (bottom-of-hour + faint half-hour lines) so the grid doesn't visibly shift when switching modes.
- Server-pref → local viewMode sync hardened with a one-shot ref so subsequent server pushes never overwrite a local user choice.

## Test plan

- [ ] Switch between Day / 3-Day / Week / Month — anchor date preserved, range labels update sensibly.
- [ ] Cross-month and cross-year ranges render correct labels.
- [ ] All-day Google Calendar event covering 2026-05-02 shows up on May 2 in every view, regardless of viewer TZ (HK, PST, Honolulu, UTC).
- [ ] Multi-day all-day event (Aug 1–3) shows on Aug 1 and 2, not Aug 3 (iCal exclusive end).
- [ ] Click an external event in any view → in-app detail sheet opens (NOT Google Calendar in a new tab).
- [ ] \"Create task from event\" prefills the AddTaskModal title.
- [ ] Click a day cell in Month view → switches to Day view anchored on that date.
- [ ] \"Today\" button stays highlighted when today is anywhere in a navigated week / month.
- [ ] Keyboard: tab to MonthView cell → Enter opens day. Tab to entry inside cell → Enter triggers entry handler only (no double-action).
- [ ] Mobile: 7-column week view fits on a 360px phone with single-letter weekday labels.
- [ ] localStorage persists view choice across reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)