### PR TITLE
feat(calendar): write-back edit + delete for Google events

### DIFF
--- a/apps/api/src/lib/websocket/events.ts
+++ b/apps/api/src/lib/websocket/events.ts
@@ -25,6 +25,8 @@ export type WebSocketEventType =
   | "calendar:account-disconnected"
   | "calendar:synced"
   | "calendar:updated"
+  | "calendar-event:updated"
+  | "calendar-event:deleted"
   // Timer events
   | "timer:started"
   | "timer:stopped"

--- a/apps/api/src/routes/calendar-events.ts
+++ b/apps/api/src/routes/calendar-events.ts
@@ -1,9 +1,11 @@
 /**
  * Calendar events routes for Open Sunsama API
- * Handles fetching calendar events for display on timeline
+ * Fetch events for display, plus write-back (edit / delete) for providers
+ * that support it.
  */
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
 import {
   getDb,
   eq,
@@ -12,6 +14,7 @@ import {
   lte,
   inArray,
   calendars,
+  calendarAccounts,
   calendarEvents,
 } from '@open-sunsama/database';
 import { auth, requireScopes, type AuthVariables } from '../middleware/auth.js';
@@ -19,6 +22,15 @@ import {
   calendarEventsQuerySchema,
   parseCalendarIds,
 } from '../validation/calendar.js';
+import {
+  getProvider,
+  refreshTokensIfNeeded,
+} from '../services/calendar-sync.js';
+import {
+  ProviderReadOnlyError,
+  type EventPatch,
+} from '../services/calendar-providers/index.js';
+import { publishEvent } from '../lib/websocket/index.js';
 
 const calendarEventsRouter = new Hono<{ Variables: AuthVariables }>();
 calendarEventsRouter.use('*', auth);
@@ -146,6 +158,302 @@ calendarEventsRouter.get(
         total: enrichedEvents.length,
       },
     });
+  }
+);
+
+/**
+ * Common helper: load the event together with its calendar + account so
+ * we can write back via the right provider with a fresh token. Returns
+ * 404 with a `null` payload if the event doesn't belong to this user.
+ */
+async function loadEventForWrite(eventId: string, userId: string) {
+  const db = getDb();
+  const rows = await db
+    .select({
+      event: calendarEvents,
+      calendar: calendars,
+      account: calendarAccounts,
+    })
+    .from(calendarEvents)
+    .innerJoin(calendars, eq(calendars.id, calendarEvents.calendarId))
+    .innerJoin(
+      calendarAccounts,
+      eq(calendarAccounts.id, calendars.accountId)
+    )
+    .where(
+      and(
+        eq(calendarEvents.id, eventId),
+        eq(calendarEvents.userId, userId)
+      )
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+/**
+ * Body for PATCH /calendar-events/:id. All fields optional. The client
+ * may send any subset of the editable fields. Times are ISO 8601.
+ */
+const updateEventBodySchema = z
+  .object({
+    title: z.string().min(1).max(500).optional(),
+    description: z.string().max(50_000).nullable().optional(),
+    location: z.string().max(1000).nullable().optional(),
+    startTime: z.string().datetime().optional(),
+    endTime: z.string().datetime().optional(),
+    isAllDay: z.boolean().optional(),
+    timezone: z.string().max(100).nullable().optional(),
+  })
+  .refine(
+    (b) =>
+      (b.startTime === undefined && b.endTime === undefined) ||
+      (b.startTime !== undefined && b.endTime !== undefined),
+    {
+      message: 'startTime and endTime must be provided together',
+      path: ['endTime'],
+    }
+  );
+
+/**
+ * PATCH /calendar-events/:id
+ * Edit an external calendar event. The change is sent upstream to the
+ * provider and only persisted locally if the upstream write succeeds —
+ * we don't want a divergent local state if the user lacks permission
+ * or the provider is down. Returns the updated event payload.
+ */
+calendarEventsRouter.patch(
+  '/:id',
+  requireScopes('user:write'),
+  zValidator('json', updateEventBodySchema),
+  async (c) => {
+    const userId = c.get('userId');
+    const eventId = c.req.param('id');
+    const body = c.req.valid('json');
+    const db = getDb();
+
+    const row = await loadEventForWrite(eventId, userId);
+    if (!row) {
+      return c.json(
+        { success: false, error: { code: 'NOT_FOUND', message: 'Event not found' } },
+        404
+      );
+    }
+
+    if (row.calendar.isReadOnly) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: 'CALENDAR_READ_ONLY',
+            message: 'This calendar is read-only — events cannot be edited.',
+          },
+        },
+        409
+      );
+    }
+
+    const provider = getProvider(row.account.provider);
+    if (!provider || !provider.updateEvent) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: 'PROVIDER_READ_ONLY',
+            message: `Editing ${row.account.provider} events is not yet supported.`,
+          },
+        },
+        409
+      );
+    }
+
+    const accessToken = await refreshTokensIfNeeded(
+      {
+        id: row.account.id,
+        provider: row.account.provider,
+        accessTokenEncrypted: row.account.accessTokenEncrypted,
+        refreshTokenEncrypted: row.account.refreshTokenEncrypted,
+        tokenExpiresAt: row.account.tokenExpiresAt,
+      },
+      provider
+    );
+
+    const patch: EventPatch = {};
+    if (body.title !== undefined) patch.title = body.title;
+    if (body.description !== undefined) patch.description = body.description;
+    if (body.location !== undefined) patch.location = body.location;
+    if (body.startTime !== undefined && body.endTime !== undefined) {
+      patch.startTime = new Date(body.startTime);
+      patch.endTime = new Date(body.endTime);
+    }
+    if (body.isAllDay !== undefined) patch.isAllDay = body.isAllDay;
+    if (body.timezone !== undefined) patch.timezone = body.timezone;
+
+    let updatedExternal;
+    try {
+      updatedExternal = await provider.updateEvent(
+        accessToken,
+        row.calendar.externalId,
+        row.event.externalId,
+        patch
+      );
+    } catch (err) {
+      if (err instanceof ProviderReadOnlyError) {
+        return c.json(
+          {
+            success: false,
+            error: { code: 'PROVIDER_READ_ONLY', message: err.message },
+          },
+          409
+        );
+      }
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return c.json(
+        {
+          success: false,
+          error: { code: 'PROVIDER_ERROR', message },
+        },
+        502
+      );
+    }
+
+    // Write-through to local DB so the user sees the change immediately
+    // without waiting for the next sync. The provider response is the
+    // canonical post-write state.
+    const [updated] = await db
+      .update(calendarEvents)
+      .set({
+        title: updatedExternal.title,
+        description: updatedExternal.description,
+        location: updatedExternal.location,
+        startTime: updatedExternal.startTime,
+        endTime: updatedExternal.endTime,
+        isAllDay: updatedExternal.isAllDay,
+        timezone: updatedExternal.timezone,
+        status: updatedExternal.status,
+        responseStatus: updatedExternal.responseStatus,
+        htmlLink: updatedExternal.htmlLink,
+        etag: updatedExternal.etag,
+        updatedAt: new Date(),
+      })
+      .where(eq(calendarEvents.id, eventId))
+      .returning();
+
+    if (updated) {
+      // Notify other tabs / devices via the realtime channel; the client
+      // invalidates the calendar-events query on receipt.
+      await publishEvent(userId, 'calendar-event:updated', {
+        id: updated.id,
+        calendarId: updated.calendarId,
+      });
+    }
+
+    return c.json({
+      success: true,
+      data: {
+        ...updated,
+        calendar: {
+          id: row.calendar.id,
+          name: row.calendar.name,
+          color: row.calendar.color,
+        },
+      },
+    });
+  }
+);
+
+/**
+ * DELETE /calendar-events/:id
+ * Delete an external calendar event upstream and locally.
+ */
+calendarEventsRouter.delete(
+  '/:id',
+  requireScopes('user:write'),
+  async (c) => {
+    const userId = c.get('userId');
+    const eventId = c.req.param('id');
+    const db = getDb();
+
+    const row = await loadEventForWrite(eventId, userId);
+    if (!row) {
+      return c.json(
+        { success: false, error: { code: 'NOT_FOUND', message: 'Event not found' } },
+        404
+      );
+    }
+
+    if (row.calendar.isReadOnly) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: 'CALENDAR_READ_ONLY',
+            message: 'This calendar is read-only — events cannot be deleted.',
+          },
+        },
+        409
+      );
+    }
+
+    const provider = getProvider(row.account.provider);
+    if (!provider || !provider.deleteEvent) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: 'PROVIDER_READ_ONLY',
+            message: `Deleting ${row.account.provider} events is not yet supported.`,
+          },
+        },
+        409
+      );
+    }
+
+    const accessToken = await refreshTokensIfNeeded(
+      {
+        id: row.account.id,
+        provider: row.account.provider,
+        accessTokenEncrypted: row.account.accessTokenEncrypted,
+        refreshTokenEncrypted: row.account.refreshTokenEncrypted,
+        tokenExpiresAt: row.account.tokenExpiresAt,
+      },
+      provider
+    );
+
+    try {
+      await provider.deleteEvent(
+        accessToken,
+        row.calendar.externalId,
+        row.event.externalId
+      );
+    } catch (err) {
+      if (err instanceof ProviderReadOnlyError) {
+        return c.json(
+          {
+            success: false,
+            error: { code: 'PROVIDER_READ_ONLY', message: err.message },
+          },
+          409
+        );
+      }
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return c.json(
+        {
+          success: false,
+          error: { code: 'PROVIDER_ERROR', message },
+        },
+        502
+      );
+    }
+
+    await db.delete(calendarEvents).where(eq(calendarEvents.id, eventId));
+
+    await publishEvent(userId, 'calendar-event:deleted', {
+      id: eventId,
+      calendarId: row.calendar.id,
+    });
+
+    return c.json({ success: true });
   }
 );
 

--- a/apps/api/src/services/calendar-providers/google.ts
+++ b/apps/api/src/services/calendar-providers/google.ts
@@ -6,6 +6,7 @@ import type {
   OAuthTokens,
   ExternalCalendar,
   ExternalEvent,
+  EventPatch,
   SyncOptions,
   SyncResult,
 } from './index';
@@ -14,6 +15,7 @@ import {
   getClientSecret,
   parseGoogleEvent,
   type GoogleCalendarListItem,
+  type GoogleEvent,
   type GoogleEventsResponse,
   type GoogleTokenResponse,
   type GoogleCalendarListResponse,
@@ -201,4 +203,106 @@ export class GoogleCalendarProvider implements CalendarProvider {
       nextSyncToken,
     };
   }
+
+  async updateEvent(
+    accessToken: string,
+    calendarId: string,
+    eventId: string,
+    patch: EventPatch
+  ): Promise<ExternalEvent> {
+    const body: Partial<GoogleEvent> = {};
+
+    if (patch.title !== undefined) {
+      body.summary = patch.title;
+    }
+    if (patch.description !== undefined) {
+      // Google accepts empty string to clear; sending null is invalid.
+      body.description = patch.description ?? '';
+    }
+    if (patch.location !== undefined) {
+      body.location = patch.location ?? '';
+    }
+    if (patch.startTime !== undefined || patch.endTime !== undefined) {
+      if (patch.startTime === undefined || patch.endTime === undefined) {
+        throw new Error('startTime and endTime must be supplied together');
+      }
+      if (patch.isAllDay) {
+        // Google all-day events use `date: "YYYY-MM-DD"` and the
+        // exclusive-end convention (end is the day AFTER the last
+        // covered day). Caller is expected to follow that convention.
+        body.start = { date: toUtcDateString(patch.startTime) };
+        body.end = { date: toUtcDateString(patch.endTime) };
+      } else {
+        const tz = patch.timezone ?? 'UTC';
+        body.start = {
+          dateTime: patch.startTime.toISOString(),
+          timeZone: tz,
+        };
+        body.end = {
+          dateTime: patch.endTime.toISOString(),
+          timeZone: tz,
+        };
+      }
+    }
+
+    const response = await fetch(
+      `${GOOGLE_CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(
+        `Google updateEvent failed (${response.status}): ${error}`
+      );
+    }
+
+    const data = (await response.json()) as GoogleEvent;
+    const parsed = parseGoogleEvent(data);
+    if (!parsed) {
+      throw new Error('Google returned an event that could not be parsed');
+    }
+    return parsed;
+  }
+
+  async deleteEvent(
+    accessToken: string,
+    calendarId: string,
+    eventId: string
+  ): Promise<void> {
+    const response = await fetch(
+      `${GOOGLE_CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
+
+    // 410 Gone = already deleted upstream. Treat as success — local row
+    // will be cleaned up alongside.
+    if (!response.ok && response.status !== 410 && response.status !== 404) {
+      const error = await response.text();
+      throw new Error(
+        `Google deleteEvent failed (${response.status}): ${error}`
+      );
+    }
+  }
+}
+
+/**
+ * Format a Date as YYYY-MM-DD using UTC components — required by Google's
+ * all-day event date format. The input is expected to already represent
+ * UTC midnight on the target calendar date (per the iCal convention).
+ */
+function toUtcDateString(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
 }

--- a/apps/api/src/services/calendar-providers/index.ts
+++ b/apps/api/src/services/calendar-providers/index.ts
@@ -40,12 +40,70 @@ export interface SyncResult {
   nextSyncToken: string | null;
 }
 
+/**
+ * Patch shape for an existing event. All fields optional — providers
+ * apply only the supplied keys, leaving the rest untouched.
+ *
+ * `startTime` / `endTime` should be supplied together if either changes.
+ * `isAllDay` flips the event between timed and date-only representations
+ * (Google: `start.dateTime` ↔ `start.date`).
+ */
+export interface EventPatch {
+  title?: string;
+  description?: string | null;
+  location?: string | null;
+  startTime?: Date;
+  endTime?: Date;
+  isAllDay?: boolean;
+  /**
+   * IANA timezone name to attach to a timed event. If omitted on a
+   * start/end change, providers fall back to UTC. Ignored for all-day.
+   */
+  timezone?: string | null;
+}
+
 export interface CalendarProvider {
   getAuthUrl(state: string, redirectUri: string): string;
   exchangeCode(code: string, redirectUri: string): Promise<OAuthTokens>;
   refreshTokens(refreshToken: string): Promise<OAuthTokens>;
   listCalendars(accessToken: string): Promise<ExternalCalendar[]>;
   listEvents(accessToken: string, calendarId: string, options: SyncOptions): Promise<SyncResult>;
+  /**
+   * Patch an event in place upstream. Returns the canonical post-write
+   * representation so the caller can update local storage without
+   * waiting for the next incremental sync. Throws on failure.
+   *
+   * Providers that don't support write-back yet must throw a
+   * `ProviderReadOnlyError` so the route layer can return 409.
+   */
+  updateEvent?(
+    accessToken: string,
+    calendarExternalId: string,
+    eventExternalId: string,
+    patch: EventPatch
+  ): Promise<ExternalEvent>;
+  /**
+   * Delete an event upstream. Resolves on success. Providers that
+   * can't delete throw `ProviderReadOnlyError`.
+   */
+  deleteEvent?(
+    accessToken: string,
+    calendarExternalId: string,
+    eventExternalId: string
+  ): Promise<void>;
+}
+
+/**
+ * Sentinel thrown when a provider doesn't support a write-back action
+ * yet. Routes catch this and return 409 Conflict so the client can
+ * surface a "read-only" message and disable the action.
+ */
+export class ProviderReadOnlyError extends Error {
+  readonly code = 'PROVIDER_READ_ONLY' as const;
+  constructor(provider: string) {
+    super(`${provider} provider does not support write-back yet`);
+    this.name = 'ProviderReadOnlyError';
+  }
 }
 
 export { GoogleCalendarProvider } from './google';

--- a/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
+++ b/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { format, isSameDay } from "date-fns";
+import { format, isSameDay, parseISO } from "date-fns";
 import {
   CalendarDays,
   Clock,
@@ -7,6 +7,9 @@ import {
   MapPin,
   Plus,
   AlignLeft,
+  Pencil,
+  Trash2,
+  Loader2,
 } from "lucide-react";
 import type { CalendarEvent } from "@open-sunsama/types";
 import {
@@ -15,7 +18,22 @@ import {
   SheetContent,
   SheetHeader,
   SheetTitle,
+  Input,
+  Textarea,
+  Label,
+  Switch,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
 } from "@/components/ui";
+import {
+  useUpdateCalendarEvent,
+  useDeleteCalendarEvent,
+} from "@/hooks/useCalendars";
+import { toast } from "@/hooks/use-toast";
 
 interface CalendarEventDetailSheetProps {
   event: CalendarEvent | null;
@@ -27,6 +45,19 @@ interface CalendarEventDetailSheetProps {
    * the event title and a scheduledDate matching the event's start.
    */
   onCreateTask?: (event: CalendarEvent) => void;
+  /**
+   * The from/to range the event is currently visible in. Required for
+   * the optimistic-update path so the right cache key is targeted.
+   */
+  rangeFrom: string;
+  rangeTo: string;
+  /**
+   * Whether the calendar this event lives on is read-only. We pull this
+   * from the calendar metadata and pass it down so the edit affordances
+   * are hidden for events the user can't actually mutate (subscribed
+   * calendars, holidays, etc.).
+   */
+  calendarReadOnly?: boolean;
 }
 
 function hexToRgba(hex: string, alpha: number): string {
@@ -34,11 +65,7 @@ function hexToRgba(hex: string, alpha: number): string {
   const r = parseInt(cleanHex.substring(0, 2), 16);
   const g = parseInt(cleanHex.substring(2, 4), 16);
   const b = parseInt(cleanHex.substring(4, 6), 16);
-  if (
-    Number.isNaN(r) ||
-    Number.isNaN(g) ||
-    Number.isNaN(b)
-  ) {
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
     return `rgba(107, 114, 128, ${alpha})`;
   }
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
@@ -54,11 +81,8 @@ function formatEventTime(event: CalendarEvent): string {
     const startDateStr = start.toISOString().slice(0, 10);
     const endDateStr = end.toISOString().slice(0, 10);
     if (startDateStr === endDateStr) {
-      // 0-day span — degenerate; show start only.
       return format(start, "EEEE, MMMM d, yyyy");
     }
-    // Convert to a real Date object in local TZ for the formatter, then
-    // back the end date off by 1 day so it reads as the inclusive last day.
     const inclusiveEnd = new Date(end.getTime() - 24 * 60 * 60 * 1000);
     if (startDateStr === inclusiveEnd.toISOString().slice(0, 10)) {
       return format(start, "EEEE, MMMM d, yyyy");
@@ -73,36 +97,118 @@ function formatEventTime(event: CalendarEvent): string {
 }
 
 /**
- * Read-only detail sheet for an external calendar event.
+ * <input type="datetime-local"> takes a "YYYY-MM-DDTHH:mm" string in the
+ * USER's local timezone — no timezone offset. We have a real Date; pull
+ * its local components and format.
+ */
+function toLocalInputValue(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Reverse of `toLocalInputValue` — datetime-local input is local time.
+ * `new Date("YYYY-MM-DDTHH:mm")` parses as local already, so we can
+ * delegate to the Date constructor.
+ */
+function fromLocalInputValue(s: string): Date {
+  return new Date(s);
+}
+
+/**
+ * For all-day inputs we use type="date" which gives a "YYYY-MM-DD"
+ * string. We project that back to UTC midnight so the value matches
+ * the iCal storage convention.
+ */
+function fromAllDayInputValue(s: string): Date {
+  // s is "YYYY-MM-DD"; appending Z gives an ISO UTC midnight.
+  return new Date(`${s}T00:00:00Z`);
+}
+
+function toAllDayInputValue(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+interface EditableState {
+  title: string;
+  description: string;
+  location: string;
+  isAllDay: boolean;
+  /** datetime-local string for timed events; date string for all-day */
+  start: string;
+  /** datetime-local string for timed events; date string for all-day */
+  end: string;
+}
+
+function buildInitialState(event: CalendarEvent): EditableState {
+  const start = new Date(event.startTime);
+  const end = new Date(event.endTime);
+  return {
+    title: event.title,
+    description: event.description ?? "",
+    location: event.location ?? "",
+    isAllDay: event.isAllDay,
+    start: event.isAllDay
+      ? toAllDayInputValue(start)
+      : toLocalInputValue(start),
+    end: event.isAllDay
+      ? toAllDayInputValue(
+          // For all-day, the input shows the LAST inclusive day (not the
+          // exclusive next-day boundary the storage uses). Subtract 1d.
+          new Date(end.getTime() - 24 * 60 * 60 * 1000)
+        )
+      : toLocalInputValue(end),
+  };
+}
+
+/**
+ * Detail sheet for an external calendar event with read + edit modes.
  *
- * This deliberately replaces the previous behaviour of opening the
- * provider's web UI on click. The user wanted to interact with their
- * events inside the app — see the details, navigate to the source if
- * they want, or convert to a task — without bouncing out to Google.
+ * View mode shows: title, time, location, description, calendar (color),
+ * response status, and the secondary actions ("Open in provider",
+ * "Create task from event"). For editable calendars an "Edit" button
+ * flips the sheet into edit mode.
  *
- * Editing/deleting requires a write-back path to the upstream provider,
- * which is shipped in a follow-up. For now the sheet exposes:
- *
- *   - title, time range, location, description, attending status
- *   - the source calendar (with its provider color)
- *   - "Open in Google / Outlook / iCloud" — explicit secondary action
- *   - "Create task from event" — explicit primary action that hands
- *     the event off to the AddTaskModal pre-filled
+ * Edit mode swaps in form controls for title, all-day toggle, start +
+ * end, location, description. Save writes through to the upstream
+ * provider; Cancel discards. Delete (with confirmation) sends a DELETE
+ * upstream and clears the local row.
  */
 export function CalendarEventDetailSheet({
   event,
   open,
   onOpenChange,
   onCreateTask,
+  rangeFrom,
+  rangeTo,
+  calendarReadOnly = false,
 }: CalendarEventDetailSheetProps) {
   // Render nothing until first open so the sheet doesn't allocate DOM
   // before a user actually clicks an event.
   const seenOpenRef = React.useRef(false);
   if (open) seenOpenRef.current = true;
+
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [editState, setEditState] = React.useState<EditableState | null>(null);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = React.useState(false);
+
+  const updateMutation = useUpdateCalendarEvent();
+  const deleteMutation = useDeleteCalendarEvent();
+
+  // When the sheet opens for a new event, reset edit state to view mode
+  // and seed the editable values from the event.
+  React.useEffect(() => {
+    if (open && event) {
+      setIsEditing(false);
+      setEditState(buildInitialState(event));
+    }
+  }, [open, event?.id]);
+
   if (!seenOpenRef.current) return null;
 
   const color = event?.calendar?.color ?? "#6B7280";
   const calendarName = event?.calendar?.name ?? "External calendar";
+  const canEdit = !!event && !calendarReadOnly;
 
   const handleOpenInProvider = () => {
     if (event?.htmlLink) {
@@ -117,106 +223,414 @@ export function CalendarEventDetailSheet({
     }
   };
 
+  const handleStartEdit = () => {
+    if (event) {
+      setEditState(buildInitialState(event));
+      setIsEditing(true);
+    }
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    if (event) setEditState(buildInitialState(event));
+  };
+
+  const handleSave = async () => {
+    if (!event || !editState) return;
+    const trimmedTitle = editState.title.trim();
+    if (!trimmedTitle) {
+      toast({
+        variant: "destructive",
+        title: "Title required",
+        description: "An event must have a title.",
+      });
+      return;
+    }
+    let startDate: Date;
+    let endDate: Date;
+    if (editState.isAllDay) {
+      startDate = fromAllDayInputValue(editState.start);
+      // Storage convention: end is the day AFTER the last covered day.
+      const inclusiveEnd = fromAllDayInputValue(editState.end);
+      endDate = new Date(inclusiveEnd.getTime() + 24 * 60 * 60 * 1000);
+    } else {
+      startDate = fromLocalInputValue(editState.start);
+      endDate = fromLocalInputValue(editState.end);
+    }
+    if (
+      Number.isNaN(startDate.getTime()) ||
+      Number.isNaN(endDate.getTime())
+    ) {
+      toast({
+        variant: "destructive",
+        title: "Invalid date",
+        description: "Please enter valid start and end dates.",
+      });
+      return;
+    }
+    if (endDate <= startDate) {
+      toast({
+        variant: "destructive",
+        title: "End must be after start",
+        description: "The event's end time has to come after its start.",
+      });
+      return;
+    }
+
+    try {
+      await updateMutation.mutateAsync({
+        id: event.id,
+        rangeFrom,
+        rangeTo,
+        patch: {
+          title: trimmedTitle,
+          description: editState.description.trim() || null,
+          location: editState.location.trim() || null,
+          startTime: startDate,
+          endTime: endDate,
+          isAllDay: editState.isAllDay,
+          // Use the browser's local TZ for timed events. iCal/Google
+          // accept this and the user expects "I edited at 3pm local"
+          // to round-trip as 3pm local on other devices.
+          ...(editState.isAllDay
+            ? {}
+            : {
+                timezone:
+                  Intl.DateTimeFormat().resolvedOptions().timeZone,
+              }),
+        },
+      });
+      toast({ title: "Event updated" });
+      setIsEditing(false);
+    } catch {
+      // Mutation hook already toasted the error and rolled back state.
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!event) return;
+    try {
+      await deleteMutation.mutateAsync({
+        id: event.id,
+        rangeFrom,
+        rangeTo,
+      });
+      toast({ title: "Event deleted" });
+      setConfirmDeleteOpen(false);
+      onOpenChange(false);
+    } catch {
+      // hook handles toast + rollback
+    }
+  };
+
+  const isMutating = updateMutation.isPending || deleteMutation.isPending;
+
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:max-w-md overflow-y-auto">
-        <SheetHeader className="space-y-3">
-          <div className="flex items-start gap-2">
-            <div
-              className="mt-1 h-3 w-3 flex-shrink-0 rounded-full"
-              style={{ backgroundColor: color }}
-              aria-hidden
-            />
-            <SheetTitle className="text-base font-semibold leading-snug">
-              {event?.title || "Untitled event"}
-            </SheetTitle>
-          </div>
-          <div
-            className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium"
-            style={{ backgroundColor: hexToRgba(color, 0.1) }}
-          >
-            <CalendarDays
-              className="h-3 w-3"
-              style={{ color }}
-              aria-hidden
-            />
-            <span style={{ color: hexToRgba(color, 1) }}>{calendarName}</span>
-            {event?.responseStatus && (
-              <span className="ml-auto text-muted-foreground">
-                {event.responseStatus === "accepted" && "Going"}
-                {event.responseStatus === "declined" && "Declined"}
-                {event.responseStatus === "tentative" && "Maybe"}
-                {event.responseStatus === "needsAction" && "Awaiting reply"}
-              </span>
-            )}
-          </div>
-        </SheetHeader>
-
-        {event && (
-          <div className="mt-6 space-y-5">
-            {/* Time */}
-            <div className="flex items-start gap-3 text-sm">
-              <Clock className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
-              <div className="text-foreground/90">{formatEventTime(event)}</div>
-            </div>
-
-            {/* Location */}
-            {event.location && (
-              <div className="flex items-start gap-3 text-sm">
-                <MapPin className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
-                <div className="text-foreground/90 break-words">
-                  {event.location}
-                </div>
-              </div>
-            )}
-
-            {/* Description */}
-            {event.description && (
-              <div className="flex items-start gap-3 text-sm">
-                <AlignLeft className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
-                <div
-                  className="prose prose-sm max-w-none text-foreground/90"
-                  // Description from external calendars is HTML in some
-                  // providers (Google in particular). We render it as
-                  // text — full HTML rendering would require sanitising
-                  // through the same path as Tiptap content does and
-                  // isn't worth the surface area for read-only display.
-                >
-                  {event.description}
-                </div>
-              </div>
-            )}
-
-            <div className="border-t pt-5 space-y-2">
-              <Button
-                onClick={handleCreateTask}
-                disabled={!onCreateTask}
-                className="w-full justify-start"
-                variant="default"
-              >
-                <Plus className="mr-2 h-4 w-4" />
-                Create task from event
-              </Button>
-              {event.htmlLink && (
-                <Button
-                  onClick={handleOpenInProvider}
-                  className="w-full justify-start"
-                  variant="outline"
-                >
-                  <ExternalLinkIcon className="mr-2 h-4 w-4" />
-                  Open in calendar provider
-                </Button>
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent className="w-full sm:max-w-md overflow-y-auto">
+          <SheetHeader className="space-y-3">
+            <div className="flex items-start gap-2">
+              <div
+                className="mt-1 h-3 w-3 flex-shrink-0 rounded-full"
+                style={{ backgroundColor: color }}
+                aria-hidden
+              />
+              {isEditing && editState ? (
+                <Input
+                  value={editState.title}
+                  onChange={(e) =>
+                    setEditState({ ...editState, title: e.target.value })
+                  }
+                  placeholder="Event title"
+                  className="h-9 text-base font-semibold"
+                  disabled={isMutating}
+                  autoFocus
+                />
+              ) : (
+                <SheetTitle className="text-base font-semibold leading-snug">
+                  {event?.title || "Untitled event"}
+                </SheetTitle>
               )}
             </div>
+            <div
+              className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium"
+              style={{ backgroundColor: hexToRgba(color, 0.1) }}
+            >
+              <CalendarDays
+                className="h-3 w-3"
+                style={{ color }}
+                aria-hidden
+              />
+              <span style={{ color: hexToRgba(color, 1) }}>{calendarName}</span>
+              {event?.responseStatus && (
+                <span className="ml-auto text-muted-foreground">
+                  {event.responseStatus === "accepted" && "Going"}
+                  {event.responseStatus === "declined" && "Declined"}
+                  {event.responseStatus === "tentative" && "Maybe"}
+                  {event.responseStatus === "needsAction" && "Awaiting reply"}
+                </span>
+              )}
+            </div>
+          </SheetHeader>
 
-            {/* Footer note: editing comes in a follow-up */}
-            <p className="pt-2 text-[11px] text-muted-foreground/70">
-              Editing and deleting events sync back to your calendar
-              provider — coming soon.
-            </p>
+          {event && (
+            <div className="mt-6 space-y-5">
+              {isEditing && editState ? (
+                <EditForm
+                  state={editState}
+                  setState={setEditState}
+                  disabled={isMutating}
+                />
+              ) : (
+                <ViewBody event={event} />
+              )}
+
+              <div className="border-t pt-5 space-y-2">
+                {isEditing ? (
+                  <>
+                    <Button
+                      onClick={handleSave}
+                      disabled={isMutating}
+                      className="w-full justify-center"
+                      variant="default"
+                    >
+                      {updateMutation.isPending && (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      )}
+                      Save changes
+                    </Button>
+                    <Button
+                      onClick={handleCancelEdit}
+                      disabled={isMutating}
+                      className="w-full justify-center"
+                      variant="outline"
+                    >
+                      Cancel
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    {canEdit && (
+                      <Button
+                        onClick={handleStartEdit}
+                        className="w-full justify-start"
+                        variant="default"
+                      >
+                        <Pencil className="mr-2 h-4 w-4" />
+                        Edit event
+                      </Button>
+                    )}
+                    <Button
+                      onClick={handleCreateTask}
+                      disabled={!onCreateTask}
+                      className="w-full justify-start"
+                      variant={canEdit ? "outline" : "default"}
+                    >
+                      <Plus className="mr-2 h-4 w-4" />
+                      Create task from event
+                    </Button>
+                    {event.htmlLink && (
+                      <Button
+                        onClick={handleOpenInProvider}
+                        className="w-full justify-start"
+                        variant="outline"
+                      >
+                        <ExternalLinkIcon className="mr-2 h-4 w-4" />
+                        Open in calendar provider
+                      </Button>
+                    )}
+                    {canEdit && (
+                      <Button
+                        onClick={() => setConfirmDeleteOpen(true)}
+                        className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
+                        variant="ghost"
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Delete event
+                      </Button>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {!canEdit && !isEditing && (
+                <p className="pt-2 text-[11px] text-muted-foreground/70">
+                  This calendar is read-only — events can't be edited or
+                  deleted from here.
+                </p>
+              )}
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <Dialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete this event?</DialogTitle>
+            <DialogDescription>
+              This will remove the event from your calendar provider too.
+              This action can't be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDeleteOpen(false)}
+              disabled={deleteMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function ViewBody({ event }: { event: CalendarEvent }) {
+  return (
+    <>
+      <div className="flex items-start gap-3 text-sm">
+        <Clock className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+        <div className="text-foreground/90">{formatEventTime(event)}</div>
+      </div>
+      {event.location && (
+        <div className="flex items-start gap-3 text-sm">
+          <MapPin className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+          <div className="text-foreground/90 break-words">
+            {event.location}
           </div>
-        )}
-      </SheetContent>
-    </Sheet>
+        </div>
+      )}
+      {event.description && (
+        <div className="flex items-start gap-3 text-sm">
+          <AlignLeft className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+          <div className="prose prose-sm max-w-none text-foreground/90 whitespace-pre-wrap break-words">
+            {event.description}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function EditForm({
+  state,
+  setState,
+  disabled,
+}: {
+  state: EditableState;
+  setState: (next: EditableState) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <Label htmlFor="event-allday" className="text-sm font-medium">
+          All-day
+        </Label>
+        <Switch
+          id="event-allday"
+          checked={state.isAllDay}
+          disabled={disabled}
+          onCheckedChange={(next) => {
+            // Switching to/from all-day reformats the start/end inputs to
+            // the right type. Convert the existing values across so we
+            // don't lose the user's chosen dates.
+            if (next === state.isAllDay) return;
+            const startDate = next
+              ? toAllDayInputValue(
+                  state.start
+                    ? new Date(`${parseISO(state.start).toISOString()}`)
+                    : new Date()
+                )
+              : toLocalInputValue(
+                  state.start ? fromAllDayInputValue(state.start) : new Date()
+                );
+            const endDate = next
+              ? toAllDayInputValue(
+                  state.end
+                    ? new Date(`${parseISO(state.end).toISOString()}`)
+                    : new Date()
+                )
+              : toLocalInputValue(
+                  state.end ? fromAllDayInputValue(state.end) : new Date()
+                );
+            setState({
+              ...state,
+              isAllDay: next,
+              start: startDate,
+              end: endDate,
+            });
+          }}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="event-start" className="text-xs text-muted-foreground">
+            Starts
+          </Label>
+          <Input
+            id="event-start"
+            type={state.isAllDay ? "date" : "datetime-local"}
+            value={state.start}
+            disabled={disabled}
+            onChange={(e) => setState({ ...state, start: e.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="event-end" className="text-xs text-muted-foreground">
+            Ends
+          </Label>
+          <Input
+            id="event-end"
+            type={state.isAllDay ? "date" : "datetime-local"}
+            value={state.end}
+            disabled={disabled}
+            onChange={(e) => setState({ ...state, end: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="event-location" className="text-xs text-muted-foreground">
+          Location
+        </Label>
+        <Input
+          id="event-location"
+          value={state.location}
+          disabled={disabled}
+          placeholder="Add location"
+          onChange={(e) => setState({ ...state, location: e.target.value })}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="event-description" className="text-xs text-muted-foreground">
+          Description
+        </Label>
+        <Textarea
+          id="event-description"
+          value={state.description}
+          disabled={disabled}
+          placeholder="Add notes"
+          rows={4}
+          onChange={(e) => setState({ ...state, description: e.target.value })}
+        />
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
+++ b/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { format, isSameDay, parseISO } from "date-fns";
+import { format, isSameDay } from "date-fns";
 import {
   CalendarDays,
   Clock,
@@ -127,6 +127,18 @@ function fromAllDayInputValue(s: string): Date {
 
 function toAllDayInputValue(d: Date): string {
   return d.toISOString().slice(0, 10);
+}
+
+/**
+ * UTC midnight projection of *today's local date* — used as the default
+ * value for an empty all-day input when toggling. We pick today as the
+ * sensible default if no value is present.
+ */
+function localMidnightTodayUtc(): Date {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0)
+  );
 }
 
 interface EditableState {
@@ -547,32 +559,33 @@ function EditForm({
           disabled={disabled}
           onCheckedChange={(next) => {
             // Switching to/from all-day reformats the start/end inputs to
-            // the right type. Convert the existing values across so we
-            // don't lose the user's chosen dates.
+            // the right type. Crucially, do NOT round-trip through
+            // UTC — toISOString.slice(0,10) shifts the date by one for
+            // users far enough from UTC. Pull the YYYY-MM-DD prefix
+            // straight from the local datetime-local string when going
+            // timed → all-day, and re-anchor at 09:00 local when going
+            // all-day → timed (sensible default for "what time?").
             if (next === state.isAllDay) return;
-            const startDate = next
-              ? toAllDayInputValue(
-                  state.start
-                    ? new Date(`${parseISO(state.start).toISOString()}`)
-                    : new Date()
-                )
-              : toLocalInputValue(
-                  state.start ? fromAllDayInputValue(state.start) : new Date()
-                );
-            const endDate = next
-              ? toAllDayInputValue(
-                  state.end
-                    ? new Date(`${parseISO(state.end).toISOString()}`)
-                    : new Date()
-                )
-              : toLocalInputValue(
-                  state.end ? fromAllDayInputValue(state.end) : new Date()
-                );
+            const datePart = (s: string) => s.slice(0, 10);
+            const newStart = next
+              ? state.start
+                ? datePart(state.start)
+                : toAllDayInputValue(localMidnightTodayUtc())
+              : state.start
+                ? `${state.start}T09:00`
+                : toLocalInputValue(new Date());
+            const newEnd = next
+              ? state.end
+                ? datePart(state.end)
+                : toAllDayInputValue(localMidnightTodayUtc())
+              : state.end
+                ? `${state.end}T10:00`
+                : toLocalInputValue(new Date());
             setState({
               ...state,
               isAllDay: next,
-              start: startDate,
-              end: endDate,
+              start: newStart,
+              end: newEnd,
             });
           }}
         />

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -30,7 +30,11 @@ import {
   useCascadeResizeTimeBlock,
 } from "@/hooks";
 import { useAuth } from "@/hooks/useAuth";
-import { useCalendarEvents, useCalendars } from "@/hooks/useCalendars";
+import {
+  useCalendarEvents,
+  useCalendars,
+  useCalendarAccounts,
+} from "@/hooks/useCalendars";
 import { useCalendarDnd } from "@/hooks/useCalendarDnd";
 import { Timeline } from "./timeline";
 import { MultiDayView } from "./multi-day-view";
@@ -217,16 +221,34 @@ export function CalendarView({
   const toDate = range.end.toISOString();
   const { data: calendarEvents = [] } = useCalendarEvents(fromDate, toDate);
 
-  // Per-calendar read-only flag — used by the detail sheet to gate the
-  // edit / delete affordances. We look it up by the selected event's
-  // calendarId rather than embedding it on the event payload to avoid
-  // a wider API change.
+  // Per-calendar capability map — used by the detail sheet to gate the
+  // edit / delete affordances. A calendar is editable if (a) the
+  // provider supports write-back AND (b) the calendar isn't flagged
+  // read-only by the provider itself (subscriptions, holidays, etc.).
+  // Provider info lives on the account; we resolve via accountId.
   const { data: calendarsList = [] } = useCalendars();
+  const { data: calendarAccounts = [] } = useCalendarAccounts();
+  const accountProviderById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const a of calendarAccounts) m.set(a.id, a.provider);
+    return m;
+  }, [calendarAccounts]);
+  const PROVIDERS_WITH_WRITE_BACK = React.useMemo(
+    () => new Set(["google"]),
+    []
+  );
   const calendarReadOnlyById = React.useMemo(() => {
     const m = new Map<string, boolean>();
-    for (const c of calendarsList) m.set(c.id, c.isReadOnly);
+    for (const c of calendarsList) {
+      const provider = accountProviderById.get(c.accountId);
+      const writable =
+        !!provider &&
+        PROVIDERS_WITH_WRITE_BACK.has(provider) &&
+        !c.isReadOnly;
+      m.set(c.id, !writable);
+    }
     return m;
-  }, [calendarsList]);
+  }, [calendarsList, accountProviderById, PROVIDERS_WITH_WRITE_BACK]);
 
   // Mutations
   const createTimeBlock = useCreateTimeBlock();

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -30,7 +30,7 @@ import {
   useCascadeResizeTimeBlock,
 } from "@/hooks";
 import { useAuth } from "@/hooks/useAuth";
-import { useCalendarEvents } from "@/hooks/useCalendars";
+import { useCalendarEvents, useCalendars } from "@/hooks/useCalendars";
 import { useCalendarDnd } from "@/hooks/useCalendarDnd";
 import { Timeline } from "./timeline";
 import { MultiDayView } from "./multi-day-view";
@@ -216,6 +216,17 @@ export function CalendarView({
   const fromDate = range.start.toISOString();
   const toDate = range.end.toISOString();
   const { data: calendarEvents = [] } = useCalendarEvents(fromDate, toDate);
+
+  // Per-calendar read-only flag — used by the detail sheet to gate the
+  // edit / delete affordances. We look it up by the selected event's
+  // calendarId rather than embedding it on the event payload to avoid
+  // a wider API change.
+  const { data: calendarsList = [] } = useCalendars();
+  const calendarReadOnlyById = React.useMemo(() => {
+    const m = new Map<string, boolean>();
+    for (const c of calendarsList) m.set(c.id, c.isReadOnly);
+    return m;
+  }, [calendarsList]);
 
   // Mutations
   const createTimeBlock = useCreateTimeBlock();
@@ -526,6 +537,15 @@ export function CalendarView({
         open={externalEventSheetOpen}
         onOpenChange={handleExternalEventSheetOpenChange}
         onCreateTask={handleCreateTaskFromEvent}
+        rangeFrom={fromDate}
+        rangeTo={toDate}
+        calendarReadOnly={
+          selectedExternalEvent
+            ? (calendarReadOnlyById.get(
+                selectedExternalEvent.calendarId
+              ) ?? true)
+            : true
+        }
       />
 
       {/* Add task modal pre-filled from a calendar event */}

--- a/apps/web/src/hooks/useCalendars.ts
+++ b/apps/web/src/hooks/useCalendars.ts
@@ -215,6 +215,170 @@ export function useConnectICloud() {
 }
 
 /**
+ * Patch shape accepted by useUpdateCalendarEvent. Times are local Date
+ * objects on the wire; the hook serialises them to ISO 8601.
+ */
+export interface UpdateCalendarEventInput {
+  id: string;
+  /**
+   * The from/to range the event currently appears in. We use this to
+   * scope the optimistic update to the right cache key. Without it the
+   * update would only land after a refetch.
+   */
+  rangeFrom: string;
+  rangeTo: string;
+  patch: {
+    title?: string;
+    description?: string | null;
+    location?: string | null;
+    startTime?: Date;
+    endTime?: Date;
+    isAllDay?: boolean;
+    timezone?: string | null;
+  };
+}
+
+/**
+ * Edit an external calendar event in place. The change is sent upstream
+ * to the provider (Google, etc.) and the local cache is optimistically
+ * updated so the UI reflects the new value immediately. If the upstream
+ * write fails, the optimistic change is rolled back.
+ */
+export function useUpdateCalendarEvent() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      patch,
+    }: UpdateCalendarEventInput): Promise<CalendarEvent> => {
+      const client = getApiClient();
+      const body: Record<string, unknown> = {};
+      if (patch.title !== undefined) body.title = patch.title;
+      if (patch.description !== undefined) body.description = patch.description;
+      if (patch.location !== undefined) body.location = patch.location;
+      if (patch.startTime !== undefined) {
+        body.startTime = patch.startTime.toISOString();
+      }
+      if (patch.endTime !== undefined) {
+        body.endTime = patch.endTime.toISOString();
+      }
+      if (patch.isAllDay !== undefined) body.isAllDay = patch.isAllDay;
+      if (patch.timezone !== undefined) body.timezone = patch.timezone;
+
+      const response = await client.patch<{ success: boolean; data: CalendarEvent }>(
+        `calendar-events/${id}`,
+        body
+      );
+      return response.data;
+    },
+    onMutate: async (input) => {
+      const key = calendarKeys.events(input.rangeFrom, input.rangeTo);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<CalendarEvent[]>(key);
+      if (previous) {
+        const next: CalendarEvent[] = previous.map((ev) => {
+          if (ev.id !== input.id) return ev;
+          // The server-side type uses ISO strings on the wire (Date in
+          // TS but the JSON layer stringifies). Match that here so the
+          // optimistic value is shape-compatible with the refetch.
+          const merged: CalendarEvent = { ...ev };
+          if (input.patch.title !== undefined) merged.title = input.patch.title;
+          if (input.patch.description !== undefined) {
+            merged.description = input.patch.description;
+          }
+          if (input.patch.location !== undefined) {
+            merged.location = input.patch.location;
+          }
+          if (input.patch.startTime !== undefined) {
+            (merged as unknown as { startTime: string }).startTime =
+              input.patch.startTime.toISOString();
+          }
+          if (input.patch.endTime !== undefined) {
+            (merged as unknown as { endTime: string }).endTime =
+              input.patch.endTime.toISOString();
+          }
+          if (input.patch.isAllDay !== undefined) {
+            merged.isAllDay = input.patch.isAllDay;
+          }
+          if (input.patch.timezone !== undefined) {
+            merged.timezone = input.patch.timezone;
+          }
+          return merged;
+        });
+        queryClient.setQueryData<CalendarEvent[]>(key, next);
+      }
+      return { previous, key };
+    },
+    onError: (error, _input, context) => {
+      // Roll back the optimistic change so the UI reflects reality.
+      if (context?.previous) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+      toast({
+        variant: "destructive",
+        title: "Failed to update event",
+        description: error instanceof Error ? error.message : "Unknown error",
+      });
+    },
+    onSettled: (_data, _err, input) => {
+      // Always re-fetch so the canonical server state lands. This also
+      // covers the case where the event moved out of the visible range.
+      queryClient.invalidateQueries({
+        queryKey: calendarKeys.events(input.rangeFrom, input.rangeTo),
+      });
+    },
+  });
+}
+
+/**
+ * Delete an external calendar event upstream + locally.
+ */
+export function useDeleteCalendarEvent() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+    }: {
+      id: string;
+      rangeFrom: string;
+      rangeTo: string;
+    }): Promise<void> => {
+      const client = getApiClient();
+      await client.delete(`calendar-events/${id}`);
+    },
+    onMutate: async (input) => {
+      const key = calendarKeys.events(input.rangeFrom, input.rangeTo);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<CalendarEvent[]>(key);
+      if (previous) {
+        queryClient.setQueryData<CalendarEvent[]>(
+          key,
+          previous.filter((ev) => ev.id !== input.id)
+        );
+      }
+      return { previous, key };
+    },
+    onError: (error, _input, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+      toast({
+        variant: "destructive",
+        title: "Failed to delete event",
+        description: error instanceof Error ? error.message : "Unknown error",
+      });
+    },
+    onSettled: (_data, _err, input) => {
+      queryClient.invalidateQueries({
+        queryKey: calendarKeys.events(input.rangeFrom, input.rangeTo),
+      });
+    },
+  });
+}
+
+/**
  * Initiate OAuth flow for a calendar provider
  * Calls the API with auth to get the OAuth URL, then redirects
  */

--- a/apps/web/src/hooks/useWebSocket.ts
+++ b/apps/web/src/hooks/useWebSocket.ts
@@ -202,8 +202,14 @@ function handleWebSocketEvent(
     case "calendar:synced":
     case "calendar:account-disconnected":
     case "calendar:updated":
+    // Per-event mutations from another tab / device land here. We
+    // refetch the same calendar sub-tree as a sync — the events
+    // query keys are scoped by date range so a global refetch is
+    // the simplest correct behavior.
+    case "calendar-event:updated":
+    case "calendar-event:deleted":
       // calendarKeys.all is the prefix for accounts/list/events, so this
-      // single refetch covers all three sub-trees.
+      // single refetch covers all sub-trees.
       queryClient.refetchQueries({ queryKey: calendarKeys.all });
       break;
   }

--- a/apps/web/src/lib/websocket/index.ts
+++ b/apps/web/src/lib/websocket/index.ts
@@ -19,6 +19,8 @@ export type WebSocketEventType =
   | "calendar:synced"
   | "calendar:account-disconnected"
   | "calendar:updated"
+  | "calendar-event:updated"
+  | "calendar-event:deleted"
   | "user:updated"
   | "connected";
 


### PR DESCRIPTION
## Summary

Phase 3 of the calendar overhaul. The detail sheet was read-only; users could only "Open in Google" or convert to a task. Now they can edit and delete events in place — the change is sent upstream to the provider and the local cache is optimistically updated so the UI reflects it instantly.

Google is supported in this PR. Outlook and iCloud are explicitly gated as read-only-from-the-app's-POV until their providers learn write-back, so users don't discover the limit only after hitting Save.

## What's new

- **API:** New \`updateEvent\` / \`deleteEvent\` methods on the provider contract, implemented for Google. \`PATCH /calendar-events/:id\` and \`DELETE /calendar-events/:id\` enforce per-user / per-calendar permissions, refresh OAuth tokens if needed, push to the provider, then write-through to the local DB with the canonical post-write payload. 409 Conflict for read-only calendars or providers without write support; 502 Bad Gateway for provider errors.
- **Realtime:** Two new WebSocket event types (\`calendar-event:updated\` / \`calendar-event:deleted\`) added to both server and client unions; client switch refetches the calendar sub-tree so other tabs / devices stay in sync.
- **Web:** \`useUpdateCalendarEvent\` and \`useDeleteCalendarEvent\` hooks with optimistic cache updates scoped to the visible date range; rollback on error; settled invalidate so the canonical state always lands.
- **UI:** \`CalendarEventDetailSheet\` toggles between view + edit modes. Edit mode has form controls for title, all-day toggle, start, end, location, description. Save / Cancel + Delete (with confirm dialog). Edit / Delete affordances are hidden when the calendar is provider-read-only or hosted on a non-Google account.

## Bugs caught + fixed in the verifier loop

- **TZ all-day toggle** was round-tripping through UTC midnight; users far from UTC saw the displayed date jump by ±1 day. Fix takes the YYYY-MM-DD prefix straight from local datetime-local strings and re-anchors at sensible defaults when going the other way.
- **Outlook / iCloud UX trap** where Edit / Delete showed for any non-read-only calendar but failed at Save with a 409 — now hidden client-side via a provider capability map.
- **Missing client WS handlers** for the two new event types — added.

## Test plan

- [ ] Edit a Google event title; sheet shows new value immediately; refresh confirms persistence.
- [ ] Edit start / end times; Google Calendar UI shows the new times.
- [ ] Toggle a Google event between all-day and timed; saves correctly without TZ shift.
- [ ] Delete a Google event; confirm dialog appears; on confirm, event disappears from the calendar; verify in Google Calendar UI.
- [ ] Open an Outlook or iCloud event: only "Open in provider" + "Create task from event" shown — no Edit/Delete buttons; read-only note visible.
- [ ] Open a holiday / subscription calendar event (\`isReadOnly=true\`): same as above — read-only.
- [ ] Force a network error mid-save: optimistic change reverts; toast appears.
- [ ] In two tabs: edit in one; the other refetches and shows the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)