### PR TITLE
fix(calendar): overlap layout + multi-day spans + 3-day weekday + drop provider link

### DIFF
--- a/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
+++ b/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
@@ -3,7 +3,6 @@ import { format, isSameDay } from "date-fns";
 import {
   CalendarDays,
   Clock,
-  ExternalLink as ExternalLinkIcon,
   MapPin,
   Plus,
   AlignLeft,
@@ -222,12 +221,6 @@ export function CalendarEventDetailSheet({
   const calendarName = event?.calendar?.name ?? "External calendar";
   const canEdit = !!event && !calendarReadOnly;
 
-  const handleOpenInProvider = () => {
-    if (event?.htmlLink) {
-      window.open(event.htmlLink, "_blank", "noopener,noreferrer");
-    }
-  };
-
   const handleCreateTask = () => {
     if (event && onCreateTask) {
       onCreateTask(event);
@@ -442,16 +435,10 @@ export function CalendarEventDetailSheet({
                       <Plus className="mr-2 h-4 w-4" />
                       Create task from event
                     </Button>
-                    {event.htmlLink && (
-                      <Button
-                        onClick={handleOpenInProvider}
-                        className="w-full justify-start"
-                        variant="outline"
-                      >
-                        <ExternalLinkIcon className="mr-2 h-4 w-4" />
-                        Open in calendar provider
-                      </Button>
-                    )}
+                    {/* Intentionally no "Open in provider" link — the
+                        in-app sheet supports full edit/delete and is
+                        the canonical surface. Bouncing out to Google /
+                        Outlook would split the user's mental model. */}
                     {canEdit && (
                       <Button
                         onClick={() => setConfirmDeleteOpen(true)}

--- a/apps/web/src/components/calendar/event-layout.ts
+++ b/apps/web/src/components/calendar/event-layout.ts
@@ -1,0 +1,130 @@
+/**
+ * Side-by-side overlap layout for calendar items.
+ *
+ * Solves the classic "Google Calendar problem": when N events overlap at
+ * the same time, they should split the available column width into N
+ * sub-columns rather than stacking on top of each other.
+ *
+ * The algorithm is the standard interval-graph greedy column packer:
+ *
+ *   1. Sort items by start time, with the longer event first as a
+ *      tiebreaker so the wider time-slot owners get the leftmost lane.
+ *   2. Walk items in order. For each one, assign it to the lowest-index
+ *      "lane" (column) that doesn't conflict in time with any other
+ *      item already placed in that lane.
+ *   3. Group items into "clusters" — chains where every member overlaps
+ *      with at least one other in the chain. Within a cluster, every
+ *      item shares the same `columnCount` (= the maximum number of
+ *      lanes used at any point in the cluster).
+ *
+ * The rendered position is then:
+ *   left  = (lane / columnCount) * 100%
+ *   width = (1 / columnCount) * 100%
+ *
+ * This component-level utility is intentionally narrow: it accepts a
+ * minimal `LayoutItem` shape (id, start, end) so both `CalendarEvent`
+ * and `TimeBlock` can be packed together — they visually compete for
+ * the same column real estate.
+ */
+
+export interface LayoutItem {
+  id: string;
+  start: Date;
+  end: Date;
+}
+
+export interface LayoutResult {
+  /** Zero-based lane index within the cluster. */
+  lane: number;
+  /** Total lanes used by the cluster this item belongs to. */
+  columnCount: number;
+}
+
+/**
+ * Compute layout positions for a list of overlapping items. Returns a
+ * Map from item id → { lane, columnCount } so callers can look up
+ * positioning info without re-iterating the input order.
+ *
+ * Items that don't overlap with anything get { lane: 0, columnCount: 1 }
+ * and so render at full width.
+ */
+export function layoutOverlappingItems(
+  items: LayoutItem[]
+): Map<string, LayoutResult> {
+  const result = new Map<string, LayoutResult>();
+  if (items.length === 0) return result;
+
+  // Sort by start time, longer-first as tiebreaker. Longer events first
+  // means a 2-hour 9am event keeps the leftmost lane against a 30-min
+  // 9am event — matches Google Calendar's visual grouping.
+  const sorted = [...items].sort((a, b) => {
+    const startDiff = a.start.getTime() - b.start.getTime();
+    if (startDiff !== 0) return startDiff;
+    return b.end.getTime() - a.end.getTime();
+  });
+
+  // A "cluster" is a contiguous group of items where every member
+  // overlaps with at least one other member. Items in a cluster share
+  // a column count.
+  let cluster: LayoutItem[] = [];
+  let clusterEnd = -Infinity; // The latest end time seen in the cluster
+
+  const flushCluster = () => {
+    if (cluster.length === 0) return;
+    const placements = packCluster(cluster);
+    const columnCount = Math.max(
+      1,
+      ...placements.map((p) => p.lane + 1)
+    );
+    for (const p of placements) {
+      result.set(p.id, { lane: p.lane, columnCount });
+    }
+    cluster = [];
+    clusterEnd = -Infinity;
+  };
+
+  for (const item of sorted) {
+    if (item.start.getTime() >= clusterEnd) {
+      // No overlap with the current cluster — start a fresh one.
+      flushCluster();
+    }
+    cluster.push(item);
+    clusterEnd = Math.max(clusterEnd, item.end.getTime());
+  }
+  flushCluster();
+
+  return result;
+}
+
+/**
+ * Pack a single cluster of overlapping items into lanes. Each item is
+ * placed in the lowest-index lane whose tail (last placed item's end)
+ * is ≤ the new item's start.
+ */
+function packCluster(
+  items: LayoutItem[]
+): Array<{ id: string; lane: number }> {
+  // laneEnds[i] = the end-time of the latest item assigned to lane i.
+  const laneEnds: number[] = [];
+  const placements: Array<{ id: string; lane: number }> = [];
+
+  for (const item of items) {
+    const startMs = item.start.getTime();
+    let lane = -1;
+    for (let i = 0; i < laneEnds.length; i++) {
+      if (laneEnds[i]! <= startMs) {
+        lane = i;
+        break;
+      }
+    }
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(item.end.getTime());
+    } else {
+      laneEnds[lane] = item.end.getTime();
+    }
+    placements.push({ id: item.id, lane });
+  }
+
+  return placements;
+}

--- a/apps/web/src/components/calendar/external-event.tsx
+++ b/apps/web/src/components/calendar/external-event.tsx
@@ -19,6 +19,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui";
+import type { LayoutResult } from "./event-layout";
+
+const COLUMN_GAP_PCT = 1; // gap between side-by-side overlapping events
 
 interface ExternalEventProps {
   event: CalendarEvent;
@@ -28,6 +31,12 @@ interface ExternalEventProps {
    * Y = "23:00 of Tuesday" on Tuesday's view (off-screen at the bottom).
    */
   displayDate: Date;
+  /**
+   * Lane assignment from the side-by-side overlap layout. When N items
+   * overlap at the same time slot, they split the column into N
+   * sub-columns and each item renders in its assigned lane.
+   */
+  layout?: LayoutResult;
   onClick?: () => void;
   className?: string;
 }
@@ -61,6 +70,7 @@ function getEventColor(event: CalendarEvent): string {
 export function ExternalEvent({
   event,
   displayDate,
+  layout = { lane: 0, columnCount: 1 },
   onClick,
   className,
 }: ExternalEventProps) {
@@ -109,14 +119,21 @@ export function ExternalEvent({
           <div
             data-external-event
             className={cn(
-              "absolute left-1 right-1 z-5 my-0.5 rounded-md border-l-[3px] transition-all select-none",
-              "hover:brightness-90 hover:z-15",
+              "absolute z-[5] my-0.5 rounded-md border-l-[3px] transition-all select-none",
+              "hover:brightness-90 hover:z-[15]",
               "cursor-pointer",
               className
             )}
             style={{
               top: `${top}px`,
               height: `${Math.max(height - 4, 20)}px`, // Account for margin
+              // Side-by-side overlap layout: split column into
+              // layout.columnCount lanes; this event lives in lane N.
+              // 4px gutter on the leftmost lane (matches the prior
+              // `left-1 right-1` look when no overlap), tighter gaps
+              // between sub-columns to keep them visually distinct.
+              left: `calc(${(100 / layout.columnCount) * layout.lane}% + ${layout.lane === 0 ? "4px" : "1px"})`,
+              width: `calc(${100 / layout.columnCount - COLUMN_GAP_PCT}% - ${layout.lane === 0 ? "4px" : "1px"})`,
               backgroundColor: hexToRgba(color, 0.1),
               borderColor: hexToRgba(color, 0.5),
             }}

--- a/apps/web/src/components/calendar/multi-day-view.tsx
+++ b/apps/web/src/components/calendar/multi-day-view.tsx
@@ -17,6 +17,18 @@ import {
   TIMELINE_END_HOUR,
   calculateYFromTime,
 } from "@/hooks/useCalendarDnd";
+import { layoutOverlappingItems, type LayoutResult } from "./event-layout";
+
+/**
+ * When N items overlap we split the column into N sub-columns, but we
+ * leave a tiny gap between them so they remain visually distinct rather
+ * than one continuous block. Tuned so 7-day week view at 50px/col still
+ * shows separation.
+ */
+const COLUMN_GAP_PCT = 1; // %
+
+/** Fallback when a layout entry isn't found (defensive). */
+const DEFAULT_LAYOUT: LayoutResult = { lane: 0, columnCount: 1 };
 
 interface MultiDayViewProps {
   /** Ordered list of dates to render as columns */
@@ -46,6 +58,27 @@ interface DayColumnEvents {
   timed: CalendarEvent[];
   allDay: CalendarEvent[];
   blocks: TimeBlock[];
+}
+
+/** A multi-day all-day event laid out as a horizontal bar in the banner. */
+interface AllDaySpan {
+  event: CalendarEvent;
+  /** First visible-day index this event covers. */
+  startIdx: number;
+  /** Last visible-day index this event covers (inclusive). */
+  endIdx: number;
+  /** Number of days the bar spans (endIdx - startIdx + 1). */
+  length: number;
+}
+
+/** YYYY-MM-DD via local components — for cell dates the user sees. */
+function localDateString(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/** YYYY-MM-DD via UTC components — for all-day events stored at UTC midnight. */
+function utcDateString(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
 }
 
 function bucketEventsForDay(
@@ -101,10 +134,12 @@ function bucketEventsForDay(
 function MultiDayEvent({
   event,
   displayDate,
+  layout,
   onClick,
 }: {
   event: CalendarEvent;
   displayDate: Date;
+  layout: LayoutResult;
   onClick?: () => void;
 }) {
   const startTime = new Date(event.startTime);
@@ -118,13 +153,19 @@ function MultiDayEvent({
   const height = (durationMins / 60) * HOUR_HEIGHT;
   const color = event.calendar?.color ?? "#6B7280";
 
+  // Split-column geometry: leftmost lane sits at lane/N of column width.
+  const widthPct = 100 / layout.columnCount - COLUMN_GAP_PCT;
+  const leftPct = (100 / layout.columnCount) * layout.lane;
+
   return (
     <div
       data-external-event
-      className="absolute left-0.5 right-0.5 z-[5] my-0.5 rounded border-l-[2px] cursor-pointer hover:brightness-90 transition-all overflow-hidden px-1 py-0.5"
+      className="absolute z-[5] my-0.5 rounded border-l-[2px] cursor-pointer hover:brightness-90 hover:z-[15] transition-all overflow-hidden px-1 py-0.5"
       style={{
         top: `${top}px`,
         height: `${Math.max(height - 2, 16)}px`,
+        left: `${leftPct}%`,
+        width: `${widthPct}%`,
         backgroundColor: hexToRgba(color, 0.12),
         borderColor: hexToRgba(color, 0.55),
       }}
@@ -166,10 +207,12 @@ function hexToRgba(hex: string, alpha: number): string {
 function MultiDayBlock({
   block,
   displayDate,
+  layout,
   onClick,
 }: {
   block: TimeBlock;
   displayDate: Date;
+  layout: LayoutResult;
   onClick?: () => void;
 }) {
   const startTime = new Date(block.startTime);
@@ -183,13 +226,18 @@ function MultiDayBlock({
   const height = (durationMins / 60) * HOUR_HEIGHT;
   const color = block.color ?? "#3B82F6";
 
+  const widthPct = 100 / layout.columnCount - COLUMN_GAP_PCT;
+  const leftPct = (100 / layout.columnCount) * layout.lane;
+
   return (
     <div
       data-time-block
-      className="absolute left-0.5 right-0.5 z-10 my-0.5 rounded cursor-pointer hover:brightness-90 transition-all overflow-hidden px-1 py-0.5"
+      className="absolute z-10 my-0.5 rounded cursor-pointer hover:brightness-90 hover:z-20 transition-all overflow-hidden px-1 py-0.5"
       style={{
         top: `${top}px`,
         height: `${Math.max(height - 2, 16)}px`,
+        left: `${leftPct}%`,
+        width: `${widthPct}%`,
         backgroundColor: hexToRgba(color, 0.85),
         color: "white",
       }}
@@ -246,8 +294,100 @@ export function MultiDayView({
     [days, calendarEvents, timeBlocks]
   );
 
-  // Aggregate all-day events row across columns
-  const hasAnyAllDay = dayBuckets.some((b) => b.allDay.length > 0);
+  // Per-day timed-event + block layout. Both kinds compete for column
+  // real estate (they overlap visually), so we pack them into the same
+  // lane assignment. The combined-id keys make the result lookup
+  // unambiguous when an event id and a block id collide.
+  const dayLayouts = React.useMemo(() => {
+    return dayBuckets.map((bucket, i) => {
+      const day = days[i]!;
+      const dayStart = startOfDay(day);
+      const dayEnd = endOfDay(day);
+      const items = [
+        ...bucket.timed.map((e) => {
+          const s = new Date(e.startTime);
+          const en = new Date(e.endTime);
+          return {
+            id: `event:${e.id}`,
+            start: s < dayStart ? dayStart : s,
+            end: en > dayEnd ? dayEnd : en,
+          };
+        }),
+        ...bucket.blocks.map((b) => {
+          const s = new Date(b.startTime);
+          const en = new Date(b.endTime);
+          return {
+            id: `block:${b.id}`,
+            start: s < dayStart ? dayStart : s,
+            end: en > dayEnd ? dayEnd : en,
+          };
+        }),
+      ];
+      return layoutOverlappingItems(items);
+    });
+  }, [dayBuckets, days]);
+
+  // All-day banner: render multi-day spans as single horizontal bars
+  // across the columns they cover, with lane stacking when bars overlap.
+  // We deduplicate the events first (an event spans multiple day buckets
+  // but is a single entity), then compute each event's start-day-index +
+  // span-length within the visible range.
+  const allDaySpans = React.useMemo(() => {
+    const seen = new Map<string, CalendarEvent>();
+    for (const b of dayBuckets) {
+      for (const e of b.allDay) seen.set(e.id, e);
+    }
+    if (seen.size === 0) {
+      return { lanes: [] as Array<Array<AllDaySpan>>, count: 0 };
+    }
+    type Span = AllDaySpan;
+    const spans: Span[] = [];
+    for (const event of seen.values()) {
+      const startDateStr = utcDateString(new Date(event.startTime));
+      const endDateStr = utcDateString(new Date(event.endTime));
+      // Find first / last visible-day index covered by this event.
+      let firstIdx = -1;
+      let lastIdx = -1;
+      for (let i = 0; i < days.length; i++) {
+        const d = localDateString(days[i]!);
+        // Event covers day d if startDateStr ≤ d < endDateStr
+        if (d >= startDateStr && d < endDateStr) {
+          if (firstIdx === -1) firstIdx = i;
+          lastIdx = i;
+        }
+      }
+      if (firstIdx === -1) continue;
+      spans.push({
+        event,
+        startIdx: firstIdx,
+        endIdx: lastIdx,
+        length: lastIdx - firstIdx + 1,
+      });
+    }
+    // Lane-pack: sort by start day asc, then by length desc so longer
+    // spans claim leftmost lane. Greedy-place into the first lane whose
+    // last placed span ends before this one starts.
+    spans.sort((a, b) => {
+      if (a.startIdx !== b.startIdx) return a.startIdx - b.startIdx;
+      return b.length - a.length;
+    });
+    const lanes: Array<Array<Span>> = [];
+    for (const s of spans) {
+      let placed = false;
+      for (const lane of lanes) {
+        const last = lane[lane.length - 1]!;
+        if (last.endIdx < s.startIdx) {
+          lane.push(s);
+          placed = true;
+          break;
+        }
+      }
+      if (!placed) lanes.push([s]);
+    }
+    return { lanes, count: spans.length };
+  }, [dayBuckets, days]);
+
+  const hasAnyAllDay = allDaySpans.count > 0;
 
   // 7-column week view on a 360px phone leaves ~44px per column after the
   // hour gutter — enough for a single-letter day label and a 2-digit date.
@@ -282,14 +422,17 @@ export function MultiDayView({
                     : "text-muted-foreground"
                 )}
               >
-                {/* On the week view at narrow widths, show single-letter
-                    weekday (M T W T F S S) so headers don't overflow. */}
-                <span className={cn(isWeek && "sm:hidden")}>
-                  {format(day, "EEEEE")}
-                </span>
-                <span className={cn(isWeek ? "hidden sm:inline" : "")}>
-                  {format(day, "EEE")}
-                </span>
+                {/* Week view at narrow widths shows single-letter
+                    weekday (M T W T F S S) so headers don't overflow.
+                    Other views always show 3-letter (SAT, SUN, MON). */}
+                {isWeek ? (
+                  <>
+                    <span className="sm:hidden">{format(day, "EEEEE")}</span>
+                    <span className="hidden sm:inline">{format(day, "EEE")}</span>
+                  </>
+                ) : (
+                  format(day, "EEE")
+                )}
               </p>
               <p
                 className={cn(
@@ -305,7 +448,10 @@ export function MultiDayView({
         })}
       </div>
 
-      {/* All-day banner row */}
+      {/* All-day banner row — multi-day events render as a single bar
+          spanning the columns they cover, lane-stacked when bars overlap.
+          Layered: a faint gridline of empty day cells underneath, the
+          spanning bars positioned absolutely on top. */}
       {hasAnyAllDay && (
         <div className="flex flex-shrink-0 border-b bg-muted/30">
           <div className="w-12 sm:w-14 flex-shrink-0 border-r flex items-start justify-end px-2 py-1">
@@ -313,34 +459,57 @@ export function MultiDayView({
               All day
             </span>
           </div>
-          {dayBuckets.map((bucket, i) => (
-            <div
-              key={days[i]!.toISOString()}
-              className="flex-1 border-r last:border-r-0 px-1 py-1 space-y-0.5 min-h-[28px] min-w-0"
-            >
-              {bucket.allDay.map((event) => {
-                const color = event.calendar?.color ?? "#6B7280";
+          <div
+            className="flex-1 relative"
+            style={{
+              // Each lane is one row of bars. 22px keeps text legible
+              // and matches Google Calendar's banner-row density.
+              height: `${allDaySpans.lanes.length * 22 + 4}px`,
+            }}
+          >
+            {/* Background day-cell separators — match the timeline below */}
+            <div className="absolute inset-0 flex">
+              {days.map((day, i) => (
+                <div
+                  key={day.toISOString()}
+                  className={cn(
+                    "flex-1 border-r min-w-0",
+                    i === days.length - 1 && "border-r-0"
+                  )}
+                />
+              ))}
+            </div>
+            {/* Spanning bars */}
+            {allDaySpans.lanes.flatMap((lane, laneIdx) =>
+              lane.map((span) => {
+                const color = span.event.calendar?.color ?? "#6B7280";
+                const widthPct = (span.length / days.length) * 100;
+                const leftPct = (span.startIdx / days.length) * 100;
                 return (
                   <button
-                    key={event.id}
+                    key={span.event.id}
                     data-all-day-event
                     onClick={(e) => {
                       e.stopPropagation();
-                      onExternalEventClick?.(event);
+                      onExternalEventClick?.(span.event);
                     }}
-                    className="block w-full text-left rounded px-1.5 py-0.5 text-[10px] truncate hover:brightness-90 cursor-pointer"
+                    className="absolute text-left rounded px-1.5 py-0.5 text-[11px] truncate hover:brightness-90 cursor-pointer"
                     style={{
-                      backgroundColor: hexToRgba(color, 0.15),
-                      borderLeft: `2px solid ${hexToRgba(color, 0.6)}`,
+                      top: `${laneIdx * 22 + 2}px`,
+                      left: `calc(${leftPct}% + 2px)`,
+                      width: `calc(${widthPct}% - 4px)`,
+                      height: "20px",
+                      backgroundColor: hexToRgba(color, 0.18),
+                      borderLeft: `3px solid ${hexToRgba(color, 0.7)}`,
                     }}
-                    title={event.title}
+                    title={span.event.title}
                   >
-                    {event.title}
+                    {span.event.title}
                   </button>
                 );
-              })}
-            </div>
-          ))}
+              })
+            )}
+          </div>
         </div>
       )}
 
@@ -431,30 +600,42 @@ export function MultiDayView({
                   )}
 
                   {/* Time blocks (above events) */}
-                  {bucket.blocks.map((block) => (
-                    <MultiDayBlock
-                      key={block.id}
-                      block={block}
-                      displayDate={day}
-                      onClick={
-                        onBlockClick ? () => onBlockClick(block) : undefined
-                      }
-                    />
-                  ))}
+                  {bucket.blocks.map((block) => {
+                    const layout =
+                      dayLayouts[i]?.get(`block:${block.id}`) ??
+                      DEFAULT_LAYOUT;
+                    return (
+                      <MultiDayBlock
+                        key={block.id}
+                        block={block}
+                        displayDate={day}
+                        layout={layout}
+                        onClick={
+                          onBlockClick ? () => onBlockClick(block) : undefined
+                        }
+                      />
+                    );
+                  })}
 
                   {/* External calendar events */}
-                  {bucket.timed.map((event) => (
-                    <MultiDayEvent
-                      key={event.id}
-                      event={event}
-                      displayDate={day}
-                      onClick={
-                        onExternalEventClick
-                          ? () => onExternalEventClick(event)
-                          : undefined
-                      }
-                    />
-                  ))}
+                  {bucket.timed.map((event) => {
+                    const layout =
+                      dayLayouts[i]?.get(`event:${event.id}`) ??
+                      DEFAULT_LAYOUT;
+                    return (
+                      <MultiDayEvent
+                        key={event.id}
+                        event={event}
+                        displayDate={day}
+                        layout={layout}
+                        onClick={
+                          onExternalEventClick
+                            ? () => onExternalEventClick(event)
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
                 </div>
               );
             })}

--- a/apps/web/src/components/calendar/time-block.tsx
+++ b/apps/web/src/components/calendar/time-block.tsx
@@ -7,9 +7,18 @@ import {
   HOUR_HEIGHT,
 } from "@/hooks/useCalendarDnd";
 import { TimeBlockContextMenu } from "./time-block-context-menu";
+import type { LayoutResult } from "./event-layout";
+
+const COLUMN_GAP_PCT = 1; // gap between side-by-side overlapping items
 
 interface TimeBlockProps {
   block: TimeBlockType;
+  /**
+   * Lane assignment from the side-by-side overlap layout. When N items
+   * overlap at the same time slot, they split the column into N
+   * sub-columns and each item renders in its assigned lane.
+   */
+  layout?: LayoutResult;
   onClick?: () => void;
   onEditBlock?: () => void;
   onDragStart?: (e: React.MouseEvent) => void;
@@ -61,6 +70,7 @@ function getBlockColors(block: TimeBlockType): {
  */
 export function TimeBlock({
   block,
+  layout = { lane: 0, columnCount: 1 },
   onClick,
   onEditBlock,
   onDragStart,
@@ -112,7 +122,7 @@ export function TimeBlock({
       <div
         data-time-block
         className={cn(
-          "absolute left-1 right-1 z-10 my-0.5 rounded-md border-l-[3px] transition-all select-none",
+          "absolute z-10 my-0.5 rounded-md border-l-[3px] transition-all select-none",
           "hover:brightness-95 hover:z-20",
           isSelected && "ring-2 ring-primary ring-offset-1",
           isDragging && "opacity-50 cursor-grabbing",
@@ -122,6 +132,12 @@ export function TimeBlock({
         style={{
           top: `${top}px`,
           height: `${Math.max(height - 4, 20)}px`, // Account for margin
+          // Side-by-side overlap: column split into layout.columnCount
+          // lanes, item lives in lane N. 4px gutter on the leftmost
+          // lane preserves the previous `left-1 right-1` look when no
+          // overlap is happening.
+          left: `calc(${(100 / layout.columnCount) * layout.lane}% + ${layout.lane === 0 ? "4px" : "1px"})`,
+          width: `calc(${100 / layout.columnCount - COLUMN_GAP_PCT}% - ${layout.lane === 0 ? "4px" : "1px"})`,
           backgroundColor: colors.bg,
           borderColor: colors.border,
         }}

--- a/apps/web/src/components/calendar/timeline.tsx
+++ b/apps/web/src/components/calendar/timeline.tsx
@@ -12,6 +12,9 @@ import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui";
 import { TimeBlock, TimeBlockPreview } from "./time-block";
 import { ExternalEvent, AllDayEvent } from "./external-event";
+import { layoutOverlappingItems, type LayoutResult } from "./event-layout";
+
+const DEFAULT_LAYOUT: LayoutResult = { lane: 0, columnCount: 1 };
 import {
   HOUR_HEIGHT,
   TIMELINE_START_HOUR,
@@ -164,6 +167,35 @@ export function Timeline({
     return { timedEvents: timed, allDayEvents: allDay };
   }, [calendarEvents, date]);
 
+  // Side-by-side overlap layout. Timed events and time blocks compete
+  // for column real estate, so we lane-pack them together — matches
+  // Google Calendar's "split the column when N items overlap" behavior.
+  const itemLayouts = React.useMemo(() => {
+    const dayStart = startOfDay(date);
+    const dayEnd = endOfDay(date);
+    const items = [
+      ...timedEvents.map((e) => {
+        const s = new Date(e.startTime);
+        const en = new Date(e.endTime);
+        return {
+          id: `event:${e.id}`,
+          start: s < dayStart ? dayStart : s,
+          end: en > dayEnd ? dayEnd : en,
+        };
+      }),
+      ...dayBlocks.map((b) => {
+        const s = new Date(b.startTime);
+        const en = new Date(b.endTime);
+        return {
+          id: `block:${b.id}`,
+          start: s < dayStart ? dayStart : s,
+          end: en > dayEnd ? dayEnd : en,
+        };
+      }),
+    ];
+    return layoutOverlappingItems(items);
+  }, [timedEvents, dayBlocks, date]);
+
   // Handle click on empty time slot
   const handleTimeSlotClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // Don't trigger if clicking on a time block, an external calendar
@@ -309,6 +341,7 @@ export function Timeline({
                   key={event.id}
                   event={event}
                   displayDate={date}
+                  layout={itemLayouts.get(`event:${event.id}`) ?? DEFAULT_LAYOUT}
                   onClick={
                     onExternalEventClick
                       ? () => onExternalEventClick(event)
@@ -323,6 +356,7 @@ export function Timeline({
                 <TimeBlock
                   key={block.id}
                   block={block}
+                  layout={itemLayouts.get(`block:${block.id}`) ?? DEFAULT_LAYOUT}
                   onClick={() => onBlockClick?.(block)}
                   onEditBlock={() => onEditBlock?.(block)}
                   onDragStart={(e) => onBlockDragStart?.(block, e)}


### PR DESCRIPTION
## Summary

Four visible calendar bugs caught from screenshots:

1. **Side-by-side overlap layout** — three 12 PM events were stacking on top of each other instead of splitting the column. Added `event-layout.ts` with the standard interval-graph greedy column packer; CalendarEvent and TimeBlock compete for the same lane assignment in both single-day Timeline and MultiDayView.
2. **3-Day weekday \"SSAT\" \"SSUN\" \"MMON\"** — both single-letter and 3-letter spans were rendering simultaneously. Switched to a real ternary so only one path renders.
3. **Multi-day all-day events repeated per column** — \"Stay at Hyatt Place Bayamón\" appeared three times across Sat/Sun/Mon instead of as one continuous bar. Refactored the all-day banner to deduplicate events, compute first/last visible-day index, and lane-pack with longer-first tiebreak so bars span continuously across the columns they cover.
4. **Removed \"Open in calendar provider\" button** — per user feedback we shouldn't be linking out; the in-app sheet is the canonical surface.

## Test plan

- [ ] Three overlapping events at 12-1pm split into three side-by-side sub-columns.
- [ ] No-overlap events look visually unchanged.
- [ ] Multi-day all-day event renders as ONE bar across the days it covers.
- [ ] Single-day all-day event renders only on its day.
- [ ] 3-day view shows \"SAT\" \"SUN\" \"MON\", not \"SSAT\" etc.
- [ ] Week view on phones shows single-letter weekday; on desktop shows 3-letter.
- [ ] Detail sheet has no \"Open in calendar provider\" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)