### PR TITLE
fix(calendar): show events in board sidebar + force-resync to fix mismapped events

### DIFF
--- a/apps/api/src/routes/calendar-accounts.ts
+++ b/apps/api/src/routes/calendar-accounts.ts
@@ -8,8 +8,10 @@ import {
   getDb,
   eq,
   and,
+  inArray,
   calendarAccounts,
   calendars,
+  calendarEvents,
   sql,
 } from '@open-sunsama/database';
 import { NotFoundError } from '@open-sunsama/utils';
@@ -141,6 +143,15 @@ calendarAccountsRouter.post(
       }, 400);
     }
 
+    // `?force=true` clears sync tokens and wipes existing events for
+    // this account's calendars before re-syncing. Used to recover from
+    // historical data corruption where events were attributed to the
+    // wrong calendar — a clean slate forces every event to be
+    // re-fetched and attributed via the (now-correct) per-calendar
+    // sync slice. Safe to run anytime; just slower than incremental.
+    const forceParam = c.req.query('force');
+    const force = forceParam === 'true' || forceParam === '1';
+
     await db
       .update(calendarAccounts)
       .set({ syncStatus: 'syncing', syncError: null, updatedAt: new Date() })
@@ -156,6 +167,30 @@ calendarAccountsRouter.post(
             eq(calendars.isEnabled, true)
           )
         );
+
+      if (force && accountCalendars.length > 0) {
+        const calendarIds = accountCalendars.map((c) => c.id);
+        // Wipe events for these calendars so the upsert below rebuilds
+        // attribution from scratch — protects against the case where
+        // an event's calendarId is wrong in the DB.
+        await db
+          .delete(calendarEvents)
+          .where(
+            and(
+              eq(calendarEvents.userId, userId),
+              inArray(calendarEvents.calendarId, calendarIds)
+            )
+          );
+        // Clear per-calendar sync tokens so the next listEvents call
+        // does a full window fetch instead of an empty incremental.
+        await db
+          .update(calendars)
+          .set({ syncToken: null, updatedAt: new Date() })
+          .where(inArray(calendars.id, calendarIds));
+        // Refresh the in-memory list so the OAuth path sees the
+        // cleared tokens.
+        for (const c of accountCalendars) c.syncToken = null;
+      }
 
       const now = new Date();
       const timeMin = new Date(now);

--- a/apps/web/src/components/kanban/kanban-calendar-panel.tsx
+++ b/apps/web/src/components/kanban/kanban-calendar-panel.tsx
@@ -1,13 +1,34 @@
 import * as React from "react";
-import { format, isSameDay, setHours, addMinutes } from "date-fns";
-import type { TimeBlock as TimeBlockType } from "@open-sunsama/types";
+import {
+  format,
+  isSameDay,
+  setHours,
+  addMinutes,
+  startOfDay,
+  endOfDay,
+} from "date-fns";
+import type {
+  TimeBlock as TimeBlockType,
+  CalendarEvent,
+} from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import {
   useTimeBlocks,
   useMoveTimeBlock,
   useCascadeResizeTimeBlock,
 } from "@/hooks/useTimeBlocks";
+import {
+  useCalendarEvents,
+  useCalendars,
+  useCalendarAccounts,
+} from "@/hooks/useCalendars";
 import { TimeBlock, TimeBlockPreview } from "@/components/calendar/time-block";
+import { ExternalEvent } from "@/components/calendar/external-event";
+import { CalendarEventDetailSheet } from "@/components/calendar/calendar-event-detail-sheet";
+import {
+  layoutOverlappingItems,
+  type LayoutResult,
+} from "@/components/calendar/event-layout";
 import {
   useCalendarDnd,
   HOUR_HEIGHT,
@@ -18,6 +39,10 @@ import {
   calculateTimeFromY,
   snapToInterval,
 } from "@/hooks/useCalendarDnd";
+
+const DEFAULT_LAYOUT: LayoutResult = { lane: 0, columnCount: 1 };
+
+const PROVIDERS_WITH_WRITE_BACK = new Set(["google"]);
 
 interface KanbanCalendarPanelProps {
   date: Date;
@@ -43,6 +68,56 @@ export function KanbanCalendarPanel({
   const dateString = format(date, "yyyy-MM-dd");
   const { data: timeBlocks = [] } = useTimeBlocks({ date: dateString });
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+
+  // External calendar events for the same day. Use the day's local
+  // start / end as the API range — matches CalendarView's convention
+  // so the React-Query cache key is shared and we don't double-fetch.
+  const dayStart = React.useMemo(() => startOfDay(date), [date]);
+  const dayEnd = React.useMemo(() => endOfDay(date), [date]);
+  const fromDate = dayStart.toISOString();
+  const toDate = dayEnd.toISOString();
+  const { data: calendarEvents = [] } = useCalendarEvents(fromDate, toDate);
+
+  // For the read-only-calendar gating in the detail sheet.
+  const { data: calendarsList = [] } = useCalendars();
+  const { data: calendarAccounts = [] } = useCalendarAccounts();
+  const calendarReadOnlyById = React.useMemo(() => {
+    const providerByAccount = new Map<string, string>();
+    for (const a of calendarAccounts) providerByAccount.set(a.id, a.provider);
+    const m = new Map<string, boolean>();
+    for (const c of calendarsList) {
+      const provider = providerByAccount.get(c.accountId);
+      const writable =
+        !!provider &&
+        PROVIDERS_WITH_WRITE_BACK.has(provider) &&
+        !c.isReadOnly;
+      m.set(c.id, !writable);
+    }
+    return m;
+  }, [calendarsList, calendarAccounts]);
+
+  // External-event detail sheet state — opens when the user clicks a
+  // calendar event in the panel. Self-contained inside the panel so the
+  // parent route doesn't need wiring.
+  const [selectedExternalEvent, setSelectedExternalEvent] =
+    React.useState<CalendarEvent | null>(null);
+  const [externalEventSheetOpen, setExternalEventSheetOpen] =
+    React.useState(false);
+
+  const handleExternalEventClick = React.useCallback((event: CalendarEvent) => {
+    setSelectedExternalEvent(event);
+    setExternalEventSheetOpen(true);
+  }, []);
+
+  const handleExternalEventSheetOpenChange = React.useCallback(
+    (next: boolean) => {
+      setExternalEventSheetOpen(next);
+      if (!next) {
+        setTimeout(() => setSelectedExternalEvent(null), 200);
+      }
+    },
+    []
+  );
 
   // Mutations
   const moveTimeBlock = useMoveTimeBlock();
@@ -106,6 +181,60 @@ export function KanbanCalendarPanel({
       isSameDay(new Date(block.startTime), date)
     );
   }, [timeBlocks, date]);
+
+  // Bucket the visible-range events into timed (drawn on the timeline)
+  // and all-day (drawn in the banner above). Same shape as the main
+  // CalendarView's per-day bucketer — kept inline because the panel is
+  // single-day and doesn't need the multi-day spanning logic.
+  const { timedEvents, allDayEvents } = React.useMemo(() => {
+    const targetCalendarDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    const timed: CalendarEvent[] = [];
+    const allDay: CalendarEvent[] = [];
+    for (const event of calendarEvents) {
+      const start = new Date(event.startTime);
+      const end = new Date(event.endTime);
+      if (event.isAllDay) {
+        // iCal/Google convention: all-day events stored at UTC midnight.
+        const startDateStr = `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, "0")}-${String(start.getUTCDate()).padStart(2, "0")}`;
+        const endDateStr = `${end.getUTCFullYear()}-${String(end.getUTCMonth() + 1).padStart(2, "0")}-${String(end.getUTCDate()).padStart(2, "0")}`;
+        if (
+          targetCalendarDate >= startDateStr &&
+          targetCalendarDate < endDateStr
+        ) {
+          allDay.push(event);
+        }
+      } else if (start < dayEnd && end > dayStart) {
+        timed.push(event);
+      }
+    }
+    return { timedEvents: timed, allDayEvents: allDay };
+  }, [calendarEvents, date, dayStart, dayEnd]);
+
+  // Side-by-side overlap layout — same algorithm as the main timeline,
+  // packing timed events and time blocks into shared lanes.
+  const itemLayouts = React.useMemo(() => {
+    const items = [
+      ...timedEvents.map((e) => {
+        const s = new Date(e.startTime);
+        const en = new Date(e.endTime);
+        return {
+          id: `event:${e.id}`,
+          start: s < dayStart ? dayStart : s,
+          end: en > dayEnd ? dayEnd : en,
+        };
+      }),
+      ...dayBlocks.map((b) => {
+        const s = new Date(b.startTime);
+        const en = new Date(b.endTime);
+        return {
+          id: `block:${b.id}`,
+          start: s < dayStart ? dayStart : s,
+          end: en > dayEnd ? dayEnd : en,
+        };
+      }),
+    ];
+    return layoutOverlappingItems(items);
+  }, [timedEvents, dayBlocks, dayStart, dayEnd]);
 
   // Auto-scroll to current time on mount and date change
   React.useEffect(() => {
@@ -179,8 +308,14 @@ export function KanbanCalendarPanel({
 
   // Handle click on empty time slot
   const handleTimeSlotClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    // Don't trigger if clicking on a time block
-    if ((e.target as HTMLElement).closest("[data-time-block]")) {
+    // Don't trigger if clicking on a time block, an external calendar
+    // event, or an all-day banner — those have their own click handlers.
+    const target = e.target as HTMLElement;
+    if (
+      target.closest("[data-time-block]") ||
+      target.closest("[data-external-event]") ||
+      target.closest("[data-all-day-event]")
+    ) {
       return;
     }
 
@@ -224,6 +359,36 @@ export function KanbanCalendarPanel({
         </div>
         <div className="text-lg font-semibold">{format(date, "MMM d")}</div>
       </div>
+
+      {/* All-day banner — only renders when there's at least one all-day
+          event for this day. Compact one-line chips with a colored
+          left-border, click to open the same detail sheet. */}
+      {allDayEvents.length > 0 && (
+        <div className="flex-shrink-0 border-b bg-muted/30 px-2 py-1 space-y-0.5">
+          {allDayEvents.map((event) => {
+            const color = event.calendar?.color ?? "#6B7280";
+            return (
+              <button
+                key={event.id}
+                type="button"
+                data-all-day-event
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleExternalEventClick(event);
+                }}
+                className="block w-full text-left rounded px-1.5 py-0.5 text-[11px] truncate hover:brightness-90 cursor-pointer"
+                style={{
+                  backgroundColor: hexToRgba(color, 0.15),
+                  borderLeft: `2px solid ${hexToRgba(color, 0.6)}`,
+                }}
+                title={event.title}
+              >
+                {event.title}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {/* Timeline */}
       <div
@@ -291,11 +456,26 @@ export function KanbanCalendarPanel({
               </div>
             )}
 
+            {/* External calendar events — drawn behind time blocks so
+                user-created blocks always layer on top. */}
+            {timedEvents.map((event) => (
+              <ExternalEvent
+                key={event.id}
+                event={event}
+                displayDate={date}
+                layout={
+                  itemLayouts.get(`event:${event.id}`) ?? DEFAULT_LAYOUT
+                }
+                onClick={() => handleExternalEventClick(event)}
+              />
+            ))}
+
             {/* Time blocks */}
             {dayBlocks.map((block) => (
               <TimeBlock
                 key={block.id}
                 block={block}
+                layout={itemLayouts.get(`block:${block.id}`) ?? DEFAULT_LAYOUT}
                 onClick={() => onBlockClick?.(block)}
                 onEditBlock={() => onEditBlock?.(block)}
                 onDragStart={(e) => handleBlockDragStart(block, e)}
@@ -327,6 +507,35 @@ export function KanbanCalendarPanel({
           </div>
         </div>
       </div>
+
+      {/* External calendar event detail sheet (read + edit + delete) */}
+      <CalendarEventDetailSheet
+        event={selectedExternalEvent}
+        open={externalEventSheetOpen}
+        onOpenChange={handleExternalEventSheetOpenChange}
+        rangeFrom={fromDate}
+        rangeTo={toDate}
+        calendarReadOnly={
+          selectedExternalEvent
+            ? (calendarReadOnlyById.get(
+                selectedExternalEvent.calendarId
+              ) ?? true)
+            : true
+        }
+      />
     </div>
   );
+}
+
+/**
+ * Convert hex color to rgba string. Same shape used by the all-day
+ * banner chips — not exported because the panel is the only consumer.
+ */
+function hexToRgba(hex: string, alpha: number): string {
+  const cleanHex = hex.replace("#", "");
+  const r = parseInt(cleanHex.substring(0, 2), 16);
+  const g = parseInt(cleanHex.substring(2, 4), 16);
+  const b = parseInt(cleanHex.substring(4, 6), 16);
+  if (Number.isNaN(r)) return `rgba(107, 114, 128, ${alpha})`;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }

--- a/apps/web/src/components/settings/calendar-account-card.tsx
+++ b/apps/web/src/components/settings/calendar-account-card.tsx
@@ -5,8 +5,18 @@ import {
   CheckCircle2,
   AlertCircle,
   Clock,
+  MoreVertical,
+  RotateCcw,
 } from "lucide-react";
-import { Button, Switch, Badge } from "@/components/ui";
+import {
+  Button,
+  Switch,
+  Badge,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { CalendarAccount, Calendar } from "@/hooks/useCalendars";
 import { PROVIDER_CONFIG } from "./calendar-provider-icons";
@@ -158,6 +168,7 @@ export function AccountCard({
   account,
   calendars,
   onSync,
+  onForceResync,
   onRemove,
   onUpdateCalendar,
   isSyncing,
@@ -166,6 +177,12 @@ export function AccountCard({
   account: CalendarAccount;
   calendars: Calendar[];
   onSync: () => void;
+  /**
+   * Wipes local events for this account's calendars and re-fetches
+   * from scratch. Used as a self-service repair for past attribution
+   * bugs where events landed under the wrong calendar.
+   */
+  onForceResync: () => void;
   onRemove: () => void;
   onUpdateCalendar: (calendarId: string, data: { isEnabled?: boolean; isDefaultForEvents?: boolean; isDefaultForTasks?: boolean }) => void;
   isSyncing: boolean;
@@ -223,15 +240,29 @@ export function AccountCard({
               className={cn("h-4 w-4", isSyncing && "animate-spin")}
             />
           </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onRemove}
-            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-            title="Remove account"
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" title="More options">
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={onForceResync}
+                disabled={isSyncing || account.syncStatus === "syncing"}
+              >
+                <RotateCcw className="mr-2 h-4 w-4" />
+                Reset & re-sync
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={onRemove}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Disconnect account
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 

--- a/apps/web/src/components/settings/calendar-settings.tsx
+++ b/apps/web/src/components/settings/calendar-settings.tsx
@@ -258,13 +258,22 @@ export function CalendarSettings() {
                   key={account.id}
                   account={account}
                   calendars={calendarsByAccount[account.id] || []}
-                  onSync={() => syncMutation.mutate(account.id)}
+                  onSync={() => syncMutation.mutate({ accountId: account.id })}
+                  onForceResync={() =>
+                    syncMutation.mutate({
+                      accountId: account.id,
+                      force: true,
+                    })
+                  }
                   onRemove={() => {
                     setAccountToRemove(account);
                     setRemoveDialogOpen(true);
                   }}
                   onUpdateCalendar={handleUpdateCalendar}
-                  isSyncing={syncMutation.isPending && syncMutation.variables === account.id}
+                  isSyncing={
+                    syncMutation.isPending &&
+                    syncMutation.variables?.accountId === account.id
+                  }
                   isUpdatingCalendar={updateCalendarMutation.isPending}
                 />
               ))}

--- a/apps/web/src/hooks/useCalendars.ts
+++ b/apps/web/src/hooks/useCalendars.ts
@@ -117,23 +117,42 @@ export function useDisconnectAccount() {
 }
 
 /**
- * Trigger manual sync for a calendar account
+ * Trigger manual sync for a calendar account.
+ *
+ * Pass `{ force: true }` to wipe local events for the account's
+ * calendars and re-fetch from scratch — used to recover from
+ * historical attribution bugs where events landed under the wrong
+ * calendar. Force is slower but always converges to a clean state.
  */
 export function useSyncAccount() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (accountId: string): Promise<void> => {
+    mutationFn: async ({
+      accountId,
+      force = false,
+    }: {
+      accountId: string;
+      force?: boolean;
+    }): Promise<void> => {
       const client = getApiClient();
-      await client.post(`calendar/accounts/${accountId}/sync`);
+      const path = force
+        ? `calendar/accounts/${accountId}/sync?force=true`
+        : `calendar/accounts/${accountId}/sync`;
+      await client.post(path);
     },
-    onSuccess: () => {
+    onSuccess: (_data, vars) => {
       queryClient.invalidateQueries({ queryKey: calendarKeys.accounts() });
       queryClient.invalidateQueries({ queryKey: calendarKeys.calendars() });
+      // Force refetch all calendar-events queries so the just-rebuilt
+      // attribution lands immediately in any open calendar view.
+      queryClient.invalidateQueries({ queryKey: calendarKeys.all });
 
       toast({
-        title: "Sync started",
-        description: "Calendar sync has been initiated.",
+        title: vars.force ? "Reset & re-sync started" : "Sync started",
+        description: vars.force
+          ? "Wiping local events and re-fetching from your provider."
+          : "Calendar sync has been initiated.",
       });
     },
     onError: (error) => {


### PR DESCRIPTION
## Summary

Two user-reported bugs:

1. **Board sidebar calendar didn't show external events** — only time blocks rendered. Wired \`useCalendarEvents\` into \`KanbanCalendarPanel\` with the same overlap-layout, all-day banner, and detail sheet as the main calendar view. Click an event → opens edit/delete sheet scoped to the day's range.

2. **Calendars showing as the wrong type (\"Family\")** — symptom consistent with stale data from before PR #21's per-calendar attribution fix. Old events kept their wrong \`calendarId\`; incremental sync alone won't repair this. Added a \`?force=true\` mode to \`POST /calendar/accounts/:id/sync\` that wipes events for the account's enabled calendars and clears per-calendar sync tokens before re-syncing — guarantees every event is re-fetched and re-attributed via the (now-correct) per-calendar slice.

   Surfaced as a **\"Reset & re-sync\"** item in a new dropdown menu in calendar settings. The existing \"remove account\" button moved into the same menu.

## Test plan

- [ ] Open the board view — external calendar events appear in the right-side calendar panel alongside time blocks.
- [ ] Overlapping events split into side-by-side sub-columns in the panel.
- [ ] All-day events appear in a compact banner above the timeline.
- [ ] Click an event in the panel → edit/delete sheet opens.
- [ ] Settings → Calendar → click ⋮ → Reset & re-sync → events get wiped and re-fetched, attribution correct.
- [ ] Regular sync icon still triggers cheap incremental sync (no wipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)