### PR TITLE
fix(calendar): audit-driven bugs — shortcuts, now-line, cache, all-day, validation

### DIFF
--- a/apps/api/src/routes/calendar-events.ts
+++ b/apps/api/src/routes/calendar-events.ts
@@ -395,6 +395,16 @@ const updateEventBodySchema = z
       message: 'startTime and endTime must be provided together',
       path: ['endTime'],
     }
+  )
+  .refine(
+    (b) =>
+      b.startTime === undefined ||
+      b.endTime === undefined ||
+      new Date(b.endTime) > new Date(b.startTime),
+    {
+      message: 'endTime must be after startTime',
+      path: ['endTime'],
+    }
   );
 
 /**

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -327,8 +327,11 @@ export function CalendarView({
   // memory transfers cleanly:
   //   D = Day, X = 3 days (their "4 days" key, near enough), W = Week,
   //   M = Month, T = Today, J = previous range, K = next range.
-  // Skip when focus is inside an input / textarea / contenteditable so
-  // typing in any form field doesn't accidentally swap the view mode.
+  // Skip when focus is in a form field OR when ANY modal/popover is
+  // open — without the second guard, pressing "M" while an event
+  // detail sheet is open silently switches the calendar view behind
+  // the overlay because the focused dialog body doesn't match
+  // INPUT/TEXTAREA/SELECT/contentEditable.
   React.useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
@@ -339,6 +342,16 @@ export function CalendarView({
           target.tagName === "TEXTAREA" ||
           target.tagName === "SELECT" ||
           target.isContentEditable)
+      ) {
+        return;
+      }
+      // Radix open overlays are tagged with `data-state="open"`. If
+      // any modal-style overlay is mounted-and-open, swallow the
+      // shortcut.
+      if (
+        document.querySelector(
+          '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]'
+        )
       ) {
         return;
       }

--- a/apps/web/src/components/calendar/create-dialog/event-form.tsx
+++ b/apps/web/src/components/calendar/create-dialog/event-form.tsx
@@ -12,6 +12,7 @@ import {
   DialogFooter,
   Input,
   Label,
+  Switch,
   Select,
   SelectTrigger,
   SelectValue,
@@ -66,10 +67,12 @@ export function EventForm({
     writableCalendars[0]?.id
   );
   const [location, setLocation] = React.useState("");
+  const [isAllDay, setIsAllDay] = React.useState(false);
 
   React.useEffect(() => {
     setTitle("");
     setLocation("");
+    setIsAllDay(false);
   }, [date, startTime, endTime]);
 
   React.useEffect(() => {
@@ -95,6 +98,29 @@ export function EventForm({
       });
       return;
     }
+    // For all-day events the iCal convention is UTC midnight of the
+    // covered date(s) with end exclusive. The user's slot click gave
+    // us a timed startTime — project to UTC midnight of that local
+    // date and set end = next-day UTC midnight (single-day all-day).
+    const finalStart = isAllDay
+      ? new Date(
+          Date.UTC(
+            startTime.getFullYear(),
+            startTime.getMonth(),
+            startTime.getDate()
+          )
+        )
+      : startTime;
+    const finalEnd = isAllDay
+      ? new Date(
+          Date.UTC(
+            startTime.getFullYear(),
+            startTime.getMonth(),
+            startTime.getDate() + 1
+          )
+        )
+      : endTime;
+
     try {
       await createMutation.mutateAsync({
         calendarId,
@@ -103,10 +129,12 @@ export function EventForm({
         payload: {
           title: trimmed,
           location: location.trim() || null,
-          startTime,
-          endTime,
-          isAllDay: false,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          startTime: finalStart,
+          endTime: finalEnd,
+          isAllDay,
+          timezone: isAllDay
+            ? null
+            : Intl.DateTimeFormat().resolvedOptions().timeZone,
         },
       });
       toast({ title: "Event created" });
@@ -142,6 +170,18 @@ export function EventForm({
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Event title"
           autoFocus
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Label htmlFor="ev-allday" className="text-sm font-medium">
+          All-day
+        </Label>
+        <Switch
+          id="ev-allday"
+          checked={isAllDay}
+          onCheckedChange={setIsAllDay}
+          disabled={createMutation.isPending}
         />
       </div>
 

--- a/apps/web/src/components/calendar/multi-day-view.tsx
+++ b/apps/web/src/components/calendar/multi-day-view.tsx
@@ -276,6 +276,14 @@ export function MultiDayView({
 }: MultiDayViewProps) {
   const hours = React.useMemo(() => generateHours(), []);
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
+  // Tick the now-indicator once per minute so it advances. Without
+  // this, `new Date()` was captured at render time and the red line
+  // froze until something else triggered a re-render.
+  const [now, setNow] = React.useState(() => new Date());
+  React.useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
 
   // Auto-scroll to ~2 hours before now on mount
   React.useEffect(() => {
@@ -592,7 +600,7 @@ export function MultiDayView({
                   {today && (
                     <div
                       className="absolute left-0 right-0 z-30 flex items-center pointer-events-none"
-                      style={{ top: calculateYFromTime(new Date()) }}
+                      style={{ top: calculateYFromTime(now) }}
                     >
                       <div className="h-2 w-2 rounded-full bg-red-500 -ml-1 shadow-sm" />
                       <div className="h-0.5 flex-1 bg-red-500 shadow-sm" />

--- a/apps/web/src/components/calendar/timeline.tsx
+++ b/apps/web/src/components/calendar/timeline.tsx
@@ -86,7 +86,14 @@ export function Timeline({
 }: TimelineProps) {
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
   const hours = React.useMemo(() => generateHours(), []);
-  const now = new Date();
+  // Tick once a minute so the now-indicator actually advances down the
+  // timeline. Without this, `now` was captured at first render and the
+  // red line froze in place until something else triggered a render.
+  const [now, setNow] = React.useState(() => new Date());
+  React.useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
   const isToday = isSameDay(date, now);
 
   // Calculate current time indicator position

--- a/apps/web/src/hooks/useCalendars.ts
+++ b/apps/web/src/hooks/useCalendars.ts
@@ -367,15 +367,23 @@ export function useUpdateCalendarEvent() {
       return response.data;
     },
     onMutate: async (input) => {
-      const key = calendarKeys.events(input.rangeFrom, input.rangeTo);
-      await queryClient.cancelQueries({ queryKey: key });
-      const previous = queryClient.getQueryData<CalendarEvent[]>(key);
-      if (previous) {
-        const next: CalendarEvent[] = previous.map((ev) => {
+      // Patch the event in EVERY cached event range so the change shows
+      // up across all open views (board sidebar, calendar week, etc.),
+      // not just the one that originated the mutation. Snapshots
+      // restore each range on rollback.
+      const eventsPrefix = ["calendars", "events"] as const;
+      await queryClient.cancelQueries({ queryKey: eventsPrefix });
+      const snapshots: Array<[unknown[], CalendarEvent[]]> = [];
+      const cached = queryClient.getQueriesData<CalendarEvent[]>({
+        queryKey: eventsPrefix,
+      });
+      for (const [key, data] of cached) {
+        if (!data) continue;
+        snapshots.push([key as unknown[], data]);
+        const next: CalendarEvent[] = data.map((ev) => {
           if (ev.id !== input.id) return ev;
-          // The server-side type uses ISO strings on the wire (Date in
-          // TS but the JSON layer stringifies). Match that here so the
-          // optimistic value is shape-compatible with the refetch.
+          // Wire shape: API serialises Date → ISO string, so optimistic
+          // values must be ISO strings to match the refetch payload.
           const merged: CalendarEvent = { ...ev };
           if (input.patch.title !== undefined) merged.title = input.patch.title;
           if (input.patch.description !== undefined) {
@@ -402,12 +410,13 @@ export function useUpdateCalendarEvent() {
         });
         queryClient.setQueryData<CalendarEvent[]>(key, next);
       }
-      return { previous, key };
+      return { snapshots };
     },
     onError: (error, _input, context) => {
-      // Roll back the optimistic change so the UI reflects reality.
-      if (context?.previous) {
-        queryClient.setQueryData(context.key, context.previous);
+      if (context?.snapshots) {
+        for (const [key, prior] of context.snapshots) {
+          queryClient.setQueryData(key, prior);
+        }
       }
       toast({
         variant: "destructive",
@@ -415,12 +424,15 @@ export function useUpdateCalendarEvent() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSettled: (_data, _err, input) => {
-      // Always re-fetch so the canonical server state lands. This also
-      // covers the case where the event moved out of the visible range.
-      queryClient.invalidateQueries({
-        queryKey: calendarKeys.events(input.rangeFrom, input.rangeTo),
-      });
+    onSettled: () => {
+      // Invalidate ALL cached calendar-event ranges so other open
+      // views (board sidebar showing day, main calendar showing week,
+      // a stale month range from a prior render) all refetch the
+      // canonical state. Without the broader invalidation, a saved
+      // edit would only land in the range that originated the
+      // mutation, leaving siblings stale or showing the event in the
+      // wrong slot if its time changed enough to leave the range.
+      queryClient.invalidateQueries({ queryKey: calendarKeys.all });
     },
   });
 }
@@ -443,20 +455,32 @@ export function useDeleteCalendarEvent() {
       await client.delete(`calendar-events/${id}`);
     },
     onMutate: async (input) => {
-      const key = calendarKeys.events(input.rangeFrom, input.rangeTo);
-      await queryClient.cancelQueries({ queryKey: key });
-      const previous = queryClient.getQueryData<CalendarEvent[]>(key);
-      if (previous) {
+      // Optimistically remove the event from EVERY cached event range
+      // (the prefix `["calendars","events"]` matches all ranges) so it
+      // disappears from all open views — board sidebar, calendar week,
+      // any stale ranges — not just the one that originated the call.
+      // Snapshot each range so rollback restores them all on error.
+      const eventsPrefix = ["calendars", "events"] as const;
+      await queryClient.cancelQueries({ queryKey: eventsPrefix });
+      const snapshots: Array<[unknown[], CalendarEvent[]]> = [];
+      const cached = queryClient.getQueriesData<CalendarEvent[]>({
+        queryKey: eventsPrefix,
+      });
+      for (const [key, data] of cached) {
+        if (!data) continue;
+        snapshots.push([key as unknown[], data]);
         queryClient.setQueryData<CalendarEvent[]>(
           key,
-          previous.filter((ev) => ev.id !== input.id)
+          data.filter((ev) => ev.id !== input.id)
         );
       }
-      return { previous, key };
+      return { snapshots };
     },
     onError: (error, _input, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(context.key, context.previous);
+      if (context?.snapshots) {
+        for (const [key, prior] of context.snapshots) {
+          queryClient.setQueryData(key, prior);
+        }
       }
       toast({
         variant: "destructive",
@@ -464,10 +488,9 @@ export function useDeleteCalendarEvent() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSettled: (_data, _err, input) => {
-      queryClient.invalidateQueries({
-        queryKey: calendarKeys.events(input.rangeFrom, input.rangeTo),
-      });
+    onSettled: () => {
+      // Invalidate ALL cached ranges — same reasoning as update.
+      queryClient.invalidateQueries({ queryKey: calendarKeys.all });
     },
   });
 }


### PR DESCRIPTION
## Summary

End-to-end calendar audit surfaced 5 real, user-visible bugs. All fixed.

1. **Keyboard shortcuts firing through open overlays** — pressing M/D/W with the event detail sheet open silently switched the calendar view. Now skipped when any Radix dialog/alertdialog is open.
2. **Now-indicator never advanced** — both Timeline and MultiDayView captured \`new Date()\` once at render and froze. Added 60s tick.
3. **Cross-range cache staleness on edit/delete** — optimistic patch only touched one cache key. Now walks the entire \`["calendars","events"]\` prefix and patches every cached range; rollback restores all snapshots.
4. **All-day event creation impossible from the grid** — added Switch to the create-event form; projects start/end to UTC midnight per iCal convention.
5. **PATCH /calendar-events/:id accepted endTime ≤ startTime** — added matching zod refine.

## Test plan

- [ ] Open detail sheet → press W → no view change. Close → press W → switches to week.
- [ ] Now-indicator visibly moves down the timeline as time passes.
- [ ] Edit an event from the board sidebar → main calendar view (week) reflects the change without manual refresh.
- [ ] Delete an event in one tab → other tab's stale cache reconciles.
- [ ] Create-event form: toggle all-day on → time inputs hide implicitly (passed as date-only); event lands as all-day in Google.
- [ ] PATCH an event with endTime ≤ startTime → API returns 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)