### PR TITLE
feat(calendar): drag-to-reschedule + resize external events on day view

### DIFF
--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -34,6 +34,7 @@ import {
   useCalendarEvents,
   useCalendars,
   useCalendarAccounts,
+  useUpdateCalendarEvent,
 } from "@/hooks/useCalendars";
 import { useCalendarDnd } from "@/hooks/useCalendarDnd";
 import { Timeline } from "./timeline";
@@ -266,6 +267,8 @@ export function CalendarView({
   }, [allTasks, timeBlocks]);
 
   // Calendar DnD hook
+  const updateCalendarEvent = useUpdateCalendarEvent();
+
   const {
     dragState,
     dropPreview,
@@ -275,6 +278,8 @@ export function CalendarView({
     startTaskDrag,
     startBlockDrag,
     startBlockResize,
+    startEventDrag,
+    startEventResize,
     updateDrag,
     endDrag,
     cancelDrag,
@@ -295,10 +300,40 @@ export function CalendarView({
     },
     onBlockResize: (blockId, startTime, endTime) => {
       // Use cascade resize to automatically shift blocks below (server-side)
-      cascadeResizeTimeBlock.mutate({ 
-        id: blockId, 
-        startTime, 
+      cascadeResizeTimeBlock.mutate({
+        id: blockId,
+        startTime,
         endTime,
+      });
+    },
+    onEventMove: (eventId, startTime, endTime) => {
+      // Write the new times back to the provider via the same path
+      // that the detail-sheet edit uses. The hook handles optimistic
+      // cache update + rollback + cross-range invalidation.
+      updateCalendarEvent.mutate({
+        id: eventId,
+        rangeFrom: fromDate,
+        rangeTo: toDate,
+        patch: {
+          startTime,
+          endTime,
+          // Preserve the user's local TZ on the round-trip; without it
+          // Google would default to UTC and the displayed time would
+          // shift on re-render.
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        },
+      });
+    },
+    onEventResize: (eventId, startTime, endTime) => {
+      updateCalendarEvent.mutate({
+        id: eventId,
+        rangeFrom: fromDate,
+        rangeTo: toDate,
+        patch: {
+          startTime,
+          endTime,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        },
       });
     },
   });
@@ -528,6 +563,38 @@ export function CalendarView({
     setViewMode("day");
   }, [setViewMode]);
 
+  // Drag handlers for external events — start the move/resize, then
+  // useCalendarDnd's `onEventMove` / `onEventResize` callbacks fire on
+  // mouseup with the new times.
+  const handleExternalEventDragStart = React.useCallback(
+    (event: CalendarEvent, e: React.MouseEvent) => {
+      e.preventDefault();
+      startEventDrag(event, e.clientY);
+    },
+    [startEventDrag]
+  );
+  const handleExternalEventResizeStart = React.useCallback(
+    (event: CalendarEvent, edge: "top" | "bottom", e: React.MouseEvent) => {
+      e.preventDefault();
+      startEventResize(event, edge, e.clientY);
+    },
+    [startEventResize]
+  );
+
+  // Editability check — used to gate drag handles. Same shape as the
+  // detail-sheet read-only check.
+  const externalEventCanEdit = React.useCallback(
+    (event: CalendarEvent) => {
+      // Don't allow drag for all-day events from the timeline path —
+      // they live in the banner row and have different semantics.
+      if (event.isAllDay) return false;
+      const isReadOnly =
+        calendarReadOnlyById.get(event.calendarId) ?? true;
+      return !isReadOnly;
+    },
+    [calendarReadOnlyById]
+  );
+
   return (
     <div className={cn("flex h-full flex-col", className)}>
       {/* Header / Toolbar */}
@@ -572,6 +639,9 @@ export function CalendarView({
               onTimelineMouseUp={handleTimelineMouseUp}
               onTimelineMouseLeave={handleTimelineMouseLeave}
               onExternalEventClick={handleExternalEventClick}
+              onExternalEventDragStart={handleExternalEventDragStart}
+              onExternalEventResizeStart={handleExternalEventResizeStart}
+              externalEventCanEdit={externalEventCanEdit}
               {...(onBlockClick ? { onBlockClick } : {})}
               {...(onEditBlock ? { onEditBlock } : {})}
               {...(onViewTask ? { onViewTask } : {})}

--- a/apps/web/src/components/calendar/drag-overlay.tsx
+++ b/apps/web/src/components/calendar/drag-overlay.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { format } from "date-fns";
-import { Clock, Calendar } from "lucide-react";
-import type { Task, TimeBlock } from "@open-sunsama/types";
+import { Clock, Calendar, CalendarDays } from "lucide-react";
+import type { Task, TimeBlock, CalendarEvent } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "@/lib/utils";
 import type { DragState, DropPreview } from "@/hooks/useCalendarDnd";
@@ -56,6 +56,16 @@ export function DragOverlay({
           dragState.block && (
             <BlockDragPreview
               block={dragState.block}
+              dropPreview={dropPreview}
+              dragType={dragState.type}
+            />
+          )}
+        {(dragState.type === "move-event" ||
+          dragState.type === "resize-event-top" ||
+          dragState.type === "resize-event-bottom") &&
+          dragState.event && (
+            <EventDragPreview
+              event={dragState.event}
               dropPreview={dropPreview}
               dragType={dragState.type}
             />
@@ -178,6 +188,69 @@ function BlockDragPreview({ block, dropPreview, dragType }: BlockDragPreviewProp
           <div
             className="flex items-center gap-2 text-xs font-medium"
             style={{ color: block.color ? "white" : "hsl(var(--primary))" }}
+          >
+            <Calendar className="h-3 w-3" />
+            <span>
+              {format(dropPreview.startTime, "h:mm")} -{" "}
+              {format(dropPreview.endTime, "h:mm a")}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Preview card for dragging or resizing an external calendar event.
+ * Mirrors `BlockDragPreview` but tinted with the source-calendar's
+ * color so the user can confirm at a glance which calendar they're
+ * editing.
+ */
+interface EventDragPreviewProps {
+  event: CalendarEvent;
+  dropPreview: DropPreview | null;
+  dragType: "move-event" | "resize-event-top" | "resize-event-bottom";
+}
+
+function EventDragPreview({
+  event,
+  dropPreview,
+  dragType,
+}: EventDragPreviewProps) {
+  const isResizing =
+    dragType === "resize-event-top" || dragType === "resize-event-bottom";
+  const color = event.calendar?.color ?? "#6B7280";
+
+  return (
+    <div
+      className={cn(
+        "w-56 rounded-lg border bg-card shadow-xl",
+        "animate-in fade-in-0 zoom-in-95 duration-150"
+      )}
+      style={{ borderColor: color }}
+    >
+      <div className="p-3">
+        <div className="flex items-center gap-1.5">
+          <CalendarDays className="h-3 w-3 flex-shrink-0" style={{ color }} />
+          <p className="text-sm font-medium truncate">{event.title}</p>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {isResizing ? "Resizing event…" : "Moving event…"}
+        </p>
+      </div>
+
+      {dropPreview && (
+        <div
+          className="border-t px-3 py-2"
+          style={{
+            backgroundColor: `${color}1a`,
+            borderColor: `${color}33`,
+          }}
+        >
+          <div
+            className="flex items-center gap-2 text-xs font-medium"
+            style={{ color }}
           >
             <Calendar className="h-3 w-3" />
             <span>

--- a/apps/web/src/components/calendar/external-event.tsx
+++ b/apps/web/src/components/calendar/external-event.tsx
@@ -51,6 +51,13 @@ interface ExternalEventProps {
   onResizeStart?: (e: React.MouseEvent, edge: "top" | "bottom") => void;
   /** True while THIS event is being dragged — used for visual feedback. */
   isDragging?: boolean;
+  /**
+   * The DnD hook's "we just finished a drag" flag. Browsers fire a
+   * synthetic click on the same element after a real drag's mouseup;
+   * without consulting this flag the trailing click would unexpectedly
+   * open the detail sheet right after the user repositioned the event.
+   */
+  justEndedDrag?: boolean;
   className?: string;
 }
 
@@ -88,6 +95,7 @@ export function ExternalEvent({
   onDragStart,
   onResizeStart,
   isDragging = false,
+  justEndedDrag = false,
   className,
 }: ExternalEventProps) {
   const startTime = new Date(event.startTime);
@@ -121,6 +129,11 @@ export function ExternalEvent({
     // slot to create a time block" handler — without this, clicking an
     // event ALSO opened the create-time-block dialog.
     e.stopPropagation();
+    // Suppress the trailing click after a real drag completes —
+    // browsers fire mouseup → click on the same element, and without
+    // this guard the detail sheet would unexpectedly open right after
+    // the user repositioned the event.
+    if (justEndedDrag) return;
     // Delegate to the parent — typically opens an in-app detail sheet
     // rather than redirecting to the provider's web UI.
     onClick?.();

--- a/apps/web/src/components/calendar/external-event.tsx
+++ b/apps/web/src/components/calendar/external-event.tsx
@@ -38,6 +38,19 @@ interface ExternalEventProps {
    */
   layout?: LayoutResult;
   onClick?: () => void;
+  /**
+   * Optional drag-to-reschedule entry point. Receives the native mouse
+   * event from `mousedown` on the event body. Resize-edge handlers
+   * stopPropagation so dragging an edge resizes instead of moving.
+   * Only wired for editable events — read-only events stay click-only.
+   */
+  onDragStart?: (e: React.MouseEvent) => void;
+  /**
+   * Resize handler — receives the edge being grabbed.
+   */
+  onResizeStart?: (e: React.MouseEvent, edge: "top" | "bottom") => void;
+  /** True while THIS event is being dragged — used for visual feedback. */
+  isDragging?: boolean;
   className?: string;
 }
 
@@ -72,6 +85,9 @@ export function ExternalEvent({
   displayDate,
   layout = { lane: 0, columnCount: 1 },
   onClick,
+  onDragStart,
+  onResizeStart,
+  isDragging = false,
   className,
 }: ExternalEventProps) {
   const startTime = new Date(event.startTime);
@@ -110,6 +126,26 @@ export function ExternalEvent({
     onClick?.();
   };
 
+  const handleMouseDown = (e: React.MouseEvent) => {
+    // If user grabbed a resize handle, the resize handler stopped
+    // propagation already and this never fires. Otherwise: start
+    // a move-event drag. The DnD hook tracks `justEndedDrag` to
+    // suppress the trailing click when the mouse actually moved.
+    if (!onDragStart) return;
+    if ((e.target as HTMLElement).dataset.resize) return;
+    onDragStart(e);
+  };
+
+  const handleTopResize = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onResizeStart?.(e, "top");
+  };
+
+  const handleBottomResize = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onResizeStart?.(e, "bottom");
+  };
+
   const calendarName = event.calendar?.name || "External Calendar";
 
   return (
@@ -121,7 +157,11 @@ export function ExternalEvent({
             className={cn(
               "absolute z-[5] my-0.5 rounded-md border-l-[3px] transition-all select-none",
               "hover:brightness-90 hover:z-[15]",
-              "cursor-pointer",
+              isDragging
+                ? "opacity-50 cursor-grabbing"
+                : onDragStart
+                  ? "cursor-grab"
+                  : "cursor-pointer",
               className
             )}
             style={{
@@ -138,6 +178,7 @@ export function ExternalEvent({
               borderColor: hexToRgba(color, 0.5),
             }}
             onClick={handleClick}
+            onMouseDown={handleMouseDown}
             role="button"
             tabIndex={0}
             aria-label={`Calendar event: ${event.title} from ${format(startTime, "h:mm a")} to ${format(endTime, "h:mm a")}`}
@@ -148,6 +189,23 @@ export function ExternalEvent({
               }
             }}
           >
+            {/* Top resize handle — only when editable. Tagged with
+                `data-resize` so the body's mousedown bails out. */}
+            {onResizeStart && !continuesFromPriorDay && (
+              <div
+                data-resize="top"
+                onMouseDown={handleTopResize}
+                className="absolute top-0 left-0 right-0 h-1.5 cursor-ns-resize hover:bg-foreground/10 rounded-t-md"
+              />
+            )}
+            {/* Bottom resize handle */}
+            {onResizeStart && !continuesToNextDay && (
+              <div
+                data-resize="bottom"
+                onMouseDown={handleBottomResize}
+                className="absolute bottom-0 left-0 right-0 h-1.5 cursor-ns-resize hover:bg-foreground/10 rounded-b-md"
+              />
+            )}
             {/* Content */}
             <div
               className={cn(

--- a/apps/web/src/components/calendar/timeline.tsx
+++ b/apps/web/src/components/calendar/timeline.tsx
@@ -361,9 +361,13 @@ export function Timeline({
             {!isLoading &&
               timedEvents.map((event) => {
                 const canEdit = externalEventCanEdit?.(event) ?? false;
+                // Match move + both resize types so the original event
+                // dims while the user is resizing AND while dragging.
                 const isThisDragging =
-                  dragState?.type === "move-event" &&
-                  dragState.eventId === event.id;
+                  dragState?.eventId === event.id &&
+                  (dragState.type === "move-event" ||
+                    dragState.type === "resize-event-top" ||
+                    dragState.type === "resize-event-bottom");
                 return (
                   <ExternalEvent
                     key={event.id}
@@ -389,6 +393,7 @@ export function Timeline({
                         : undefined
                     }
                     isDragging={isThisDragging}
+                    justEndedDrag={justEndedDrag}
                   />
                 );
               })}
@@ -415,13 +420,18 @@ export function Timeline({
                 title={
                   dragState.task?.title ||
                   dragState.block?.title ||
+                  dragState.event?.title ||
                   "New Time Block"
                 }
                 startTime={dropPreview.startTime}
                 endTime={dropPreview.endTime}
                 top={dropPreview.top}
                 height={dropPreview.height}
-                {...(dragState.block?.color ? { color: dragState.block.color } : {})}
+                {...(dragState.block?.color
+                  ? { color: dragState.block.color }
+                  : dragState.event?.calendar?.color
+                    ? { color: dragState.event.calendar.color }
+                    : {})}
               />
             )}
           </div>

--- a/apps/web/src/components/calendar/timeline.tsx
+++ b/apps/web/src/components/calendar/timeline.tsx
@@ -43,6 +43,19 @@ interface TimelineProps {
   onViewTask?: (taskId: string) => void;
   /** Fired when the user clicks an external (Google/Outlook/iCloud) event */
   onExternalEventClick?: (event: CalendarEvent) => void;
+  /** Fired when the user starts dragging an editable external event */
+  onExternalEventDragStart?: (event: CalendarEvent, e: React.MouseEvent) => void;
+  /** Fired when the user starts resizing an editable external event */
+  onExternalEventResizeStart?: (
+    event: CalendarEvent,
+    edge: "top" | "bottom",
+    e: React.MouseEvent
+  ) => void;
+  /**
+   * Lookup of `eventId → can-write` so editable events get drag handles
+   * and read-only events stay click-only.
+   */
+  externalEventCanEdit?: (event: CalendarEvent) => boolean;
   onTimelineMouseMove?: (e: React.MouseEvent) => void;
   onTimelineMouseUp?: () => void;
   onTimelineMouseLeave?: () => void;
@@ -78,6 +91,9 @@ export function Timeline({
   onBlockResizeStart,
   onViewTask,
   onExternalEventClick,
+  onExternalEventDragStart,
+  onExternalEventResizeStart,
+  externalEventCanEdit,
   onTimelineMouseMove,
   onTimelineMouseUp,
   onTimelineMouseLeave,
@@ -343,19 +359,39 @@ export function Timeline({
 
             {/* External calendar events (rendered behind time blocks) */}
             {!isLoading &&
-              timedEvents.map((event) => (
-                <ExternalEvent
-                  key={event.id}
-                  event={event}
-                  displayDate={date}
-                  layout={itemLayouts.get(`event:${event.id}`) ?? DEFAULT_LAYOUT}
-                  onClick={
-                    onExternalEventClick
-                      ? () => onExternalEventClick(event)
-                      : undefined
-                  }
-                />
-              ))}
+              timedEvents.map((event) => {
+                const canEdit = externalEventCanEdit?.(event) ?? false;
+                const isThisDragging =
+                  dragState?.type === "move-event" &&
+                  dragState.eventId === event.id;
+                return (
+                  <ExternalEvent
+                    key={event.id}
+                    event={event}
+                    displayDate={date}
+                    layout={
+                      itemLayouts.get(`event:${event.id}`) ?? DEFAULT_LAYOUT
+                    }
+                    onClick={
+                      onExternalEventClick
+                        ? () => onExternalEventClick(event)
+                        : undefined
+                    }
+                    onDragStart={
+                      canEdit && onExternalEventDragStart
+                        ? (e) => onExternalEventDragStart(event, e)
+                        : undefined
+                    }
+                    onResizeStart={
+                      canEdit && onExternalEventResizeStart
+                        ? (e, edge) =>
+                            onExternalEventResizeStart(event, edge, e)
+                        : undefined
+                    }
+                    isDragging={isThisDragging}
+                  />
+                );
+              })}
 
             {/* Time blocks */}
             {!isLoading &&

--- a/apps/web/src/hooks/calendar-dnd-types.ts
+++ b/apps/web/src/hooks/calendar-dnd-types.ts
@@ -1,4 +1,4 @@
-import type { Task, TimeBlock } from "@open-sunsama/types";
+import type { Task, TimeBlock, CalendarEvent } from "@open-sunsama/types";
 
 /**
  * Types for drag and drop operations
@@ -7,14 +7,21 @@ export type DragType =
   | "task-to-timeline" // Dragging unscheduled task to timeline
   | "move-block" // Moving existing time block
   | "resize-top" // Resizing block from top edge
-  | "resize-bottom"; // Resizing block from bottom edge
+  | "resize-bottom" // Resizing block from bottom edge
+  | "move-event" // Moving an external calendar event
+  | "resize-event-top" // Resizing external event from top
+  | "resize-event-bottom"; // Resizing external event from bottom
 
 export interface DragState {
   type: DragType;
   taskId?: string;
   blockId?: string;
+  /** External calendar event id for move-event / resize-event-* */
+  eventId?: string;
   task?: Task;
   block?: TimeBlock;
+  /** External event being dragged */
+  event?: CalendarEvent;
   startY: number;
   currentY: number;
   initialStartTime?: Date;
@@ -32,4 +39,15 @@ export interface CalendarDndOptions {
   onTaskDrop?: (taskId: string, startTime: Date, endTime: Date) => void;
   onBlockMove?: (blockId: string, startTime: Date, endTime: Date) => void;
   onBlockResize?: (blockId: string, startTime: Date, endTime: Date) => void;
+  /**
+   * Fired after the user finishes dragging an external calendar event
+   * to a new time slot. Receives the new times so the parent can
+   * write the change back to the provider.
+   */
+  onEventMove?: (eventId: string, startTime: Date, endTime: Date) => void;
+  /**
+   * Fired after the user finishes resizing an external event from
+   * either edge.
+   */
+  onEventResize?: (eventId: string, startTime: Date, endTime: Date) => void;
 }

--- a/apps/web/src/hooks/useCalendarDnd.ts
+++ b/apps/web/src/hooks/useCalendarDnd.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from "react";
-import type { Task, TimeBlock } from "@open-sunsama/types";
+import type { Task, TimeBlock, CalendarEvent } from "@open-sunsama/types";
 import type { DragState, DropPreview, CalendarDndOptions } from "./calendar-dnd-types";
 import {
   calculateTimeFromY,
@@ -76,6 +76,45 @@ export function useCalendarDnd(
   );
 
   /**
+   * Start dragging an external calendar event to a new time slot.
+   * Mirrors `startBlockDrag` — the move math doesn't care whether the
+   * draggable thing is a TimeBlock or a CalendarEvent, only its
+   * current start/end pair.
+   */
+  const startEventDrag = useCallback(
+    (event: CalendarEvent, startY: number) => {
+      setDragState({
+        type: "move-event",
+        eventId: event.id,
+        event,
+        startY,
+        currentY: startY,
+        initialStartTime: new Date(event.startTime),
+        initialEndTime: new Date(event.endTime),
+      });
+    },
+    []
+  );
+
+  /**
+   * Start resizing an external calendar event from one of its edges.
+   */
+  const startEventResize = useCallback(
+    (event: CalendarEvent, edge: "top" | "bottom", startY: number) => {
+      setDragState({
+        type: edge === "top" ? "resize-event-top" : "resize-event-bottom",
+        eventId: event.id,
+        event,
+        startY,
+        currentY: startY,
+        initialStartTime: new Date(event.startTime),
+        initialEndTime: new Date(event.endTime),
+      });
+    },
+    []
+  );
+
+  /**
    * Start resizing a time block
    */
   const startBlockResize = useCallback(
@@ -141,6 +180,37 @@ export function useCalendarDnd(
           }
           break;
         }
+        case "move-event": {
+          if (dragState.event) {
+            const deltaY = currentY - dragState.startY;
+            // calculateMovePreview reads only `startTime` / `endTime`
+            // off its second arg, so a CalendarEvent satisfies its
+            // structural contract.
+            const preview = calculateMovePreview(
+              deltaY,
+              dragState.event as unknown as TimeBlock,
+              selectedDate
+            );
+            setDropPreview(preview);
+          }
+          break;
+        }
+        case "resize-event-top":
+        case "resize-event-bottom": {
+          if (dragState.event) {
+            const deltaY = currentY - dragState.startY;
+            const edge =
+              dragState.type === "resize-event-top" ? "top" : "bottom";
+            const preview = calculateResizePreview(
+              deltaY,
+              dragState.event as unknown as TimeBlock,
+              edge,
+              selectedDate
+            );
+            setDropPreview(preview);
+          }
+          break;
+        }
       }
     },
     [dragState, selectedDate]
@@ -174,6 +244,17 @@ export function useCalendarDnd(
         case "resize-bottom":
           if (dragState.blockId) {
             options?.onBlockResize?.(dragState.blockId, startTime, endTime);
+          }
+          break;
+        case "move-event":
+          if (dragState.eventId) {
+            options?.onEventMove?.(dragState.eventId, startTime, endTime);
+          }
+          break;
+        case "resize-event-top":
+        case "resize-event-bottom":
+          if (dragState.eventId) {
+            options?.onEventResize?.(dragState.eventId, startTime, endTime);
           }
           break;
       }
@@ -211,6 +292,8 @@ export function useCalendarDnd(
     startTaskDrag,
     startBlockDrag,
     startBlockResize,
+    startEventDrag,
+    startEventResize,
     updateDrag,
     endDrag,
     cancelDrag,


### PR DESCRIPTION
## Summary

Phase 4's signature feature: grab a Google Calendar event on the day timeline and drop it at a new time, or grab its top/bottom edge to resize. Writes through to the provider via the existing PATCH path with optimistic UI.

- New DnD types: \`move-event\`, \`resize-event-top\`, \`resize-event-bottom\`. Mirror the existing block-drag plumbing — \`calculateMovePreview\` and \`calculateResizePreview\` are agnostic to type because they only read \`startTime\` / \`endTime\`.
- ExternalEvent gets \`onDragStart\`, \`onResizeStart\`, \`isDragging\`, \`justEndedDrag\` props. Editable events get grab cursor + edge handles; read-only events stay click-only.
- CalendarView wires the chain: editability gate via the existing provider-write-back map, mounts \`useUpdateCalendarEvent\`, routes the DnD callbacks. Cross-range optimistic update + rollback comes for free.
- DragOverlay learned an \`EventDragPreview\` branch tinted with the source-calendar color so the user can confirm at a glance which calendar they're editing.

Scope: single-day Timeline only. Multi-day (week / 3-day) drag is a follow-up — it needs per-column bounding rects which the current single-\`timelineRef\` DnD context can't represent.

## Test plan

- [ ] Drag an editable Google event to a new time → it lands at the new slot, Google Calendar reflects the change, no detail sheet opens.
- [ ] Drag the top edge → start time changes, end stays; resize cursor visible.
- [ ] Drag the bottom edge → end time changes, start stays.
- [ ] Read-only or Outlook event: cursor is pointer, no drag handles, click still opens the detail sheet.
- [ ] All-day event: no drag.
- [ ] Mid-drag floating preview shows the event's title and calendar tint.
- [ ] Original event dims to 50% during the drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)