### PR TITLE
fix(calendar): shortcut menu guard + drag day-boundary clamp + single TooltipProvider

### DIFF
--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -382,10 +382,16 @@ export function CalendarView({
       }
       // Radix open overlays are tagged with `data-state="open"`. If
       // any modal-style overlay is mounted-and-open, swallow the
-      // shortcut.
+      // shortcut. We cover dialog (Sheet/Dialog), alertdialog
+      // (confirm prompts), AND menu (ContextMenu / DropdownMenu) —
+      // without the menu match, right-clicking a time block to open
+      // its context menu and then pressing a letter shortcut would
+      // silently switch the calendar view behind the open menu.
       if (
         document.querySelector(
-          '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]'
+          '[role="dialog"][data-state="open"], ' +
+          '[role="alertdialog"][data-state="open"], ' +
+          '[role="menu"][data-state="open"]'
         )
       ) {
         return;

--- a/apps/web/src/components/calendar/external-event.tsx
+++ b/apps/web/src/components/calendar/external-event.tsx
@@ -16,7 +16,6 @@ import {
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui";
 import type { LayoutResult } from "./event-layout";
@@ -162,9 +161,8 @@ export function ExternalEvent({
   const calendarName = event.calendar?.name || "External Calendar";
 
   return (
-    <TooltipProvider>
-      <Tooltip delayDuration={300}>
-        <TooltipTrigger asChild>
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
           <div
             data-external-event
             className={cn(
@@ -292,8 +290,7 @@ export function ExternalEvent({
             )}
           </div>
         </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    </Tooltip>
   );
 }
 
@@ -320,9 +317,8 @@ export function AllDayEvent({
   };
 
   return (
-    <TooltipProvider>
-      <Tooltip delayDuration={300}>
-        <TooltipTrigger asChild>
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
           <div
             data-all-day-event
             className={cn(
@@ -364,7 +360,6 @@ export function AllDayEvent({
             )}
           </div>
         </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    </Tooltip>
   );
 }

--- a/apps/web/src/hooks/calendar-dnd-utils.ts
+++ b/apps/web/src/hooks/calendar-dnd-utils.ts
@@ -79,6 +79,19 @@ export function calculateTaskDropPreview(
 }
 
 /**
+ * The lowest start-of-minute slot the timeline allows. Set to
+ * (TIMELINE_END_HOUR + 1) so dragging an event to "midnight tomorrow"
+ * is forbidden — without this clamp, dragging a 4h event past 23:00
+ * silently produces an event that crosses midnight onto the next day,
+ * persisting on a date the user wasn't viewing.
+ */
+const TIMELINE_END_MINUTE = (TIMELINE_END_HOUR + 1) * 60; // 24 * 60 = 1440
+
+function minutesFromMidnight(d: Date): number {
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+/**
  * Calculate preview for moving a time block
  */
 export function calculateMovePreview(
@@ -90,12 +103,22 @@ export function calculateMovePreview(
     new Date(block.endTime),
     new Date(block.startTime)
   );
-  
+
   const originalTop = calculateYFromTime(new Date(block.startTime));
   const newTop = Math.max(0, originalTop + deltaY);
-  
+
   const rawStartTime = calculateTimeFromY(newTop, baseDate);
-  const startTime = snapToInterval(rawStartTime);
+  let startTime = snapToInterval(rawStartTime);
+
+  // Clamp the start so the entire event still fits inside the day.
+  // Without this, a 4h event dragged past 20:00 would silently roll
+  // onto the next day's date.
+  const startMins = minutesFromMidnight(startTime);
+  const maxStartMins = TIMELINE_END_MINUTE - originalDuration;
+  if (startMins > maxStartMins) {
+    const overflow = startMins - maxStartMins;
+    startTime = addMinutes(startTime, -overflow);
+  }
   const endTime = addMinutes(startTime, originalDuration);
 
   const top = calculateYFromTime(startTime);
@@ -137,7 +160,16 @@ export function calculateResizePreview(
     const newBottom = originalBottom + deltaY;
     const rawEndTime = calculateTimeFromY(newBottom, baseDate);
     endTime = snapToInterval(rawEndTime);
-    
+
+    // Clamp end so it can't spill past midnight onto the next day.
+    const endMins = minutesFromMidnight(endTime);
+    if (endMins === 0 && endTime.getDate() !== originalStart.getDate()) {
+      // Crossed into next day — pull back to end-of-day.
+      endTime = addMinutes(originalStart, TIMELINE_END_MINUTE - minutesFromMidnight(originalStart));
+    } else if (endMins > TIMELINE_END_MINUTE) {
+      endTime = addMinutes(endTime, -(endMins - TIMELINE_END_MINUTE));
+    }
+
     // Ensure minimum duration
     const duration = differenceInMinutes(endTime, startTime);
     if (duration < MIN_BLOCK_DURATION) {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,6 +10,7 @@ import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client
 import { HelmetProvider } from "react-helmet-async";
 import { AuthProvider } from "@/hooks/useAuth";
 import { ThemeProvider } from "@/hooks/useTheme";
+import { TooltipProvider } from "@/components/ui";
 import { useTimezoneSync } from "@/hooks/useTimezoneSync";
 import { persister, shouldPersistQueryFn } from "@/lib/query-persister";
 import { installChunkErrorRecovery } from "@/lib/chunk-error-recovery";
@@ -113,9 +114,17 @@ function App() {
   const inner = (
     <AuthProvider>
       <ThemeProvider>
-        <TimezoneSync>
-          <RouterProvider router={router} />
-        </TimezoneSync>
+        {/* Single app-wide TooltipProvider so individual leaf
+            components don't have to mount their own — a busy week
+            view used to instantiate 50+ providers. Children that
+            need different timing (e.g. add-task-inline with
+            delayDuration={0}) can still nest their own; Radix
+            allows nesting and inner overrides outer. */}
+        <TooltipProvider delayDuration={300}>
+          <TimezoneSync>
+            <RouterProvider router={router} />
+          </TimezoneSync>
+        </TooltipProvider>
       </ThemeProvider>
     </AuthProvider>
   );


### PR DESCRIPTION
## Summary

End-to-end audit found three more bugs after the drag-to-reschedule ship:

1. **Shortcut guard missed open ContextMenu.** Right-clicking a time block opens a Radix ContextMenu (\`role=\"menu\"\`), not a dialog — pressing M/W/D inside an open menu silently switched the calendar view behind it. Extended the overlay-aware selector to cover \`[role=\"menu\"][data-state=\"open\"]\`.

2. **Drag/resize could spill events past midnight.** \`calculateMovePreview\` only clamped the top of the drag, never the bottom — a 4h event dragged past 20:00 would silently roll onto the next day and persist on a date the user wasn't viewing. Visual clipped at \`dayEnd\` so the spill was invisible. Added \`TIMELINE_END_MINUTE\` clamp on both move (start + duration ≤ end-of-day) and resize (end can't cross midnight).

3. **TooltipProvider mounted per ExternalEvent.** A busy week view created 50+ Provider instances. Consolidated into a single app-level provider in \`main.tsx\` and removed per-event wrappers. Children that need different timing (e.g. \`add-task-inline\`) keep their nested providers — Radix supports nesting, inner overrides outer.

## Test plan

- [ ] Right-click a time block → press W → no view change. Close menu → press W → switches.
- [ ] Drag a 4h event past 20:00 → clamps to start at 20:00, never spills to tomorrow.
- [ ] Drag a 30min event past 23:45 → clamps to start at 23:30.
- [ ] Resize bottom edge past midnight → clamps at end-of-day.
- [ ] Hover an external event → tooltip still appears with the right delay.
- [ ] Hover the kanban add-task hint → tooltip appears with delay=0 (nested provider still wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)