### PR TITLE
fix(calendar): clean errors + auto-cleanup when Google says event is gone

### DIFF
--- a/apps/api/src/routes/calendar-events.ts
+++ b/apps/api/src/routes/calendar-events.ts
@@ -28,6 +28,8 @@ import {
 } from '../services/calendar-sync.js';
 import {
   ProviderReadOnlyError,
+  ProviderEventNotFoundError,
+  ProviderAuthError,
   type EventPatch,
 } from '../services/calendar-providers/index.js';
 import { publishEvent } from '../lib/websocket/index.js';
@@ -317,6 +319,32 @@ calendarEventsRouter.post(
           409
         );
       }
+      if (err instanceof ProviderEventNotFoundError) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: 'CALENDAR_OUT_OF_SYNC',
+              message:
+                'This calendar is out of sync. Run "Reset & re-sync" in Settings.',
+            },
+          },
+          410
+        );
+      }
+      if (err instanceof ProviderAuthError) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: 'PROVIDER_AUTH_FAILED',
+              message:
+                'Your calendar connection needs to be re-authorized. Reconnect the account in Settings.',
+            },
+          },
+          401
+        );
+      }
       const message = err instanceof Error ? err.message : 'Unknown error';
       return c.json(
         {
@@ -499,6 +527,42 @@ calendarEventsRouter.patch(
           409
         );
       }
+      if (err instanceof ProviderEventNotFoundError) {
+        // The event no longer exists upstream — most likely deleted in
+        // the provider's UI, or a residue of pre-PR-#21 attribution
+        // corruption pointing our local row at a calendar/event id
+        // pair that doesn't match Google. Either way, the local row
+        // is stale; remove it so the next refetch hides it instead of
+        // surfacing the same broken event again. Return 410 with a
+        // clean, actionable message.
+        await db
+          .delete(calendarEvents)
+          .where(eq(calendarEvents.id, eventId));
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: 'EVENT_OUT_OF_SYNC',
+              message:
+                'This event is out of sync with your calendar. Refresh or run "Reset & re-sync" in Settings.',
+            },
+          },
+          410
+        );
+      }
+      if (err instanceof ProviderAuthError) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: 'PROVIDER_AUTH_FAILED',
+              message:
+                'Your calendar connection needs to be re-authorized. Reconnect the account in Settings.',
+            },
+          },
+          401
+        );
+      }
       const message = err instanceof Error ? err.message : 'Unknown error';
       return c.json(
         {
@@ -626,6 +690,19 @@ calendarEventsRouter.delete(
             error: { code: 'PROVIDER_READ_ONLY', message: err.message },
           },
           409
+        );
+      }
+      if (err instanceof ProviderAuthError) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: 'PROVIDER_AUTH_FAILED',
+              message:
+                'Your calendar connection needs to be re-authorized. Reconnect the account in Settings.',
+            },
+          },
+          401
         );
       }
       const message = err instanceof Error ? err.message : 'Unknown error';

--- a/apps/api/src/services/calendar-providers/google.ts
+++ b/apps/api/src/services/calendar-providers/google.ts
@@ -11,6 +11,10 @@ import type {
   SyncResult,
 } from './index';
 import {
+  ProviderAuthError,
+  ProviderEventNotFoundError,
+} from './index';
+import {
   getClientId,
   getClientSecret,
   parseGoogleEvent,
@@ -254,6 +258,12 @@ export class GoogleCalendarProvider implements CalendarProvider {
     );
 
     if (!response.ok) {
+      if (response.status === 404 || response.status === 410) {
+        throw new ProviderEventNotFoundError('google');
+      }
+      if (response.status === 401 || response.status === 403) {
+        throw new ProviderAuthError('google');
+      }
       const error = await response.text();
       throw new Error(
         `Google createEvent failed (${response.status}): ${error}`
@@ -322,6 +332,15 @@ export class GoogleCalendarProvider implements CalendarProvider {
     );
 
     if (!response.ok) {
+      // Map common Google error codes to typed errors so the route
+      // layer can produce clean, actionable messages instead of
+      // forwarding the raw Google JSON to the user.
+      if (response.status === 404 || response.status === 410) {
+        throw new ProviderEventNotFoundError('google');
+      }
+      if (response.status === 401 || response.status === 403) {
+        throw new ProviderAuthError('google');
+      }
       const error = await response.text();
       throw new Error(
         `Google updateEvent failed (${response.status}): ${error}`
@@ -351,9 +370,12 @@ export class GoogleCalendarProvider implements CalendarProvider {
       }
     );
 
-    // 410 Gone = already deleted upstream. Treat as success — local row
-    // will be cleaned up alongside.
+    // 404 / 410 = already deleted upstream. Treat as success — local
+    // row will be cleaned up alongside.
     if (!response.ok && response.status !== 410 && response.status !== 404) {
+      if (response.status === 401 || response.status === 403) {
+        throw new ProviderAuthError('google');
+      }
       const error = await response.text();
       throw new Error(
         `Google deleteEvent failed (${response.status}): ${error}`

--- a/apps/api/src/services/calendar-providers/index.ts
+++ b/apps/api/src/services/calendar-providers/index.ts
@@ -120,6 +120,37 @@ export class ProviderReadOnlyError extends Error {
   }
 }
 
+/**
+ * Thrown when the upstream provider says the event no longer exists
+ * (HTTP 404 / 410). The most common cause is local data drift — the
+ * event was deleted in the provider's UI, or our local row points at
+ * a calendar/event id pair that doesn't match upstream (typically a
+ * residue of pre-PR-#21 attribution corruption).
+ *
+ * Routes translate this into a 410 Gone with a clean, actionable
+ * message; clients also use the signal to trigger a quick re-sync
+ * of the affected account so the next attempt has fresh data.
+ */
+export class ProviderEventNotFoundError extends Error {
+  readonly code = 'EVENT_NOT_FOUND_UPSTREAM' as const;
+  constructor(provider: string) {
+    super(`${provider} no longer has this event`);
+    this.name = 'ProviderEventNotFoundError';
+  }
+}
+
+/**
+ * Thrown when the access token is rejected (401 / 403) and the
+ * refresh path can't recover. Client should prompt re-auth.
+ */
+export class ProviderAuthError extends Error {
+  readonly code = 'PROVIDER_AUTH_FAILED' as const;
+  constructor(provider: string) {
+    super(`${provider} authentication failed — please reconnect the account`);
+    this.name = 'ProviderAuthError';
+  }
+}
+
 export { GoogleCalendarProvider } from './google';
 export { OutlookCalendarProvider } from './outlook';
 export { ICloudCalendarProvider } from './icloud';

--- a/apps/web/src/hooks/useCalendars.ts
+++ b/apps/web/src/hooks/useCalendars.ts
@@ -6,9 +6,49 @@ import type {
   ConnectCalDavRequest,
   UpdateCalendarRequest,
 } from "@open-sunsama/types";
+import { isApiError } from "@open-sunsama/api-client";
 import { getApiClient } from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
 import { calendarKeys } from "@/lib/query-keys";
+
+/**
+ * Map a write-back API error into a human-readable {title, description}
+ * pair. The server already produces clean message strings for known
+ * codes (EVENT_OUT_OF_SYNC, PROVIDER_AUTH_FAILED, etc.); this helper
+ * just gives them friendlier titles and falls back to generic for
+ * unknown errors.
+ */
+function describeWriteBackError(error: unknown, action: "update" | "delete" | "create"): { title: string; description: string } {
+  const verb = action === "update" ? "updated" : action === "delete" ? "deleted" : "created";
+  if (isApiError(error)) {
+    if (error.code === "EVENT_OUT_OF_SYNC" || error.code === "CALENDAR_OUT_OF_SYNC") {
+      return {
+        title: "Event out of sync",
+        description: error.message,
+      };
+    }
+    if (error.code === "PROVIDER_AUTH_FAILED") {
+      return {
+        title: "Reconnect your calendar",
+        description: error.message,
+      };
+    }
+    if (error.code === "PROVIDER_READ_ONLY" || error.code === "CALENDAR_READ_ONLY") {
+      return {
+        title: "Read-only calendar",
+        description: error.message,
+      };
+    }
+    return {
+      title: `Failed to ${action} event`,
+      description: error.message,
+    };
+  }
+  return {
+    title: `Failed to ${action} event`,
+    description: error instanceof Error ? error.message : `Couldn't be ${verb}.`,
+  };
+}
 
 // Canonical key factory lives in lib/query-keys; re-exported for callers.
 export { calendarKeys };
@@ -299,11 +339,8 @@ export function useCreateCalendarEvent() {
       queryClient.invalidateQueries({ queryKey: calendarKeys.all });
     },
     onError: (error) => {
-      toast({
-        variant: "destructive",
-        title: "Failed to create event",
-        description: error instanceof Error ? error.message : "Unknown error",
-      });
+      const { title, description } = describeWriteBackError(error, "create");
+      toast({ variant: "destructive", title, description });
     },
   });
 }
@@ -418,11 +455,15 @@ export function useUpdateCalendarEvent() {
           queryClient.setQueryData(key, prior);
         }
       }
-      toast({
-        variant: "destructive",
-        title: "Failed to update event",
-        description: error instanceof Error ? error.message : "Unknown error",
-      });
+      const { title, description } = describeWriteBackError(error, "update");
+      toast({ variant: "destructive", title, description });
+      // EVENT_OUT_OF_SYNC means the server already cleaned up the
+      // stale local row — refetch so the dead event disappears from
+      // the UI. (The standard onSettled invalidation also fires, but
+      // doing this here ensures we cover the rollback path too.)
+      if (isApiError(error) && error.code === "EVENT_OUT_OF_SYNC") {
+        queryClient.invalidateQueries({ queryKey: calendarKeys.all });
+      }
     },
     onSettled: () => {
       // Invalidate ALL cached calendar-event ranges so other open
@@ -482,11 +523,8 @@ export function useDeleteCalendarEvent() {
           queryClient.setQueryData(key, prior);
         }
       }
-      toast({
-        variant: "destructive",
-        title: "Failed to delete event",
-        description: error instanceof Error ? error.message : "Unknown error",
-      });
+      const { title, description } = describeWriteBackError(error, "delete");
+      toast({ variant: "destructive", title, description });
     },
     onSettled: () => {
       // Invalidate ALL cached ranges — same reasoning as update.


### PR DESCRIPTION
## Summary

User reported drag-to-reschedule failing with raw Google JSON in the toast (\`Google updateEvent failed (404): { \"error\": ... }\`). Two problems:

1. **Local row was stale** — Google's 404 means our local row points at an upstream event/calendar id pair that doesn't match. Either the event was deleted in Google's UI, or it's residual data drift from before the per-calendar attribution fix (PR #21). Trying to PATCH it would keep failing forever.
2. **Error message was unactionable** — dumping raw upstream JSON helps nobody.

Fix:
- Provider contract gets typed errors: \`ProviderEventNotFoundError\` (404/410) and \`ProviderAuthError\` (401/403). Google's create/update/delete map status codes to these instead of forwarding raw text.
- PATCH route catches \`ProviderEventNotFoundError\`, deletes the stale local row, returns 410 with a clean message pointing to \"Reset & re-sync\".
- Client \`describeWriteBackError\` helper turns typed errors into friendly toast titles (\"Event out of sync\", \"Reconnect your calendar\", \"Read-only calendar\") and forces a cache invalidation on EVENT_OUT_OF_SYNC so the dead row vanishes from the UI.

## Test plan

- [ ] Drag a stale event (404 from Google) → toast says \"Event out of sync\" with the actionable message; the broken event disappears from the UI.
- [ ] Drag a healthy event → updates normally.
- [ ] If access token is rejected → toast says \"Reconnect your calendar\" with the right message; user goes to Settings.
- [ ] Edit a read-only calendar event → still gets the read-only message (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)