### PR TITLE
fix(calendar): stale flash + read-only events-default + token null guard

### DIFF
--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -15,6 +15,7 @@ import { decrypt, encrypt } from './encryption.js';
 import {
   GoogleCalendarProvider,
   OutlookCalendarProvider,
+  ProviderAuthError,
   type CalendarProvider,
   type SyncOptions,
   type ExternalEvent,
@@ -47,11 +48,19 @@ export async function refreshTokensIfNeeded(
   provider: CalendarProvider
 ): Promise<string> {
   const db = getDb();
-  let accessToken = decrypt(account.accessTokenEncrypted!);
+  // Throw a typed auth error instead of crashing the decrypt path
+  // with an unhelpful crypto stack trace. The route layer maps this
+  // to a clean 401 with a "Reconnect your calendar" toast. The most
+  // common cause is a partially-disconnected account whose token
+  // column was nulled out without flipping isActive.
+  if (!account.accessTokenEncrypted) {
+    throw new ProviderAuthError(account.provider);
+  }
+  let accessToken = decrypt(account.accessTokenEncrypted);
 
   if (account.tokenExpiresAt && new Date(account.tokenExpiresAt) < new Date()) {
     if (!account.refreshTokenEncrypted) {
-      throw new Error('Token expired and no refresh token available');
+      throw new ProviderAuthError(account.provider);
     }
 
     const refreshToken = decrypt(account.refreshTokenEncrypted);

--- a/apps/web/src/components/settings/calendar-account-card.tsx
+++ b/apps/web/src/components/settings/calendar-account-card.tsx
@@ -126,15 +126,22 @@ export function CalendarItem({
         <button
           type="button"
           onClick={onSetDefaultEvents}
-          disabled={isUpdating || !calendar.isEnabled}
+          disabled={
+            isUpdating || !calendar.isEnabled || calendar.isReadOnly
+          }
           className={cn(
             "flex h-7 items-center gap-1 rounded-md border px-2 text-xs transition-colors",
             defaultForEvents
               ? "border-primary bg-primary/10 text-primary"
               : "border-transparent text-muted-foreground hover:border-border hover:text-foreground",
-            (!calendar.isEnabled || isUpdating) && "cursor-not-allowed opacity-50"
+            (!calendar.isEnabled || isUpdating || calendar.isReadOnly) &&
+              "cursor-not-allowed opacity-50"
           )}
-          title="Set as default for new events"
+          title={
+            calendar.isReadOnly
+              ? "Read-only calendars can't be a default for new events"
+              : "Set as default for new events"
+          }
         >
           {defaultForEvents && <CheckCircle2 className="h-3 w-3" />}
           Events

--- a/apps/web/src/hooks/useCalendars.ts
+++ b/apps/web/src/hooks/useCalendars.ts
@@ -449,19 +449,33 @@ export function useUpdateCalendarEvent() {
       }
       return { snapshots };
     },
-    onError: (error, _input, context) => {
+    onError: (error, input, context) => {
+      const isOutOfSync =
+        isApiError(error) && error.code === "EVENT_OUT_OF_SYNC";
       if (context?.snapshots) {
-        for (const [key, prior] of context.snapshots) {
-          queryClient.setQueryData(key, prior);
+        if (isOutOfSync) {
+          // The server has already deleted the stale row — restoring
+          // the snapshot would put the dead event back in the cache
+          // for the brief window before the refetch lands, causing a
+          // visible flash. Filter the event out of every cached range
+          // instead, so it disappears immediately and stays gone.
+          for (const [key, prior] of context.snapshots) {
+            queryClient.setQueryData<CalendarEvent[]>(
+              key,
+              prior.filter((ev) => ev.id !== input.id)
+            );
+          }
+        } else {
+          // Real failure (validation, auth, network) — restore the
+          // snapshot so the user's pre-mutation state is preserved.
+          for (const [key, prior] of context.snapshots) {
+            queryClient.setQueryData(key, prior);
+          }
         }
       }
       const { title, description } = describeWriteBackError(error, "update");
       toast({ variant: "destructive", title, description });
-      // EVENT_OUT_OF_SYNC means the server already cleaned up the
-      // stale local row — refetch so the dead event disappears from
-      // the UI. (The standard onSettled invalidation also fires, but
-      // doing this here ensures we cover the rollback path too.)
-      if (isApiError(error) && error.code === "EVENT_OUT_OF_SYNC") {
+      if (isOutOfSync) {
         queryClient.invalidateQueries({ queryKey: calendarKeys.all });
       }
     },


### PR DESCRIPTION
## Summary

Three audit-driven follow-ups:

1. **Stale event flash on PATCH 410.** PR #32 deleted the local row when the server returned EVENT_OUT_OF_SYNC, but the client's optimistic-rollback restored the snapshot — including the dead event — for the brief window before the refetch landed. Now the rollback filters the event out of every snapshot when the error code is EVENT_OUT_OF_SYNC; real failures still restore.

2. **Read-only calendar could be set as the events default.** The tasks button had the right \`isReadOnly\` guard but the events button only checked \`isEnabled\`. A user could pick a Holidays / subscribed calendar and then have create-event fail with 409. Added the matching guard + conditional tooltip.

3. **\`accessTokenEncrypted!\` non-null assertion crashed on null.** Decrypt would throw an unhelpful crypto stack for any account row missing its encrypted token. Now throws \`ProviderAuthError\` explicitly, which the existing 401 branch maps to the friendly \"Reconnect your calendar\" toast.

## Test plan

- [ ] Drag a stale event → toast shows once, broken event vanishes immediately (no flash).
- [ ] Settings → Calendar: a Holidays calendar's \"Events\" button is disabled with the read-only tooltip.
- [ ] An account with a corrupted/missing access token now produces a clean 401 instead of a 502 with raw crypto text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)