### PR TITLE
fix(calendar): clear-color label honesty + server-side read-only default guard

### DIFF
--- a/apps/api/src/routes/calendars.ts
+++ b/apps/api/src/routes/calendars.ts
@@ -107,6 +107,46 @@ calendarsRouter.patch(
       throw new NotFoundError('Calendar', id);
     }
 
+    // Server-side guard: a read-only calendar can't be the default
+    // target for new events (the API would 409 on the next create).
+    // The settings UI already disables this button (per PR #33), but
+    // any non-UI client (mobile, MCP, scripted) would otherwise be
+    // able to set it and produce confusing failures down the line.
+    if (
+      updates.isDefaultForEvents === true &&
+      calendar.isReadOnly
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: 'CALENDAR_READ_ONLY',
+            message:
+              "Read-only calendars can't be the default for new events.",
+          },
+        },
+        409
+      );
+    }
+    // Same guard for tasks default — can't put your tasks under a
+    // read-only calendar either.
+    if (
+      updates.isDefaultForTasks === true &&
+      calendar.isReadOnly
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: 'CALENDAR_READ_ONLY',
+            message:
+              "Read-only calendars can't be the default for tasks.",
+          },
+        },
+        409
+      );
+    }
+
     // If setting as default for events, clear other defaults first
     if (updates.isDefaultForEvents === true) {
       await db

--- a/apps/web/src/components/settings/calendar-account-card.tsx
+++ b/apps/web/src/components/settings/calendar-account-card.tsx
@@ -120,7 +120,7 @@ export function CalendarItem({
           value={calendar.color}
           disabled={isUpdating}
           onChange={(c) => onSetColor(c)}
-          onReset={() => onSetColor(null)}
+          onClear={() => onSetColor(null)}
         />
         <span className={cn("text-sm", !calendar.isEnabled && "text-muted-foreground")}>
           {calendar.name}

--- a/apps/web/src/components/settings/calendar-color-picker.tsx
+++ b/apps/web/src/components/settings/calendar-color-picker.tsx
@@ -32,13 +32,20 @@ const PALETTE: Array<{ label: string; hex: string }> = [
 ];
 
 interface CalendarColorPickerProps {
-  /** Current color (override or provider). */
+  /** Current color — provider's at first sync, the user's after. */
   value: string | null;
   /** True while the API call is in flight — disables the trigger. */
   disabled?: boolean;
   onChange: (next: string) => void;
-  /** Optional "reset to provider color" — null clears override. */
-  onReset?: () => void;
+  /**
+   * Clears the color back to null. The dot then renders in the
+   * neutral fallback (grey). We intentionally don't call this
+   * "Reset to provider color" because we don't store the provider's
+   * original color separately — sync only writes color on the
+   * initial insert, so once cleared, the provider color does NOT
+   * come back unless the user disconnects + reconnects the account.
+   */
+  onClear?: () => void;
 }
 
 /**
@@ -52,7 +59,7 @@ export function CalendarColorPicker({
   value,
   disabled,
   onChange,
-  onReset,
+  onClear,
 }: CalendarColorPickerProps) {
   const [open, setOpen] = React.useState(false);
   const display = value ?? "#6B7280";
@@ -106,16 +113,16 @@ export function CalendarColorPicker({
             );
           })}
         </div>
-        {onReset && (
+        {onClear && value !== null && (
           <button
             type="button"
             onClick={() => {
-              onReset();
+              onClear();
               setOpen(false);
             }}
             className="mt-2 w-full rounded px-2 py-1 text-left text-xs text-muted-foreground hover:bg-muted/50"
           >
-            Reset to provider color
+            Clear color
           </button>
         )}
       </PopoverContent>


### PR DESCRIPTION
## Summary

Two follow-up bugs found in audit after the color-override ship.

1. **\"Reset to provider color\" was misleading.** Sync only writes \`color\` on initial insert, so once the user clicks reset the column is just nulled and the dot falls back to neutral grey, never the provider's hex. Renamed the button to \"Clear color\", renamed the prop \`onReset → onClear\`, and hide the button when there's no color to clear.

2. **Server accepted \`isDefaultForEvents: true\` for read-only calendars.** PR #33 disabled the button in the settings UI, but any non-UI client (mobile, MCP, scripted) could still set a read-only Holidays calendar as the default and produce confusing 409 failures on the next event-create. Added matching server-side guards for both \`isDefaultForEvents\` and \`isDefaultForTasks\`.

Also dropped a stray untracked \`multi-day-event-drag.ts\` leftover from a prior in-flight branch.

## Test plan

- [ ] Color picker: when calendar has no override, the \"Clear color\" button is hidden.
- [ ] Setting a color → button appears → click → color clears, dot grey.
- [ ] PATCH /calendars/:id with isDefaultForEvents=true on a Holidays calendar returns 409 CALENDAR_READ_ONLY (was 200 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)