### PR TITLE
feat(calendar): drag-to-reschedule + resize on week and 3-day views

### DIFF
--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -668,6 +668,24 @@ export function CalendarView({
             timeBlocks={timeBlocks}
             isLoading={isLoading}
             onExternalEventClick={handleExternalEventClick}
+            onExternalEventReschedule={(eventId, startTime, endTime) => {
+              // Same write-back path as the day-view drag — the
+              // mutation hook handles optimistic update + rollback +
+              // cross-range invalidation. Browser local TZ preserved
+              // so the round-trip doesn't shift the displayed time.
+              updateCalendarEvent.mutate({
+                id: eventId,
+                rangeFrom: fromDate,
+                rangeTo: toDate,
+                patch: {
+                  startTime,
+                  endTime,
+                  timezone:
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                },
+              });
+            }}
+            externalEventCanEdit={externalEventCanEdit}
             {...(onBlockClick ? { onBlockClick } : {})}
           />
         )}

--- a/apps/web/src/components/calendar/multi-day-event-drag.ts
+++ b/apps/web/src/components/calendar/multi-day-event-drag.ts
@@ -1,0 +1,241 @@
+import * as React from "react";
+import { addMinutes, differenceInMinutes } from "date-fns";
+import {
+  HOUR_HEIGHT,
+  TIMELINE_END_HOUR,
+  TIMELINE_START_HOUR,
+  calculateTimeFromY,
+  snapToInterval,
+  MIN_BLOCK_DURATION,
+} from "@/hooks/useCalendarDnd";
+
+const TIMELINE_END_MINUTE = (TIMELINE_END_HOUR + 1) * 60; // 24*60 = 1440
+const DRAG_THRESHOLD_PX = 4;
+
+function minutesFromMidnight(d: Date): number {
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+export type EventDragMode = "move" | "resize-top" | "resize-bottom";
+
+export interface EventDragState {
+  eventId: string;
+  /** Day this event was grabbed in — drag stays within this day. */
+  dayDate: Date;
+  columnRect: DOMRect;
+  /** scrollTop at drag start, used to compensate for mid-drag scroll. */
+  scrollTopAtStart: number;
+  scrollEl: HTMLElement | null;
+  startY: number;
+  initialStart: Date;
+  initialEnd: Date;
+  mode: EventDragMode;
+  previewStart: Date;
+  previewEnd: Date;
+  /** Tracks whether the mouse moved past the click threshold. */
+  moved: boolean;
+}
+
+export interface EventDragOptions {
+  onCommit: (
+    eventId: string,
+    startTime: Date,
+    endTime: Date,
+    mode: EventDragMode
+  ) => void;
+}
+
+/**
+ * Same-column drag for external calendar events in the multi-day view.
+ *
+ * The single-day Timeline uses `useCalendarDnd` with one global
+ * `timelineRef` — that doesn't translate to multi-day where each day
+ * column has its own bounding rect. This hook keeps the drag scoped
+ * to the column the user grabbed the event in: vertical drag changes
+ * the start/end time within that day; the day itself never changes.
+ *
+ * Cross-column (Mon → Wed) is intentionally out of scope — the user
+ * can use the detail sheet to change the date.
+ */
+export function useMultiDayEventDrag(options: EventDragOptions) {
+  const [dragState, setDragState] = React.useState<EventDragState | null>(null);
+  const dragStateRef = React.useRef<EventDragState | null>(null);
+  React.useEffect(() => {
+    dragStateRef.current = dragState;
+  }, [dragState]);
+
+  // Stash latest options in a ref so the global listeners can call the
+  // most recent onCommit without re-binding on every options change.
+  const optionsRef = React.useRef(options);
+  React.useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
+  const startDrag = React.useCallback(
+    (
+      eventId: string,
+      dayDate: Date,
+      eventStart: Date,
+      eventEnd: Date,
+      mode: EventDragMode,
+      e: React.MouseEvent
+    ) => {
+      e.preventDefault();
+      const target = e.currentTarget as HTMLElement;
+      // Walk up to the column root (marked with `data-day-column`).
+      const column = target.closest<HTMLElement>("[data-day-column]");
+      if (!column) return;
+      const columnRect = column.getBoundingClientRect();
+      const scrollEl =
+        column.closest<HTMLElement>("[data-radix-scroll-area-viewport]") ??
+        null;
+      const scrollTopAtStart = scrollEl?.scrollTop ?? 0;
+      setDragState({
+        eventId,
+        dayDate,
+        columnRect,
+        scrollTopAtStart,
+        scrollEl,
+        startY: e.clientY,
+        initialStart: eventStart,
+        initialEnd: eventEnd,
+        mode,
+        previewStart: eventStart,
+        previewEnd: eventEnd,
+        moved: false,
+      });
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    if (!dragState) return;
+    const handleMove = (e: MouseEvent) => {
+      const ds = dragStateRef.current;
+      if (!ds) return;
+      const liveScroll = ds.scrollEl?.scrollTop ?? ds.scrollTopAtStart;
+      const scrollDelta = liveScroll - ds.scrollTopAtStart;
+      // The cursor's Y relative to the column's top, accounting for
+      // any scrolling that happened during the drag.
+      const relativeY = e.clientY - ds.columnRect.top + scrollDelta;
+      const movedEnough =
+        ds.moved || Math.abs(e.clientY - ds.startY) >= DRAG_THRESHOLD_PX;
+
+      const originalDurationMins = differenceInMinutes(
+        ds.initialEnd,
+        ds.initialStart
+      );
+
+      let previewStart = ds.previewStart;
+      let previewEnd = ds.previewEnd;
+
+      if (ds.mode === "move") {
+        // Anchor the event's top edge to the cursor by computing the
+        // offset between cursor's start position and event's top, then
+        // shifting the new top by the same offset.
+        const initialTopPx =
+          ((minutesFromMidnight(ds.initialStart) - TIMELINE_START_HOUR * 60) /
+            60) *
+          HOUR_HEIGHT;
+        const cursorOffsetWithinEvent =
+          ds.startY - ds.columnRect.top + ds.scrollTopAtStart - initialTopPx;
+        const newTopPx = relativeY - cursorOffsetWithinEvent;
+        const rawStart = calculateTimeFromY(
+          Math.max(0, newTopPx),
+          ds.dayDate
+        );
+        let snappedStart = snapToInterval(rawStart);
+        // Clamp so the event still fits in the day.
+        const startMins = minutesFromMidnight(snappedStart);
+        const maxStart = TIMELINE_END_MINUTE - originalDurationMins;
+        if (startMins > maxStart) {
+          snappedStart = addMinutes(snappedStart, -(startMins - maxStart));
+        }
+        previewStart = snappedStart;
+        previewEnd = addMinutes(snappedStart, originalDurationMins);
+      } else if (ds.mode === "resize-top") {
+        const rawStart = calculateTimeFromY(
+          Math.max(0, relativeY),
+          ds.dayDate
+        );
+        let snappedStart = snapToInterval(rawStart);
+        const minutesBeforeEnd = differenceInMinutes(
+          ds.initialEnd,
+          snappedStart
+        );
+        if (minutesBeforeEnd < MIN_BLOCK_DURATION) {
+          snappedStart = addMinutes(ds.initialEnd, -MIN_BLOCK_DURATION);
+        }
+        previewStart = snappedStart;
+        previewEnd = ds.initialEnd;
+      } else {
+        // resize-bottom
+        const rawEnd = calculateTimeFromY(
+          Math.max(0, relativeY),
+          ds.dayDate
+        );
+        let snappedEnd = snapToInterval(rawEnd);
+        const minutesAfterStart = differenceInMinutes(
+          snappedEnd,
+          ds.initialStart
+        );
+        if (minutesAfterStart < MIN_BLOCK_DURATION) {
+          snappedEnd = addMinutes(ds.initialStart, MIN_BLOCK_DURATION);
+        }
+        // Don't let the end cross midnight onto the next day.
+        const endMins = minutesFromMidnight(snappedEnd);
+        if (endMins === 0 && snappedEnd.getDate() !== ds.dayDate.getDate()) {
+          snappedEnd = addMinutes(
+            ds.initialStart,
+            TIMELINE_END_MINUTE - minutesFromMidnight(ds.initialStart)
+          );
+        }
+        previewStart = ds.initialStart;
+        previewEnd = snappedEnd;
+      }
+
+      setDragState((prev) =>
+        prev
+          ? { ...prev, previewStart, previewEnd, moved: movedEnough }
+          : prev
+      );
+    };
+
+    const handleUp = () => {
+      const ds = dragStateRef.current;
+      if (!ds) return;
+      // Only commit if the user actually moved past the click
+      // threshold. A pure click should fall through to the event's
+      // onClick (which opens the detail sheet).
+      if (ds.moved) {
+        optionsRef.current.onCommit(
+          ds.eventId,
+          ds.previewStart,
+          ds.previewEnd,
+          ds.mode
+        );
+      }
+      setDragState(null);
+    };
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setDragState(null);
+    };
+
+    document.addEventListener("mousemove", handleMove);
+    document.addEventListener("mouseup", handleUp);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousemove", handleMove);
+      document.removeEventListener("mouseup", handleUp);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [dragState]);
+
+  return {
+    dragState,
+    startDrag,
+    /** True for the duration of any drag past the click threshold — used to suppress trailing click. */
+    justEndedDrag: dragState?.moved ?? false,
+  };
+}

--- a/apps/web/src/components/calendar/multi-day-view.tsx
+++ b/apps/web/src/components/calendar/multi-day-view.tsx
@@ -18,6 +18,10 @@ import {
   calculateYFromTime,
 } from "@/hooks/useCalendarDnd";
 import { layoutOverlappingItems, type LayoutResult } from "./event-layout";
+import {
+  useMultiDayEventDrag,
+  type EventDragMode,
+} from "./multi-day-event-drag";
 
 /**
  * When N items overlap we split the column into N sub-columns, but we
@@ -44,6 +48,18 @@ interface MultiDayViewProps {
   isLoading?: boolean;
   onExternalEventClick?: (event: CalendarEvent) => void;
   onBlockClick?: (block: TimeBlock) => void;
+  /**
+   * Fired after the user drops an external event at a new time on the
+   * same day (no cross-column drag). The parent translates this into
+   * a PATCH /calendar-events/:id via useUpdateCalendarEvent.
+   */
+  onExternalEventReschedule?: (
+    eventId: string,
+    startTime: Date,
+    endTime: Date
+  ) => void;
+  /** Editability gate per event — read-only events stay click-only. */
+  externalEventCanEdit?: (event: CalendarEvent) => boolean;
   className?: string;
 }
 
@@ -136,11 +152,23 @@ function MultiDayEvent({
   displayDate,
   layout,
   onClick,
+  onMouseDownDrag,
+  onMouseDownResize,
+  isDragging = false,
+  justEndedDrag = false,
 }: {
   event: CalendarEvent;
   displayDate: Date;
   layout: LayoutResult;
   onClick?: () => void;
+  /** mousedown on the body — starts a move drag if defined. */
+  onMouseDownDrag?: (e: React.MouseEvent) => void;
+  /** mousedown on a resize handle — pass the edge. */
+  onMouseDownResize?: (e: React.MouseEvent, edge: "top" | "bottom") => void;
+  /** True while THIS event is mid-drag — dim it. */
+  isDragging?: boolean;
+  /** Suppress the trailing click after a real drag completes. */
+  justEndedDrag?: boolean;
 }) {
   const startTime = new Date(event.startTime);
   const endTime = new Date(event.endTime);
@@ -157,10 +185,26 @@ function MultiDayEvent({
   const widthPct = 100 / layout.columnCount - COLUMN_GAP_PCT;
   const leftPct = (100 / layout.columnCount) * layout.lane;
 
+  const cursor = isDragging
+    ? "cursor-grabbing"
+    : onMouseDownDrag
+      ? "cursor-grab"
+      : "cursor-pointer";
+
+  // Trim resize-handle space from the chip body when handles render
+  // (so the chip's middle area is clearly the drag/click target).
+  const continuesAcrossDay =
+    startTime < startOfDay(displayDate) || endTime > endOfDay(displayDate);
+  const showResizeHandles = !!onMouseDownResize && !continuesAcrossDay;
+
   return (
     <div
       data-external-event
-      className="absolute z-[5] my-0.5 rounded border-l-[2px] cursor-pointer hover:brightness-90 hover:z-[15] transition-all overflow-hidden px-1 py-0.5"
+      className={cn(
+        "absolute z-[5] my-0.5 rounded border-l-[2px] hover:brightness-90 hover:z-[15] transition-all overflow-hidden px-1 py-0.5",
+        cursor,
+        isDragging && "opacity-50"
+      )}
       style={{
         top: `${top}px`,
         height: `${Math.max(height - 2, 16)}px`,
@@ -171,7 +215,16 @@ function MultiDayEvent({
       }}
       onClick={(e) => {
         e.stopPropagation();
+        // Browsers fire click after mouseup even for drags — bail if
+        // the DnD hook says we just dragged.
+        if (justEndedDrag) return;
         onClick?.();
+      }}
+      onMouseDown={(e) => {
+        if (!onMouseDownDrag) return;
+        // Resize handles stop propagation; if we got here, body drag.
+        if ((e.target as HTMLElement).dataset.resize) return;
+        onMouseDownDrag(e);
       }}
       role="button"
       tabIndex={0}
@@ -183,6 +236,26 @@ function MultiDayEvent({
       }}
       aria-label={`${event.title} at ${format(startTime, "h:mm a")}`}
     >
+      {showResizeHandles && (
+        <div
+          data-resize="top"
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            onMouseDownResize?.(e, "top");
+          }}
+          className="absolute top-0 left-0 right-0 h-1 cursor-ns-resize hover:bg-foreground/10 rounded-t"
+        />
+      )}
+      {showResizeHandles && (
+        <div
+          data-resize="bottom"
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            onMouseDownResize?.(e, "bottom");
+          }}
+          className="absolute bottom-0 left-0 right-0 h-1 cursor-ns-resize hover:bg-foreground/10 rounded-b"
+        />
+      )}
       <p className="truncate text-[10px] font-medium text-foreground/85">
         {event.title}
       </p>
@@ -272,8 +345,18 @@ export function MultiDayView({
   isLoading = false,
   onExternalEventClick,
   onBlockClick,
+  onExternalEventReschedule,
+  externalEventCanEdit,
   className,
 }: MultiDayViewProps) {
+  // Per-column drag state. The hook tracks which day was grabbed, so
+  // vertical drag stays scoped to that column. Cross-column drag
+  // (Mon → Wed) is intentionally out of scope — see hook docstring.
+  const drag = useMultiDayEventDrag({
+    onCommit: (eventId, startTime, endTime, _mode: EventDragMode) => {
+      onExternalEventReschedule?.(eventId, startTime, endTime);
+    },
+  });
   const hours = React.useMemo(() => generateHours(), []);
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
   // Tick the now-indicator once per minute so it advances. Without
@@ -564,6 +647,9 @@ export function MultiDayView({
               return (
                 <div
                   key={day.toISOString()}
+                  // `data-day-column` lets the drag hook find this
+                  // column's bounding rect via element.closest().
+                  data-day-column
                   className={cn(
                     "flex-1 relative border-r last:border-r-0 min-w-0",
                     today && "bg-primary/[0.02]",
@@ -630,6 +716,10 @@ export function MultiDayView({
                     const layout =
                       dayLayouts[i]?.get(`event:${event.id}`) ??
                       DEFAULT_LAYOUT;
+                    const canEdit =
+                      externalEventCanEdit?.(event) ?? false;
+                    const isThisDragging =
+                      drag.dragState?.eventId === event.id;
                     return (
                       <MultiDayEvent
                         key={event.id}
@@ -641,9 +731,71 @@ export function MultiDayView({
                             ? () => onExternalEventClick(event)
                             : undefined
                         }
+                        onMouseDownDrag={
+                          canEdit && onExternalEventReschedule
+                            ? (e) =>
+                                drag.startDrag(
+                                  event.id,
+                                  day,
+                                  new Date(event.startTime),
+                                  new Date(event.endTime),
+                                  "move",
+                                  e
+                                )
+                            : undefined
+                        }
+                        onMouseDownResize={
+                          canEdit && onExternalEventReschedule
+                            ? (e, edge) =>
+                                drag.startDrag(
+                                  event.id,
+                                  day,
+                                  new Date(event.startTime),
+                                  new Date(event.endTime),
+                                  edge === "top"
+                                    ? "resize-top"
+                                    : "resize-bottom",
+                                  e
+                                )
+                            : undefined
+                        }
+                        isDragging={isThisDragging}
+                        justEndedDrag={drag.justEndedDrag}
                       />
                     );
                   })}
+
+                  {/* Live drop preview while this column owns the
+                      active drag — a dashed outline at the new
+                      position so the user sees where they'll land.
+                      Hidden once dragState clears on mouseup. */}
+                  {drag.dragState &&
+                    drag.dragState.dayDate.toDateString() ===
+                      day.toDateString() &&
+                    drag.dragState.moved && (() => {
+                      const previewTop = calculateYFromTime(
+                        drag.dragState.previewStart
+                      );
+                      const previewMins =
+                        (drag.dragState.previewEnd.getTime() -
+                          drag.dragState.previewStart.getTime()) /
+                        60000;
+                      const previewHeight = (previewMins / 60) * HOUR_HEIGHT;
+                      return (
+                        <div
+                          className="absolute inset-x-1 z-30 rounded border-2 border-dashed border-primary bg-primary/10 pointer-events-none flex items-start justify-start px-1.5 py-0.5"
+                          style={{
+                            top: `${previewTop}px`,
+                            height: `${Math.max(previewHeight, 16)}px`,
+                          }}
+                        >
+                          <span className="text-[10px] font-semibold text-primary">
+                            {format(drag.dragState.previewStart, "h:mm a")} –{" "}
+                            {format(drag.dragState.previewEnd, "h:mm a")}
+                          </span>
+                        </div>
+                      );
+                    })()}
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary

PR #30 shipped drag-to-reschedule on the single-day Timeline; this closes the gap on multi-day (week / 3-day).

- **\`useMultiDayEventDrag\`** — per-column drag scoped to the day the event was grabbed in. Walks up to the nearest \`[data-day-column]\` on mousedown to capture the right rect, compensates for mid-drag scrolling via the Radix scroll viewport, and snaps to the same SNAP_INTERVAL as the day-view DnD math.
- **\`MultiDayEvent\`** gets onMouseDownDrag / onMouseDownResize / isDragging / justEndedDrag. Editable events get grab cursor + 1px edge handles; read-only events stay click-only. Trailing click suppressed via justEndedDrag so the detail sheet doesn't unexpectedly open after every drag.
- **\`MultiDayView\`** mounts the hook, tags day columns, threads handlers, and renders a live drop preview (dashed primary outline + new time range label) only for the column currently owning the drag.
- **\`CalendarView\`** wires the chain: same \`externalEventCanEdit\` resolver as day view, same \`useUpdateCalendarEvent\` mutation, browser local TZ in the patch.

Scope: same-column drag only. Cross-column (Mon → Wed) is intentionally out of scope — the user can use the detail sheet's date field for that. Most multi-day adjustments are time-only ("oops, that's at 2pm not 3pm"), and the same-column slice covers the common case while keeping the drag math simple.

## Test plan

- [ ] Week view: drag an editable event vertically → lands at new time, Google reflects, no detail sheet opens.
- [ ] Top edge resize → start changes.
- [ ] Bottom edge resize → end changes.
- [ ] Drag past midnight → clamps to end-of-day.
- [ ] Read-only event: cursor stays pointer, no drag.
- [ ] All-day event: no drag (banner row, separate semantics).
- [ ] Mid-drag scroll the timeline → preview stays anchored to cursor.
- [ ] Esc → cancels drag without commit.
- [ ] Click without drag → opens detail sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)