### PR TITLE
fix(calendar): midnight-snap clamps + read-only-default toast

### DIFF
--- a/apps/web/src/components/calendar/multi-day-event-drag.ts
+++ b/apps/web/src/components/calendar/multi-day-event-drag.ts
@@ -145,11 +145,28 @@ export function useMultiDayEventDrag(options: EventDragOptions) {
           ds.dayDate
         );
         let snappedStart = snapToInterval(rawStart);
-        // Clamp so the event still fits in the day.
+        // Clamp so the event still fits in the day. We also handle
+        // the snap-rolled-to-next-day case explicitly: if the snapped
+        // start landed on a different calendar date than the column
+        // we're dragging in (snapToInterval can roll 23:53 → 00:00
+        // tomorrow), force it back to today's last legal start slot.
+        const sameDay =
+          snappedStart.getDate() === ds.dayDate.getDate() &&
+          snappedStart.getMonth() === ds.dayDate.getMonth() &&
+          snappedStart.getFullYear() === ds.dayDate.getFullYear();
         const startMins = minutesFromMidnight(snappedStart);
         const maxStart = TIMELINE_END_MINUTE - originalDurationMins;
-        if (startMins > maxStart) {
-          snappedStart = addMinutes(snappedStart, -(startMins - maxStart));
+        if (!sameDay || startMins > maxStart) {
+          const startOfDayBase = new Date(
+            ds.dayDate.getFullYear(),
+            ds.dayDate.getMonth(),
+            ds.dayDate.getDate(),
+            0,
+            0,
+            0,
+            0
+          );
+          snappedStart = addMinutes(startOfDayBase, Math.max(0, maxStart));
         }
         previewStart = snappedStart;
         previewEnd = addMinutes(snappedStart, originalDurationMins);
@@ -182,13 +199,41 @@ export function useMultiDayEventDrag(options: EventDragOptions) {
         if (minutesAfterStart < MIN_BLOCK_DURATION) {
           snappedEnd = addMinutes(ds.initialStart, MIN_BLOCK_DURATION);
         }
-        // Don't let the end cross midnight onto the next day.
+        // Don't let the end cross midnight. `snapToInterval(23:53)`
+        // rolls to next-day 00:00, which calculateYFromTime would
+        // render at y=0 (top of timeline) — the preview collapses.
+        // Clamp explicitly to the last snap slot of the day so the
+        // preview stays visible at the bottom. Drag can take you to
+        // 23:45 (with 15-min SNAP_INTERVAL); for an event that
+        // genuinely ends at midnight, use the detail sheet.
         const endMins = minutesFromMidnight(snappedEnd);
-        if (endMins === 0 && snappedEnd.getDate() !== ds.dayDate.getDate()) {
-          snappedEnd = addMinutes(
-            ds.initialStart,
-            TIMELINE_END_MINUTE - minutesFromMidnight(ds.initialStart)
+        const crossedMidnight =
+          (endMins === 0 && snappedEnd.getDate() !== ds.dayDate.getDate()) ||
+          snappedEnd.getDate() !== ds.dayDate.getDate() ||
+          snappedEnd.getMonth() !== ds.dayDate.getMonth() ||
+          snappedEnd.getFullYear() !== ds.dayDate.getFullYear();
+        if (crossedMidnight) {
+          // Last full slot of the day: 24:00 - SNAP_INTERVAL.
+          const lastSlotMins = TIMELINE_END_MINUTE - 15;
+          const startOfDayBase = new Date(
+            ds.dayDate.getFullYear(),
+            ds.dayDate.getMonth(),
+            ds.dayDate.getDate(),
+            0,
+            0,
+            0,
+            0
           );
+          snappedEnd = addMinutes(startOfDayBase, lastSlotMins);
+          // If that would shrink below MIN_BLOCK_DURATION, the user
+          // is dragging an event that already starts close to EOD —
+          // pin to start + MIN_BLOCK.
+          if (
+            differenceInMinutes(snappedEnd, ds.initialStart) <
+            MIN_BLOCK_DURATION
+          ) {
+            snappedEnd = addMinutes(ds.initialStart, MIN_BLOCK_DURATION);
+          }
         }
         previewStart = ds.initialStart;
         previewEnd = snappedEnd;

--- a/apps/web/src/hooks/calendar-dnd-utils.ts
+++ b/apps/web/src/hooks/calendar-dnd-utils.ts
@@ -112,12 +112,25 @@ export function calculateMovePreview(
 
   // Clamp the start so the entire event still fits inside the day.
   // Without this, a 4h event dragged past 20:00 would silently roll
-  // onto the next day's date.
+  // onto the next day's date. Also detect snap-rolled-to-next-day
+  // (snapToInterval(23:53) → tomorrow 00:00) and pull back to today.
+  const sameDay =
+    startTime.getDate() === baseDate.getDate() &&
+    startTime.getMonth() === baseDate.getMonth() &&
+    startTime.getFullYear() === baseDate.getFullYear();
   const startMins = minutesFromMidnight(startTime);
   const maxStartMins = TIMELINE_END_MINUTE - originalDuration;
-  if (startMins > maxStartMins) {
-    const overflow = startMins - maxStartMins;
-    startTime = addMinutes(startTime, -overflow);
+  if (!sameDay || startMins > maxStartMins) {
+    const startOfDayBase = new Date(
+      baseDate.getFullYear(),
+      baseDate.getMonth(),
+      baseDate.getDate(),
+      0,
+      0,
+      0,
+      0
+    );
+    startTime = addMinutes(startOfDayBase, Math.max(0, maxStartMins));
   }
   const endTime = addMinutes(startTime, originalDuration);
 
@@ -162,12 +175,29 @@ export function calculateResizePreview(
     endTime = snapToInterval(rawEndTime);
 
     // Clamp end so it can't spill past midnight onto the next day.
-    const endMins = minutesFromMidnight(endTime);
-    if (endMins === 0 && endTime.getDate() !== originalStart.getDate()) {
-      // Crossed into next day — pull back to end-of-day.
-      endTime = addMinutes(originalStart, TIMELINE_END_MINUTE - minutesFromMidnight(originalStart));
-    } else if (endMins > TIMELINE_END_MINUTE) {
-      endTime = addMinutes(endTime, -(endMins - TIMELINE_END_MINUTE));
+    // `snapToInterval(23:53)` rolls to next-day 00:00, which the
+    // previous clamp's recomputation would also produce — a no-op,
+    // and `calculateYFromTime(00:00)` renders at top=0 (preview
+    // collapses). Pull back to the last full slot of the day instead
+    // (24:00 - SNAP_INTERVAL) so the preview stays visible. For an
+    // event ending at literal midnight, use the detail sheet.
+    const crossedMidnight =
+      endTime.getDate() !== originalStart.getDate() ||
+      endTime.getMonth() !== originalStart.getMonth() ||
+      endTime.getFullYear() !== originalStart.getFullYear() ||
+      minutesFromMidnight(endTime) > TIMELINE_END_MINUTE;
+    if (crossedMidnight) {
+      const lastSlotMins = TIMELINE_END_MINUTE - SNAP_INTERVAL;
+      const startOfDayBase = new Date(
+        baseDate.getFullYear(),
+        baseDate.getMonth(),
+        baseDate.getDate(),
+        0,
+        0,
+        0,
+        0
+      );
+      endTime = addMinutes(startOfDayBase, lastSlotMins);
     }
 
     // Ensure minimum duration

--- a/apps/web/src/hooks/useCalendars.ts
+++ b/apps/web/src/hooks/useCalendars.ts
@@ -230,6 +230,23 @@ export function useUpdateCalendar() {
       queryClient.invalidateQueries({ queryKey: calendarKeys.calendars() });
     },
     onError: (error) => {
+      // Reuse the same friendly mapper used by the event mutations.
+      // Most importantly, server 409 CALENDAR_READ_ONLY now produces
+      // "Read-only calendar" + the actionable server message instead
+      // of the generic "Failed to update calendar".
+      if (isApiError(error)) {
+        if (
+          error.code === "CALENDAR_READ_ONLY" ||
+          error.code === "PROVIDER_READ_ONLY"
+        ) {
+          toast({
+            variant: "destructive",
+            title: "Read-only calendar",
+            description: error.message,
+          });
+          return;
+        }
+      }
       toast({
         variant: "destructive",
         title: "Failed to update calendar",


### PR DESCRIPTION
## Summary

Three audit follow-ups after PRs #35 / #36.

1. **Resize-bottom collapse at midnight.** When dragging the bottom edge near 23:50, \`snapToInterval\` rounded 23:53 → next-day 00:00. The previous \"clamp\" recomputed back to the same next-day 00:00 (no-op), and \`getHours()\` returns 0 for midnight, so the preview/event rendered at top=0, visually collapsing to the top of the timeline. Now detects cross-day rolls explicitly and pulls back to the last full snap slot of today (23:45 with default 15-min snap). Applied in both multi-day and single-day paths.

2. **Move-mode start could leak past midnight.** Same root cause: snap rolled the start onto next day, the existing \`startMins > maxStart\` check didn't fire because \`startMins\` was 0. Same cross-day detection.

3. **\`useUpdateCalendar\` toast was generic on read-only 409.** Server-side guard (PR #35) returned a clean code/message but the hook still surfaced \"Failed to update calendar\". Now branches on \`error.code\` to show \"Read-only calendar\" + the server message.

## Test plan

- [ ] Drag bottom edge of an event near 23:50 → preview stays visible at 23:45, doesn't collapse to top.
- [ ] Move a 4h event so the cursor is past 20:00 → start clamps to 20:00, end at midnight, no spill.
- [ ] Try to set a Holidays calendar as default-events → friendly \"Read-only calendar\" toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)