### PR TITLE
fix(calendar): Outlook write/parse TZ correctness — events no longer shift by UTC offset

### DIFF
--- a/apps/api/src/services/calendar-providers/outlook-helpers.ts
+++ b/apps/api/src/services/calendar-providers/outlook-helpers.ts
@@ -213,25 +213,31 @@ export function parseOutlookEvent(event: OutlookEvent): ExternalEvent | null {
   let startTime: Date;
   let endTime: Date;
 
+  // Microsoft Graph returns `dateTime` strings without an explicit
+  // timezone offset (e.g. "2026-05-03T10:00:00.0000000") and pairs
+  // them with a separate `timeZone` field. For our query path
+  // (`/calendarView` with `startDateTime`/`endDateTime` params),
+  // Graph returns times in UTC unless a `Prefer: outlook.timezone`
+  // header is sent — and we don't send one, so the dateTime IS UTC.
+  // For all-day events, Graph returns dateTime at "00:00:00.0000000"
+  // with timeZone="UTC" — same UTC convention. In both cases the
+  // JS Date parser would default to LOCAL time without the trailing
+  // Z, shifting the moment by the viewer's UTC offset (off by a
+  // whole day for all-day events east/west of UTC). Append Z to
+  // force UTC interpretation in both branches.
+  const toUtcDate = (s: string): Date =>
+    new Date(s.endsWith('Z') ? s : s + 'Z');
+
   if (isAllDay) {
-    startTime = new Date(event.start.dateTime);
+    startTime = toUtcDate(event.start.dateTime);
     endTime = event.end?.dateTime
-      ? new Date(event.end.dateTime)
+      ? toUtcDate(event.end.dateTime)
       : new Date(startTime.getTime() + 24 * 60 * 60 * 1000);
   } else {
-    const startStr = event.start.dateTime.endsWith('Z')
-      ? event.start.dateTime
-      : event.start.dateTime + 'Z';
-    startTime = new Date(startStr);
-
-    if (event.end?.dateTime) {
-      const endStr = event.end.dateTime.endsWith('Z')
-        ? event.end.dateTime
-        : event.end.dateTime + 'Z';
-      endTime = new Date(endStr);
-    } else {
-      endTime = new Date(startTime.getTime() + 60 * 60 * 1000);
-    }
+    startTime = toUtcDate(event.start.dateTime);
+    endTime = event.end?.dateTime
+      ? toUtcDate(event.end.dateTime)
+      : new Date(startTime.getTime() + 60 * 60 * 1000);
   }
 
   let description: string | null = null;

--- a/apps/api/src/services/calendar-providers/outlook.ts
+++ b/apps/api/src/services/calendar-providers/outlook.ts
@@ -283,7 +283,6 @@ export class OutlookCalendarProvider implements CalendarProvider {
       if (patch.startTime === undefined || patch.endTime === undefined) {
         throw new Error('startTime and endTime must be supplied together');
       }
-      const tz = patch.timezone ?? 'UTC';
       if (patch.isAllDay) {
         // Microsoft Graph all-day: isAllDay=true, dateTime at 00:00
         // of the date, timeZone fixed to UTC.
@@ -297,14 +296,26 @@ export class OutlookCalendarProvider implements CalendarProvider {
           timeZone: 'UTC',
         };
       } else {
+        // Send the UTC instant directly. Graph reads `dateTime` as
+        // wall-clock in `timeZone`, so pairing the user's IANA zone
+        // with a Z-stripped UTC string would tell Graph "this NYC
+        // wall-clock time is 14:00" when it's actually 14:00 UTC =
+        // 10:00 NYC — every write would shift the event by the
+        // user's UTC offset on round-trip. Sending the UTC instant
+        // with timeZone="UTC" lets Graph store the absolute instant
+        // and display it in the user's mailbox-default zone, which
+        // matches what the user dragged on screen. The `tz` argument
+        // is intentionally unused — it's only relevant for create-
+        // from-grid where the user might have a hint about which
+        // zone to display the event in.
         body.isAllDay = false;
         body.start = {
-          dateTime: stripIsoZ(patch.startTime),
-          timeZone: tz,
+          dateTime: patch.startTime.toISOString(),
+          timeZone: 'UTC',
         };
         body.end = {
-          dateTime: stripIsoZ(patch.endTime),
-          timeZone: tz,
+          dateTime: patch.endTime.toISOString(),
+          timeZone: 'UTC',
         };
       }
     }
@@ -399,30 +410,19 @@ function buildOutlookEventBody(input: {
       timeZone: 'UTC',
     };
   } else {
-    const tz = input.timezone ?? 'UTC';
+    // See updateEvent for the full reasoning: send the UTC instant
+    // with timeZone="UTC" so Graph stores the absolute moment. The
+    // `input.timezone` is intentionally unused here.
     body.start = {
-      dateTime: stripIsoZ(input.startTime),
-      timeZone: tz,
+      dateTime: input.startTime.toISOString(),
+      timeZone: 'UTC',
     };
     body.end = {
-      dateTime: stripIsoZ(input.endTime),
-      timeZone: tz,
+      dateTime: input.endTime.toISOString(),
+      timeZone: 'UTC',
     };
   }
   return body;
-}
-
-/**
- * Microsoft Graph rejects ISO strings with a `Z` suffix when a
- * timeZone is supplied separately — it expects the local-naive
- * dateTime ("2026-05-03T10:00:00.0000000") with the `timeZone` field
- * carrying the IANA name. Strip the Z and any trailing offset so
- * Graph treats the dateTime as wall-clock in the given zone.
- */
-function stripIsoZ(d: Date): string {
-  const iso = d.toISOString();
-  // "2026-05-03T10:00:00.000Z" → "2026-05-03T10:00:00.000"
-  return iso.endsWith('Z') ? iso.slice(0, -1) : iso;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two correctness bugs in PR #38's Outlook write-back, both shifting events by the user's UTC offset:

1. **Timed write was off by the UTC offset on every save.** \`updateEvent\` and \`buildOutlookEventBody\` ran the UTC instant through \`stripIsoZ\` (drop the trailing 'Z') and paired the result with \`timeZone: <user IANA zone>\`. Microsoft Graph reads \`dateTime\` as wall-clock in \`timeZone\`, so a NYC user dragging an event to 10:00 EDT round-tripped as \`dateTime: \"...T14:00:00.000\"\` + \`timeZone: \"America/New_York\"\` → Graph stored 14:00 NYC = 18:00 UTC. Every drag/edit/resize shifted the event by 4–8h on the next sync.

   Fix: send the UTC instant directly with \`timeZone: \"UTC\"\`. Graph stores the absolute moment and displays it in the user's mailbox-default zone — matches what the user sees on screen. \`stripIsoZ\` deleted.

2. **All-day Outlook events parsed as local midnight.** \`parseOutlookEvent\` did \`new Date(\"2026-05-03T00:00:00.0000000\")\` for all-day events. Without a timezone offset, JS Date defaults to local time → for users east/west of UTC the event was stored shifted by the user's offset. Google's parser correctly appends 'Z'; Outlook's didn't.

   Fix: unified both branches behind a tiny \`toUtcDate\` helper that appends 'Z' if missing.

## Test plan

- [ ] Drag an Outlook event in NYC from 10:00 to 11:00 → refetch shows 11:00 (was 15:00 before).
- [ ] Create an all-day Outlook event → it lands on the right day for users in any timezone.
- [ ] Edit an Outlook event title only → time stays correct (no leak from the time path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)