### PR TITLE
fix(calendar): mobile handlers wired + midnight day-flip + recurring disclosure

### DIFF
--- a/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
+++ b/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
@@ -9,6 +9,7 @@ import {
   Pencil,
   Trash2,
   Loader2,
+  Repeat,
 } from "lucide-react";
 import type { CalendarEvent } from "@open-sunsama/types";
 import {
@@ -381,6 +382,30 @@ export function CalendarEventDetailSheet({
 
           {event && (
             <div className="mt-6 space-y-5">
+              {/* Recurring-event disclosure. Edits and deletes from
+                  this sheet apply to THIS instance only — Google and
+                  Outlook both interpret a PATCH/DELETE on an instance
+                  id as an exception, not a series modification. We
+                  surface the badge plus a one-line note so users
+                  aren't surprised when the next occurrence still
+                  shows the old title or still exists after delete. */}
+              {(event.recurringEventId || event.recurrenceRule) && (
+                <div className="flex items-start gap-2 rounded-md border border-dashed border-border/60 bg-muted/30 px-3 py-2">
+                  <Repeat
+                    className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground"
+                    aria-hidden
+                  />
+                  <div className="text-xs">
+                    <p className="font-medium text-foreground/80">
+                      Recurring event · this instance
+                    </p>
+                    <p className="mt-0.5 text-muted-foreground">
+                      Changes here apply to this occurrence only. To
+                      edit the whole series, use the calendar provider.
+                    </p>
+                  </div>
+                </div>
+              )}
               {isEditing && editState ? (
                 <EditForm
                   state={editState}

--- a/apps/web/src/components/mobile/mobile-calendar-view.tsx
+++ b/apps/web/src/components/mobile/mobile-calendar-view.tsx
@@ -113,6 +113,25 @@ export function MobileCalendarView({
     return () => clearInterval(id);
   }, []);
 
+  // Auto-advance the displayed day when the wall-clock crosses
+  // midnight and the user was looking at "today" before the flip.
+  // Without this, the now-line vanishes at 00:00 but the timeline
+  // keeps showing yesterday's events until the user manually taps
+  // "Today" / "Next". The ref tracks the "today" we last saw — when
+  // the tick produces a new "today" AND the user was previously on
+  // the old "today", we slide forward; if they navigated elsewhere,
+  // they stay put.
+  const lastTodayRef = React.useRef(startOfDay(now));
+  React.useEffect(() => {
+    const todayStart = startOfDay(now);
+    if (todayStart.getTime() === lastTodayRef.current.getTime()) return;
+    const wasOnOldToday = isSameDay(selectedDate, lastTodayRef.current);
+    lastTodayRef.current = todayStart;
+    if (wasOnOldToday) {
+      setSelectedDate(todayStart);
+    }
+  }, [now, selectedDate]);
+
   // Format date for API calls
   const dateString = format(selectedDate, "yyyy-MM-dd");
   const dayStart = React.useMemo(

--- a/apps/web/src/routes/app/calendar.tsx
+++ b/apps/web/src/routes/app/calendar.tsx
@@ -89,7 +89,37 @@ export default function CalendarPage() {
   };
 
   if (isMobile) {
-    return <MobileCalendarView />;
+    // Wire the same handlers the desktop branch uses so the mobile
+    // FAB, time-block taps, and drawer-task taps actually open the
+    // right sheets / dialogs. Without these props the mobile surface
+    // is read-only by accident — every tap is a no-op.
+    return (
+      <>
+        <MobileCalendarView
+          onTaskClick={handleTaskClick}
+          onBlockClick={handleBlockClick}
+          onViewTask={handleViewTask}
+          onTimeSlotClick={handleTimeSlotClick}
+        />
+        <TaskModal
+          task={selectedTask}
+          open={taskPanelOpen}
+          onOpenChange={handleTaskPanelOpenChange}
+        />
+        <TimeBlockDetailSheet
+          timeBlock={selectedTimeBlock}
+          open={timeBlockSheetOpen}
+          onOpenChange={handleTimeBlockSheetOpenChange}
+        />
+        <CreateTimeBlockDialog
+          open={createDialogOpen}
+          onOpenChange={setCreateDialogOpen}
+          date={createDialogDate}
+          startTime={createDialogStartTime}
+          endTime={createDialogEndTime}
+        />
+      </>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

Three audit follow-ups after PR #40 (mobile parity).

1. **BLOCKER: mobile FAB / time-block tap / drawer-task tap were dead no-ops.** \`routes/app/calendar.tsx\` rendered \`<MobileCalendarView />\` with NO props, so every callback fell through to undefined. Mobile calendar was effectively read-only except for external events. Wired the same handlers the desktop branch uses + mounted TaskModal / TimeBlockDetailSheet / CreateTimeBlockDialog.

2. **Important: \`selectedDate\` did not advance at midnight.** A user with the calendar open at 23:55 saw the now-line vanish at 00:00 but the timeline kept showing yesterday until manual nav. Added a ref-tracked midnight detector — when the wall-clock crosses to a new day AND the user was previously viewing the OLD today, advance to the new today.

3. **Important: recurring-event edits silently applied to \"this instance only\" with no UX disclosure.** Added a dashed-border disclosure block in the detail sheet when \`recurringEventId\` or \`recurrenceRule\` is set: \"Recurring event · this instance — Changes here apply to this occurrence only. To edit the whole series, use the calendar provider.\"

## Test plan

- [ ] Mobile: tap FAB → CreateTimeBlockDialog opens.
- [ ] Mobile: tap a time block → TimeBlockDetailSheet opens (or TaskModal if linked).
- [ ] Mobile: open at 23:59 → at 00:00 the day flips automatically.
- [ ] Open a recurring Google/Outlook event → badge visible: \"Recurring event · this instance\".
- [ ] Open a non-recurring event → no badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)