### PR TITLE
feat(calendar): server-side view-mode persistence + mobile FAB time clamp

### DIFF
--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -30,6 +30,7 @@ import {
   useCascadeResizeTimeBlock,
 } from "@/hooks";
 import { useAuth } from "@/hooks/useAuth";
+import { useSavePreferences } from "@/hooks/useUserPreferences";
 import {
   useCalendarEvents,
   useCalendars,
@@ -180,13 +181,37 @@ export function CalendarView({
     }
   }, [user?.preferences?.calendarViewMode]);
 
-  const setViewMode = React.useCallback((mode: CalendarViewMode) => {
-    setViewModeRaw(mode);
-    storeViewMode(mode);
-    // TODO: also write the preference back to the server via
-    // `useUpdateUser` once we want it to sync across devices. For now
-    // localStorage is enough for the in-session experience.
-  }, []);
+  const savePreferences = useSavePreferences();
+  const setViewMode = React.useCallback(
+    (mode: CalendarViewMode) => {
+      setViewModeRaw(mode);
+      storeViewMode(mode);
+      // Also write the preference back to the server so the choice
+      // syncs across devices. We send the full preferences object
+      // (server replaces it wholesale) by spreading the current
+      // user.preferences and overriding calendarViewMode. The hook
+      // is a no-op for unauthenticated users and swallows errors —
+      // the local change still sticks via setViewModeRaw +
+      // storeViewMode, so a transient API failure doesn't break UX.
+      if (user?.preferences) {
+        savePreferences.mutate({
+          ...user.preferences,
+          calendarViewMode: mode,
+        });
+      } else if (user) {
+        // Authenticated but no prefs object yet — seed with safe
+        // defaults for the required theme fields plus the chosen
+        // view mode. Future writes will preserve siblings.
+        savePreferences.mutate({
+          themeMode: "system" as const,
+          colorTheme: "default",
+          fontFamily: "geist",
+          calendarViewMode: mode,
+        });
+      }
+    },
+    [savePreferences, user]
+  );
 
   // The window of days currently visible.
   const range = React.useMemo(

--- a/apps/web/src/components/mobile/mobile-calendar-view.tsx
+++ b/apps/web/src/components/mobile/mobile-calendar-view.tsx
@@ -491,10 +491,18 @@ export function MobileCalendarView({
       {/* FAB for creating time blocks */}
       <button
         onClick={() => {
-          // Default to next-hour slot on the current day.
+          // Default-time logic: when viewing today, anchor at the
+          // next hour from now (clamped to ≤22:00 so the +1h end
+          // doesn't roll past midnight). When viewing any other
+          // day, anchor at 09:00 — using "current time of day" on
+          // a navigated day produces a confusing slot mismatched
+          // with the displayed date in the dialog header.
+          const baseHour = isToday
+            ? Math.min(now.getHours() + 1, 22)
+            : 9;
           const defaultStart = setHours(
             setMinutes(selectedDate, 0),
-            now.getHours() + 1
+            baseHour
           );
           const defaultEnd = addMinutes(defaultStart, 60);
           if (onTimeSlotClick) {


### PR DESCRIPTION
## Summary

Two follow-ups: one new feature, one cosmetic polish.

1. **View mode now syncs across devices.** PR #24 introduced localStorage-only persistence with a TODO. Picking Week on desktop and opening on phone landed on whatever the phone last had. \`setViewMode\` now also calls \`useSavePreferences\` so the choice writes to \`user.preferences.calendarViewMode\` on the server. Local state still wins (responsive UI on transient API failure), and the existing one-shot seed brings the value in on a fresh device.

2. **Mobile FAB default-time clamp.** Tapping the FAB at 23:xx silently rolled past midnight via \`setHours(d, 24)\` — the dialog header showed today but the time inputs were tomorrow. Fix: only use \`now+1\` when viewing today, clamped to ≤22:00; for other days, anchor at 09:00.

## Test plan

- [ ] Pick Week on desktop → open in another browser/device → loads in Week.
- [ ] Mobile FAB at 14:00 today → 15:00-16:00 default. At 23:30 today → 22:00-23:00 (no rollover). On any other day → 09:00-10:00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)