### PR TITLE
fix(calendar): server-side view-mode sync was silently dropped by zod

### DIFF
--- a/apps/api/src/validation/auth.ts
+++ b/apps/api/src/validation/auth.ts
@@ -24,6 +24,13 @@ export const loginSchema = z.object({
 
 /**
  * Schema for user preferences
+ *
+ * Zod's default mode strips unknown keys, so any field not declared
+ * here is silently dropped from PATCH /auth/me even when the client
+ * sends it. Keep this in sync with `UserPreferences` in
+ * `packages/types/src/user.ts` — missing keys here are real bugs
+ * (the symptom is "client picks a value, server returns success,
+ * but the field never lands in the DB").
  */
 export const userPreferencesSchema = z.object({
   themeMode: z.enum(["light", "dark", "system"]),
@@ -32,6 +39,8 @@ export const userPreferencesSchema = z.object({
   workStartHour: z.number().int().min(0).max(23).optional(),
   workEndHour: z.number().int().min(0).max(23).optional(),
   homeTab: z.enum(["board", "tasks", "calendar"]).optional(),
+  weekStartsOn: z.union([z.literal(0), z.literal(1)]).optional(),
+  calendarViewMode: z.enum(["day", "3-day", "week", "month"]).optional(),
 });
 
 /**

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -161,22 +161,35 @@ export function CalendarView({
   });
   // If the server preference loads *after* mount (typical: /auth/me
   // resolves shortly after the first paint), seed it into local state
-  // exactly once. We use a ref to ensure subsequent local changes are
-  // never overwritten by a stale server value re-arriving — the user's
-  // intent always wins after they've interacted. The current viewMode
-  // is read via a ref so this effect's dep array can stay focused on
-  // the canonical server value.
+  // exactly once. The server is the source of truth for cross-device
+  // sync — if you picked "week" on desktop and open the phone, the
+  // phone's view should update to "week" even if its localStorage
+  // happens to remember a different value from a prior session.
+  // (PR #42 was supposed to enable this but the server schema was
+  // dropping the field; once that's fixed, we also need to drop the
+  // localStorage gate that the original effect had — which silently
+  // pinned each device to whatever it last had.)
+  // We use a ref to ensure subsequent server pushes (e.g. another
+  // tab updating prefs) don't fight with the user's local picks
+  // after mount — first arrival wins, then local state owns.
   const didSeedFromServerRef = React.useRef(false);
   const viewModeRef = React.useRef(viewMode);
   viewModeRef.current = viewMode;
+  // Tracks whether the user has interacted with the view-mode toggle
+  // since mount. If they have, we never seed from a late-arriving
+  // server value — their explicit pick beats a stale server value
+  // that happened to lose the race. (First-login-on-device case:
+  // no cached user → lazy init falls back to "day" → user picks
+  // "month" → /auth/me arrives 2s later with "week" → without this
+  // gate the user's pick gets silently clobbered.)
+  const userInteractedRef = React.useRef(false);
   React.useEffect(() => {
     if (didSeedFromServerRef.current) return;
+    if (userInteractedRef.current) return;
     const remote = user?.preferences?.calendarViewMode;
     if (!remote) return;
     didSeedFromServerRef.current = true;
-    // Only override if the user hasn't already overridden via local
-    // storage on this device (otherwise their per-device choice stands).
-    if (getStoredViewMode() === null && remote !== viewModeRef.current) {
+    if (remote !== viewModeRef.current) {
       setViewModeRaw(remote);
     }
   }, [user?.preferences?.calendarViewMode]);
@@ -184,6 +197,9 @@ export function CalendarView({
   const savePreferences = useSavePreferences();
   const setViewMode = React.useCallback(
     (mode: CalendarViewMode) => {
+      // Mark the user as having interacted so a late /auth/me push
+      // can't clobber this pick (see the seed effect for context).
+      userInteractedRef.current = true;
       setViewModeRaw(mode);
       storeViewMode(mode);
       // Also write the preference back to the server so the choice


### PR DESCRIPTION
## Summary

PR #42 wired \`setViewMode\` to PATCH \`user.preferences.calendarViewMode\` to the server, but the round-trip never worked: the server's \`userPreferencesSchema\` (the zod object guarding the route) didn't declare \`calendarViewMode\` (or \`weekStartsOn\`). Zod's default mode strips unknown keys, so every PATCH succeeded, returned a user with the field gone, and the JSONB column was written without it. Cross-device sync was a no-op masked by per-device localStorage.

Fix:

1. **\`userPreferencesSchema\`** now declares \`calendarViewMode\` and \`weekStartsOn\`, both optional. Doc note added about keeping it in sync with the types package.

2. **Seed-effect localStorage gate dropped** — that gate had each device pin itself to whatever it last had, the opposite of cross-device sync. Now first server arrival wins.

3. **\`userInteractedRef\` added to prevent late /auth/me from clobbering a user's local pick** — the audit caught a regression scenario (first login on device, user picks before /auth/me arrives, server's old value would silently override). Now once the user touches the toggle, the seed effect bails for the rest of the session.

## Test plan

- [ ] Pick \"week\" on desktop → open in incognito on phone (no localStorage) → loads in week.
- [ ] Logout/login on a device that had \"month\" set → first-paint matches the server, not stale local.
- [ ] First-login race: pick \"month\" while /auth/me is loading → it stays \"month\" after /auth/me arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)