### PR TITLE
feat(calendar): list shortcuts in ? modal + skip no-op view-mode PATCH

### DIFF
--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -197,6 +197,9 @@ export function CalendarView({
   const savePreferences = useSavePreferences();
   const setViewMode = React.useCallback(
     (mode: CalendarViewMode) => {
+      // No-op short-circuit: pressing the same view's key (e.g. "d"
+      // when already on day) shouldn't fire a redundant PATCH.
+      if (mode === viewModeRef.current) return;
       // Mark the user as having interacted so a late /auth/me push
       // can't clobber this pick (see the seed effect for context).
       userInteractedRef.current = true;

--- a/apps/web/src/components/ui/shortcuts-modal.tsx
+++ b/apps/web/src/components/ui/shortcuts-modal.tsx
@@ -32,10 +32,11 @@ const categoryLabels: Record<string, string> = {
   general: "General",
   navigation: "Navigation",
   task: "Task Actions",
+  calendar: "Calendar",
   focus: "Focus Mode",
 };
 
-const categoryOrder = ["general", "navigation", "task", "focus"];
+const categoryOrder = ["general", "navigation", "task", "calendar", "focus"];
 
 export function ShortcutsModal({ open, onOpenChange }: ShortcutsModalProps) {
   return (

--- a/apps/web/src/hooks/useKeyboardShortcuts.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.tsx
@@ -9,7 +9,7 @@ export interface ShortcutDefinition {
     alt?: boolean;
   };
   description: string;
-  category: "navigation" | "task" | "general" | "focus";
+  category: "navigation" | "task" | "general" | "focus" | "calendar";
 }
 
 // Define all shortcuts
@@ -135,6 +135,48 @@ export const SHORTCUTS: Record<string, ShortcutDefinition> = {
     key: "w",
     description: "Edit planned time",
     category: "focus",
+  },
+  // Calendar view-mode shortcuts (matches Google Calendar's defaults
+  // so the muscle memory transfers cleanly). The actual handler lives
+  // in `apps/web/src/components/calendar/calendar-view.tsx` because
+  // the hook here is a registry — the calendar-view's local listener
+  // owns the dispatch since it needs access to `setViewMode`,
+  // `goToToday`, etc. The entries here exist so the `?` shortcuts
+  // modal can list them.
+  calendarDayView: {
+    key: "d",
+    description: "Switch to day view",
+    category: "calendar",
+  },
+  calendarThreeDayView: {
+    key: "x",
+    description: "Switch to 3-day view",
+    category: "calendar",
+  },
+  calendarWeekView: {
+    key: "w",
+    description: "Switch to week view",
+    category: "calendar",
+  },
+  calendarMonthView: {
+    key: "m",
+    description: "Switch to month view",
+    category: "calendar",
+  },
+  calendarToday: {
+    key: "t",
+    description: "Jump to today",
+    category: "calendar",
+  },
+  calendarPrevious: {
+    key: "j",
+    description: "Previous range",
+    category: "calendar",
+  },
+  calendarNext: {
+    key: "k",
+    description: "Next range",
+    category: "calendar",
   },
 };
 


### PR DESCRIPTION
## Summary

Two small wins.

1. **Calendar shortcuts (D / X / W / M / T / J / K) now appear in the global ? help modal.** Added a \"calendar\" category to the SHORTCUTS registry plus 7 entries. Discoverability win — users were previously guessing.

2. **\`setViewMode\` short-circuits when mode unchanged** so pressing \"d\" while already on day view doesn't fire a redundant PATCH /auth/me.

## Test plan

- [ ] Press \`?\` anywhere in the app → modal lists Calendar section with all 7 shortcuts.
- [ ] Press \`d\` while already on day view → no network call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)