### PR TITLE
feat(mobile): long-press drag-to-reschedule for external events

### DIFF
--- a/apps/web/src/components/mobile/mobile-calendar-view.tsx
+++ b/apps/web/src/components/mobile/mobile-calendar-view.tsx
@@ -31,7 +31,9 @@ import {
   useCalendarEvents,
   useCalendars,
   useCalendarAccounts,
+  useUpdateCalendarEvent,
 } from "@/hooks/useCalendars";
+import { useMobileTouchDrag } from "./use-mobile-touch-drag";
 import {
   HOUR_HEIGHT,
   TIMELINE_START_HOUR,
@@ -172,6 +174,25 @@ export function MobileCalendarView({
     }
     return m;
   }, [calendarsList, calendarAccounts]);
+
+  // Long-press-to-drag for external events. Same write-back path the
+  // desktop uses — useUpdateCalendarEvent handles optimistic update +
+  // rollback + cross-range invalidation.
+  const updateCalendarEvent = useUpdateCalendarEvent();
+  const touchDrag = useMobileTouchDrag({
+    onCommit: (eventId, startTime, endTime) => {
+      updateCalendarEvent.mutate({
+        id: eventId,
+        rangeFrom: fromDate,
+        rangeTo: toDate,
+        patch: {
+          startTime,
+          endTime,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        },
+      });
+    },
+  });
 
   // Bucket events into timed (drawn on timeline) and all-day (banner).
   const { timedEvents, allDayEvents } = React.useMemo(() => {
@@ -409,6 +430,10 @@ export function MobileCalendarView({
           {/* Timeline Content */}
           <div
             ref={timelineRef}
+            // `data-mobile-timeline` lets the touch-drag hook find
+            // this element via element.closest() so it can compute
+            // pixel-to-time math against the right rect.
+            data-mobile-timeline
             className={cn(
               "relative flex-1",
               "touch-pan-y",
@@ -459,19 +484,81 @@ export function MobileCalendarView({
               </div>
             )}
 
-            {/* External calendar events (drawn behind time blocks) */}
+            {/* External calendar events (drawn behind time blocks).
+                Wrapped so we can install touch handlers without
+                changing ExternalEvent's contract. The wrapper
+                intentionally contributes nothing to layout — its
+                pointer-events stay default and clicks pass through
+                to the chip's own handler (which respects
+                justEndedDrag). */}
             {!isLoading &&
-              timedEvents.map((event) => (
-                <ExternalEvent
-                  key={event.id}
-                  event={event}
-                  displayDate={selectedDate}
-                  layout={
-                    itemLayouts.get(`event:${event.id}`) ?? DEFAULT_LAYOUT
-                  }
-                  onClick={() => handleExternalEventClick(event)}
-                />
-              ))}
+              timedEvents.map((event) => {
+                const canEdit =
+                  !(calendarReadOnlyById.get(event.calendarId) ?? true) &&
+                  !event.isAllDay;
+                const isThisDragging =
+                  touchDrag.dragState?.eventId === event.id;
+                return (
+                  <div
+                    key={event.id}
+                    className={cn(
+                      "contents",
+                      isThisDragging && "[&>*]:opacity-60 [&>*]:scale-[1.02] [&>*]:shadow-lg [&>*]:transition-transform"
+                    )}
+                    onTouchStart={
+                      canEdit
+                        ? (e) =>
+                            touchDrag.handleTouchStart(
+                              event.id,
+                              selectedDate,
+                              new Date(event.startTime),
+                              new Date(event.endTime),
+                              e
+                            )
+                        : undefined
+                    }
+                    onTouchMove={canEdit ? touchDrag.handleTouchMove : undefined}
+                    onTouchEnd={canEdit ? touchDrag.handleTouchEnd : undefined}
+                  >
+                    <ExternalEvent
+                      event={event}
+                      displayDate={selectedDate}
+                      layout={
+                        itemLayouts.get(`event:${event.id}`) ?? DEFAULT_LAYOUT
+                      }
+                      onClick={() => handleExternalEventClick(event)}
+                      justEndedDrag={touchDrag.justEndedDrag}
+                    />
+                  </div>
+                );
+              })}
+
+            {/* Live drop preview during touch drag — dashed outline at
+                the new position with the new time range label. */}
+            {touchDrag.dragState && (() => {
+              const previewTop = calculateYFromTime(
+                touchDrag.dragState.previewStart
+              );
+              const previewMins =
+                (touchDrag.dragState.previewEnd.getTime() -
+                  touchDrag.dragState.previewStart.getTime()) /
+                60000;
+              const previewHeight = (previewMins / 60) * HOUR_HEIGHT;
+              return (
+                <div
+                  className="absolute inset-x-1 z-30 rounded border-2 border-dashed border-primary bg-primary/10 pointer-events-none flex items-start justify-start px-1.5 py-0.5"
+                  style={{
+                    top: `${previewTop}px`,
+                    height: `${Math.max(previewHeight, 16)}px`,
+                  }}
+                >
+                  <span className="text-[10px] font-semibold text-primary">
+                    {format(touchDrag.dragState.previewStart, "h:mm a")} –{" "}
+                    {format(touchDrag.dragState.previewEnd, "h:mm a")}
+                  </span>
+                </div>
+              );
+            })()}
 
             {/* Time blocks */}
             {!isLoading &&

--- a/apps/web/src/components/mobile/use-mobile-touch-drag.ts
+++ b/apps/web/src/components/mobile/use-mobile-touch-drag.ts
@@ -1,0 +1,299 @@
+import * as React from "react";
+import { addMinutes, differenceInMinutes } from "date-fns";
+import {
+  HOUR_HEIGHT,
+  TIMELINE_END_HOUR,
+  TIMELINE_START_HOUR,
+  calculateTimeFromY,
+  snapToInterval,
+} from "@/hooks/useCalendarDnd";
+
+const TIMELINE_END_MINUTE = (TIMELINE_END_HOUR + 1) * 60;
+/** ms to wait before a hold becomes a drag instead of a tap. */
+const LONG_PRESS_MS = 400;
+/** px the finger can wander pre-long-press before we abort (treat as scroll). */
+const SCROLL_ABORT_PX = 10;
+
+function minutesFromMidnight(d: Date): number {
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+export interface MobileEventDragState {
+  eventId: string;
+  /** Day this event lives on. */
+  dayDate: Date;
+  /** The timeline-content rect at drag-start. */
+  timelineRect: DOMRect;
+  scrollEl: HTMLElement | null;
+  scrollTopAtStart: number;
+  /** Y of the touch at drag-start, used to compute pixel deltas. */
+  startY: number;
+  initialStart: Date;
+  initialEnd: Date;
+  /** Live preview times, updated on each touchmove. */
+  previewStart: Date;
+  previewEnd: Date;
+}
+
+export interface MobileTouchDragOptions {
+  /** Fired when the user lifts their finger after a real drag. */
+  onCommit: (eventId: string, startTime: Date, endTime: Date) => void;
+}
+
+interface PendingPress {
+  eventId: string;
+  dayDate: Date;
+  initialStart: Date;
+  initialEnd: Date;
+  timelineEl: HTMLElement;
+  startX: number;
+  startY: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Long-press-to-drag for mobile calendar events.
+ *
+ * Touch UX is fundamentally different from mouse:
+ * - Tap = open the detail sheet (existing onClick still fires).
+ * - Long-press (~400ms still finger) = enter drag mode. Once in drag
+ *   mode, subsequent touchmove events update the live preview and
+ *   call preventDefault to stop the timeline from scrolling under
+ *   the finger.
+ * - If the finger MOVES more than ~10px during the pre-long-press
+ *   window, we abort the timer — that was a scroll attempt, not a
+ *   drag attempt, so we let the browser handle the scroll natively.
+ * - Lift finger after a real drag → commit. Lift finger before the
+ *   timer fires → it's a tap → onClick fires from the chip's React
+ *   handler (this hook doesn't intercept that path).
+ *
+ * Same-day-only for now. Cross-day touch drag is plausible (find the
+ * day-column the finger ended on via elementFromPoint) but mobile is
+ * single-day, so it's moot here.
+ */
+export function useMobileTouchDrag(options: MobileTouchDragOptions) {
+  const [dragState, setDragState] =
+    React.useState<MobileEventDragState | null>(null);
+  const dragStateRef = React.useRef<MobileEventDragState | null>(null);
+  React.useEffect(() => {
+    dragStateRef.current = dragState;
+  }, [dragState]);
+  // Mirror useCalendarDnd's justEndedDrag flag so the chip's onClick
+  // can suppress the trailing synthetic click after a real drag.
+  // setTimeout(0) defers the clear past the click event in the same
+  // task — same pattern as the desktop path.
+  const [justEndedDrag, setJustEndedDrag] = React.useState(false);
+
+  // Latest options via ref so global listeners don't need to re-bind.
+  const optionsRef = React.useRef(options);
+  React.useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
+  // Tracks an in-flight long-press timer between touchstart and the
+  // moment the timer fires (or the user lifts / scrolls).
+  const pendingRef = React.useRef<PendingPress | null>(null);
+
+  const cancelPending = React.useCallback(() => {
+    if (pendingRef.current) {
+      clearTimeout(pendingRef.current.timer);
+      pendingRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Wire onto the chip's onTouchStart. Pass the event id, day, and
+   * its current start/end times. The hook stages a long-press timer;
+   * on fire, it enters drag mode and the rest of the gesture is
+   * handled by the global touchmove/touchend listeners installed
+   * below via useEffect.
+   */
+  const handleTouchStart = React.useCallback(
+    (
+      eventId: string,
+      dayDate: Date,
+      eventStart: Date,
+      eventEnd: Date,
+      e: React.TouchEvent
+    ) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      // The timeline content div is the element that owns Y → time
+      // mapping; we walk up via `data-mobile-timeline`.
+      const timelineEl = (e.currentTarget as HTMLElement).closest<HTMLElement>(
+        "[data-mobile-timeline]"
+      );
+      if (!timelineEl) return;
+      cancelPending();
+      pendingRef.current = {
+        eventId,
+        dayDate,
+        initialStart: eventStart,
+        initialEnd: eventEnd,
+        timelineEl,
+        startX: touch.clientX,
+        startY: touch.clientY,
+        timer: setTimeout(() => {
+          // Long-press fired → enter drag mode. Capture the
+          // timeline rect now so subsequent moves can compute Y
+          // relative to the right element.
+          const pending = pendingRef.current;
+          if (!pending) return;
+          const timelineRect = pending.timelineEl.getBoundingClientRect();
+          const scrollEl =
+            pending.timelineEl.closest<HTMLElement>(
+              "[data-radix-scroll-area-viewport]"
+            ) ?? null;
+          // Light haptic feedback (Android / iOS Safari support
+          // varies — silently no-op when missing).
+          try {
+            navigator.vibrate?.(15);
+          } catch {
+            /* ignore */
+          }
+          setDragState({
+            eventId: pending.eventId,
+            dayDate: pending.dayDate,
+            timelineRect,
+            scrollEl,
+            scrollTopAtStart: scrollEl?.scrollTop ?? 0,
+            startY: pending.startY,
+            initialStart: pending.initialStart,
+            initialEnd: pending.initialEnd,
+            previewStart: pending.initialStart,
+            previewEnd: pending.initialEnd,
+          });
+          pendingRef.current = null;
+        }, LONG_PRESS_MS),
+      };
+    },
+    [cancelPending]
+  );
+
+  // Pre-long-press touchmove handler — lives on the chip itself so
+  // it can decide "this is a scroll, not a drag" before we lock
+  // scrolling. Once drag starts, the global listeners take over.
+  const handleTouchMove = React.useCallback(
+    (e: React.TouchEvent) => {
+      const pending = pendingRef.current;
+      if (!pending) return;
+      const touch = e.touches[0];
+      if (!touch) return;
+      const dx = touch.clientX - pending.startX;
+      const dy = touch.clientY - pending.startY;
+      if (dx * dx + dy * dy > SCROLL_ABORT_PX * SCROLL_ABORT_PX) {
+        cancelPending();
+      }
+    },
+    [cancelPending]
+  );
+
+  const handleTouchEnd = React.useCallback(() => {
+    cancelPending();
+  }, [cancelPending]);
+
+  // Global touchmove + touchend installed only while dragging. We
+  // need passive:false on touchmove so we can preventDefault to
+  // stop the timeline from scrolling under the finger.
+  const isDragging = dragState !== null;
+  React.useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMove = (e: TouchEvent) => {
+      const ds = dragStateRef.current;
+      if (!ds) return;
+      const touch = e.touches[0];
+      if (!touch) return;
+      e.preventDefault();
+      const liveScroll = ds.scrollEl?.scrollTop ?? ds.scrollTopAtStart;
+      const scrollDelta = liveScroll - ds.scrollTopAtStart;
+      const originalDuration = differenceInMinutes(
+        ds.initialEnd,
+        ds.initialStart
+      );
+      // Anchor the event's TOP to the finger's current Y minus the
+      // offset between the original touch Y and the event's top edge.
+      const initialTopPx =
+        ((minutesFromMidnight(ds.initialStart) - TIMELINE_START_HOUR * 60) /
+          60) *
+        HOUR_HEIGHT;
+      const cursorOffsetWithinEvent =
+        ds.startY - ds.timelineRect.top + ds.scrollTopAtStart - initialTopPx;
+      const newTopPx =
+        touch.clientY - ds.timelineRect.top + scrollDelta - cursorOffsetWithinEvent;
+      const rawStart = calculateTimeFromY(
+        Math.max(0, newTopPx),
+        ds.dayDate
+      );
+      let snappedStart = snapToInterval(rawStart);
+      // Clamp to keep the event in the day. Detect snap-rolled-to-
+      // next-day and pull back to the last legal start slot.
+      const sameDay =
+        snappedStart.getDate() === ds.dayDate.getDate() &&
+        snappedStart.getMonth() === ds.dayDate.getMonth() &&
+        snappedStart.getFullYear() === ds.dayDate.getFullYear();
+      const startMins = minutesFromMidnight(snappedStart);
+      const maxStart = TIMELINE_END_MINUTE - originalDuration;
+      if (!sameDay || startMins > maxStart) {
+        const startOfDayBase = new Date(
+          ds.dayDate.getFullYear(),
+          ds.dayDate.getMonth(),
+          ds.dayDate.getDate(),
+          0,
+          0,
+          0,
+          0
+        );
+        snappedStart = addMinutes(startOfDayBase, Math.max(0, maxStart));
+      }
+      const previewStart = snappedStart;
+      const previewEnd = addMinutes(snappedStart, originalDuration);
+      setDragState((prev) =>
+        prev ? { ...prev, previewStart, previewEnd } : prev
+      );
+    };
+
+    const handleEnd = () => {
+      const ds = dragStateRef.current;
+      if (!ds) return;
+      const moved =
+        ds.previewStart.getTime() !== ds.initialStart.getTime();
+      // Only commit if the preview actually shifted (long-press hold
+      // without movement is a no-op, not a drag).
+      if (moved) {
+        optionsRef.current.onCommit(
+          ds.eventId,
+          ds.previewStart,
+          ds.previewEnd
+        );
+        setJustEndedDrag(true);
+        setTimeout(() => setJustEndedDrag(false), 0);
+      }
+      setDragState(null);
+    };
+
+    const handleCancel = () => {
+      setDragState(null);
+    };
+
+    document.addEventListener("touchmove", handleMove, { passive: false });
+    document.addEventListener("touchend", handleEnd);
+    document.addEventListener("touchcancel", handleCancel);
+    return () => {
+      document.removeEventListener("touchmove", handleMove);
+      document.removeEventListener("touchend", handleEnd);
+      document.removeEventListener("touchcancel", handleCancel);
+    };
+  }, [isDragging]);
+
+  return {
+    dragState,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    /** True for the duration of any active drag — used for visual feedback. */
+    isDragging,
+    /** True briefly after a drag commits — gates the chip's onClick. */
+    justEndedDrag,
+  };
+}


### PR DESCRIPTION
## Summary

Mobile touch drag was deferred from PR #40. This closes the gap.

UX:
- Tap event → opens detail sheet (unchanged).
- Hold ~400ms still → enters drag mode (light haptic feedback via \`navigator.vibrate\` where supported), chip lifts (scale + shadow).
- Drag finger → live preview at the new time.
- Lift finger → commits via the same \`useUpdateCalendarEvent\` path the desktop uses.
- Move finger >10px before the timer fires → press is interpreted as scroll attempt; native scrolling resumes.

Implementation:
- New \`useMobileTouchDrag\` hook tracks long-press timer + global touchmove/touchend listeners (passive:false on touchmove so we can preventDefault to stop the timeline scrolling under the finger).
- Mobile view wraps each \`ExternalEvent\` in a \`display:contents\` div that owns the touch handlers — keeps the chip's contract unchanged. Wrapper applies opacity/scale/shadow when its event is dragging.
- Read-only and all-day events are gated out of touch drag (canEdit check).
- \`justEndedDrag\` threaded into ExternalEvent's existing prop to suppress the trailing tap-to-click.

Same-day-only — cross-day touch drag is moot (mobile is single-day). Resize handles aren't exposed on touch (would need separate edge hit-targets to coexist with long-press body grab); use the detail sheet's time fields.

## Test plan

- [ ] Tap event → sheet opens.
- [ ] Hold 400ms still → vibrate, chip lifts.
- [ ] Drag → preview moves with finger.
- [ ] Lift → event lands at new time, Google/Outlook reflects.
- [ ] Pre-long-press swipe → timeline scrolls normally, no drag.
- [ ] Read-only event: long-press doesn't enter drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)