### PR TITLE
fix(mobile): touch-drag iOS Safari fixes — drop display:contents, kill OS callout

### DIFF
--- a/apps/web/src/components/calendar/external-event.tsx
+++ b/apps/web/src/components/calendar/external-event.tsx
@@ -57,6 +57,20 @@ interface ExternalEventProps {
    * open the detail sheet right after the user repositioned the event.
    */
   justEndedDrag?: boolean;
+  /**
+   * Touch handlers for the mobile long-press drag. Wired by
+   * `useMobileTouchDrag` — set on the chip's root div so the
+   * `display: contents` Safari-iOS regression doesn't apply.
+   */
+  onTouchStart?: (e: React.TouchEvent) => void;
+  onTouchMove?: (e: React.TouchEvent) => void;
+  onTouchEnd?: (e: React.TouchEvent) => void;
+  /**
+   * Visual-only "this chip is currently being dragged on touch".
+   * The mobile drag hook sets this; the chip uses it to apply
+   * scale/shadow/opacity feedback so the user sees the lift.
+   */
+  isTouchDragging?: boolean;
   className?: string;
 }
 
@@ -95,6 +109,10 @@ export function ExternalEvent({
   onResizeStart,
   isDragging = false,
   justEndedDrag = false,
+  onTouchStart,
+  onTouchMove,
+  onTouchEnd,
+  isTouchDragging = false,
   className,
 }: ExternalEventProps) {
   const startTime = new Date(event.startTime);
@@ -173,6 +191,9 @@ export function ExternalEvent({
                 : onDragStart
                   ? "cursor-grab"
                   : "cursor-pointer",
+              // Touch-drag visual feedback: lift + shadow on mobile.
+              isTouchDragging &&
+                "opacity-60 scale-[1.02] shadow-lg z-[15]",
               className
             )}
             style={{
@@ -187,9 +208,21 @@ export function ExternalEvent({
               width: `calc(${100 / layout.columnCount - COLUMN_GAP_PCT}% - ${layout.lane === 0 ? "4px" : "1px"})`,
               backgroundColor: hexToRgba(color, 0.1),
               borderColor: hexToRgba(color, 0.5),
+              // Suppress iOS Safari's text-selection callout on
+              // long-press — it would otherwise race with our 400ms
+              // long-press-to-drag timer and sometimes win, blocking
+              // the drag from starting. Belt + suspenders with
+              // `select-none` (which only suppresses selection, not
+              // the callout). Inline because there's no Tailwind
+              // shorthand for `-webkit-touch-callout`.
+              WebkitTouchCallout: "none",
+              WebkitUserSelect: "none",
             }}
             onClick={handleClick}
             onMouseDown={handleMouseDown}
+            onTouchStart={onTouchStart}
+            onTouchMove={onTouchMove}
+            onTouchEnd={onTouchEnd}
             role="button"
             tabIndex={0}
             aria-label={`Calendar event: ${event.title} from ${format(startTime, "h:mm a")} to ${format(endTime, "h:mm a")}`}

--- a/apps/web/src/components/mobile/mobile-calendar-view.tsx
+++ b/apps/web/src/components/mobile/mobile-calendar-view.tsx
@@ -485,12 +485,12 @@ export function MobileCalendarView({
             )}
 
             {/* External calendar events (drawn behind time blocks).
-                Wrapped so we can install touch handlers without
-                changing ExternalEvent's contract. The wrapper
-                intentionally contributes nothing to layout — its
-                pointer-events stay default and clicks pass through
-                to the chip's own handler (which respects
-                justEndedDrag). */}
+                Touch handlers go directly on the chip's root via
+                ExternalEvent's `onTouchStart`/etc props — earlier
+                we used a `display: contents` wrapper but Safari ≤
+                iOS 15 has known bugs with pointer/touch events on
+                `display: contents` elements. Wiring through the
+                chip's root avoids the wrapper entirely. */}
             {!isLoading &&
               timedEvents.map((event) => {
                 const canEdit =
@@ -499,12 +499,16 @@ export function MobileCalendarView({
                 const isThisDragging =
                   touchDrag.dragState?.eventId === event.id;
                 return (
-                  <div
+                  <ExternalEvent
                     key={event.id}
-                    className={cn(
-                      "contents",
-                      isThisDragging && "[&>*]:opacity-60 [&>*]:scale-[1.02] [&>*]:shadow-lg [&>*]:transition-transform"
-                    )}
+                    event={event}
+                    displayDate={selectedDate}
+                    layout={
+                      itemLayouts.get(`event:${event.id}`) ?? DEFAULT_LAYOUT
+                    }
+                    onClick={() => handleExternalEventClick(event)}
+                    justEndedDrag={touchDrag.justEndedDrag}
+                    isTouchDragging={isThisDragging}
                     onTouchStart={
                       canEdit
                         ? (e) =>
@@ -519,17 +523,7 @@ export function MobileCalendarView({
                     }
                     onTouchMove={canEdit ? touchDrag.handleTouchMove : undefined}
                     onTouchEnd={canEdit ? touchDrag.handleTouchEnd : undefined}
-                  >
-                    <ExternalEvent
-                      event={event}
-                      displayDate={selectedDate}
-                      layout={
-                        itemLayouts.get(`event:${event.id}`) ?? DEFAULT_LAYOUT
-                      }
-                      onClick={() => handleExternalEventClick(event)}
-                      justEndedDrag={touchDrag.justEndedDrag}
-                    />
-                  </div>
+                  />
                 );
               })}
 


### PR DESCRIPTION
## Summary

Audit caught two iOS Safari regressions in PR #47.

1. **\`display: contents\` wrapper broke touch events on Safari ≤ iOS 15.** Some users couldn't long-press at all. Fix: \`ExternalEvent\` now accepts \`onTouchStart\`/\`onTouchMove\`/\`onTouchEnd\` + \`isTouchDragging\` props that wire onto the chip's existing root div. Wrapper deleted.

2. **iOS callout raced with the long-press timer.** iOS shows the OS text-selection callout at roughly the same ~400ms threshold; sometimes the OS won, blocking the drag. Fix: \`-webkit-touch-callout: none\` and \`-webkit-user-select: none\` inline on the chip (no Tailwind shorthand for those).

## Test plan

- [ ] iOS Safari: long-press an event → no OS copy/share menu appears, drag starts cleanly.
- [ ] Android Chrome: long-press still works.
- [ ] Visual feedback (scale + shadow) shows during drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)