### PR TITLE
fix(calendar): iCloud delete typed-error pass-through + consolidate PROVIDERS_WITH_WRITE_BACK

### DIFF
--- a/apps/api/src/services/calendar-providers/icloud.ts
+++ b/apps/api/src/services/calendar-providers/icloud.ts
@@ -417,8 +417,23 @@ function mergePatchIntoEvent(
   };
 }
 
-/** Map a thrown error from tsdav to a typed provider error. */
+/**
+ * Map a thrown error from tsdav to a typed provider error.
+ *
+ * Pass-through for already-typed errors (`ProviderEventNotFoundError`,
+ * `ProviderAuthError`, `ProviderReadOnlyError`) — without this guard,
+ * a typed error thrown inside a `try` block would be re-wrapped here
+ * as a generic `Error("iCloud ... failed: ...")`, the route's
+ * `instanceof` checks would miss, and the user would see a 502
+ * instead of the friendly 410/401 toast.
+ */
 function mapCalDavError(op: string, err: unknown): Error {
+  if (
+    err instanceof ProviderAuthError ||
+    err instanceof ProviderEventNotFoundError
+  ) {
+    return err;
+  }
   const message = err instanceof Error ? err.message : 'Unknown error';
   if (/401|Unauthorized|403|Forbidden/i.test(message)) {
     return new ProviderAuthError('icloud');

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/hooks";
 import { useAuth } from "@/hooks/useAuth";
 import { useSavePreferences } from "@/hooks/useUserPreferences";
+import { isCalendarReadOnlyForUi } from "@/lib/calendar-providers";
 import {
   useCalendarEvents,
   useCalendars,
@@ -278,22 +279,14 @@ export function CalendarView({
     for (const a of calendarAccounts) m.set(a.id, a.provider);
     return m;
   }, [calendarAccounts]);
-  const PROVIDERS_WITH_WRITE_BACK = React.useMemo(
-    () => new Set(["google", "outlook", "icloud"]),
-    []
-  );
   const calendarReadOnlyById = React.useMemo(() => {
     const m = new Map<string, boolean>();
     for (const c of calendarsList) {
       const provider = accountProviderById.get(c.accountId);
-      const writable =
-        !!provider &&
-        PROVIDERS_WITH_WRITE_BACK.has(provider) &&
-        !c.isReadOnly;
-      m.set(c.id, !writable);
+      m.set(c.id, isCalendarReadOnlyForUi(provider, c.isReadOnly));
     }
     return m;
-  }, [calendarsList, accountProviderById, PROVIDERS_WITH_WRITE_BACK]);
+  }, [calendarsList, accountProviderById]);
 
   // Mutations
   const createTimeBlock = useCreateTimeBlock();

--- a/apps/web/src/components/calendar/create-dialog/event-form.tsx
+++ b/apps/web/src/components/calendar/create-dialog/event-form.tsx
@@ -19,8 +19,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui";
-
-const PROVIDERS_WITH_WRITE_BACK = new Set(["google", "outlook", "icloud"]);
+import { PROVIDERS_WITH_WRITE_BACK } from "@/lib/calendar-providers";
 
 /**
  * Calendar event sub-form for the create dialog. Picks among the

--- a/apps/web/src/components/kanban/kanban-calendar-panel.tsx
+++ b/apps/web/src/components/kanban/kanban-calendar-panel.tsx
@@ -29,6 +29,7 @@ import {
   layoutOverlappingItems,
   type LayoutResult,
 } from "@/components/calendar/event-layout";
+import { PROVIDERS_WITH_WRITE_BACK } from "@/lib/calendar-providers";
 import {
   useCalendarDnd,
   HOUR_HEIGHT,
@@ -42,7 +43,8 @@ import {
 
 const DEFAULT_LAYOUT: LayoutResult = { lane: 0, columnCount: 1 };
 
-const PROVIDERS_WITH_WRITE_BACK = new Set(["google", "outlook", "icloud"]);
+// Imported from the central source so adding a new provider is a
+// one-line change in one place.
 
 interface KanbanCalendarPanelProps {
   date: Date;

--- a/apps/web/src/components/mobile/mobile-calendar-view.tsx
+++ b/apps/web/src/components/mobile/mobile-calendar-view.tsx
@@ -34,6 +34,7 @@ import {
   useUpdateCalendarEvent,
 } from "@/hooks/useCalendars";
 import { useMobileTouchDrag } from "./use-mobile-touch-drag";
+import { PROVIDERS_WITH_WRITE_BACK } from "@/lib/calendar-providers";
 import {
   HOUR_HEIGHT,
   TIMELINE_START_HOUR,
@@ -57,7 +58,8 @@ import {
 import { UnscheduledTasksDrawer } from "./mobile-unscheduled-drawer";
 
 const DEFAULT_LAYOUT: LayoutResult = { lane: 0, columnCount: 1 };
-const PROVIDERS_WITH_WRITE_BACK = new Set(["google", "outlook", "icloud"]);
+// Imported from the central source so adding a new provider is a
+// one-line change in one place.
 
 interface MobileCalendarViewProps {
   /** Initial date to display */

--- a/apps/web/src/lib/calendar-providers.ts
+++ b/apps/web/src/lib/calendar-providers.ts
@@ -1,0 +1,34 @@
+/**
+ * Single source of truth for which calendar providers support
+ * write-back (create / update / delete from in-app surfaces).
+ *
+ * Previously declared in 4 separate places (calendar-view, mobile-
+ * calendar-view, kanban-calendar-panel, create-dialog/event-form),
+ * which had drifted at least once during the per-provider rollout
+ * (Outlook added in 3 of 4 sites in one PR, then iCloud in all 4
+ * later). Centralised here so adding a new provider is a one-line
+ * change.
+ */
+export const PROVIDERS_WITH_WRITE_BACK: ReadonlySet<string> = new Set([
+  "google",
+  "outlook",
+  "icloud",
+]);
+
+/**
+ * Lookup helper: given a per-calendar map of provider names (resolved
+ * via the account map), return whether the calendar accepts writes
+ * AND isn't flagged read-only by the provider itself.
+ *
+ * Returns `true` for "calendar should be treated as read-only in our
+ * UI" — which gates the Edit/Delete buttons in the detail sheet, the
+ * drag/resize handles on the timeline, and the calendar picker in
+ * the create-event dialog.
+ */
+export function isCalendarReadOnlyForUi(
+  provider: string | undefined,
+  isReadOnly: boolean
+): boolean {
+  if (!provider || !PROVIDERS_WITH_WRITE_BACK.has(provider)) return true;
+  return isReadOnly;
+}


### PR DESCRIPTION
## Summary

Two cleanups from the audit on PR #49.

1. **iCloud \`deleteEvent\` swallowed typed errors.** The inner \`throw await mapCalDavHttpError(...)\` got caught by the outer \`catch\`, re-wrapped via \`mapCalDavError\` (whose regex doesn't match the typed errors' message strings), and the route's \`instanceof\` checks then missed → user got a 502 instead of the friendly 410 "out-of-sync" cleanup or 401 "reconnect" toast. Fix: pass typed errors through unchanged.

2. **\`PROVIDERS_WITH_WRITE_BACK\` duplicated 4×** across calendar-view, create-dialog/event-form, mobile-calendar-view, kanban-calendar-panel. Consolidated into \`apps/web/src/lib/calendar-providers.ts\` with both the constant and an \`isCalendarReadOnlyForUi(provider, isReadOnly)\` helper. Adding a new provider is now a one-line change.

## Test plan

- [ ] Delete an iCloud event whose local row has stale htmlLink → friendly "Event out of sync" toast + auto-cleanup (was 502 before).
- [ ] Delete an iCloud event when the access token is rejected → "Reconnect your calendar" toast (was 502).
- [ ] All four surfaces (main calendar, mobile, kanban panel, create dialog) gate Edit/Delete/Drag identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)