### PR TITLE
fix(calendar): correct iCloud recurring-event disclosure + migrate inline read-only checks

### DIFF
--- a/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
+++ b/apps/web/src/components/calendar/calendar-event-detail-sheet.tsx
@@ -58,6 +58,16 @@ interface CalendarEventDetailSheetProps {
    * calendars, holidays, etc.).
    */
   calendarReadOnly?: boolean;
+  /**
+   * Provider name (e.g. "google", "outlook", "icloud") for the
+   * event's calendar — used to branch the recurring-event
+   * disclosure copy. Google and Outlook treat a PATCH on an
+   * instance id as an exception (this instance only), but iCloud's
+   * CalDAV PUT replaces the whole VEVENT including RRULE → the
+   * change hits the entire series. Without this prop the
+   * disclosure would lie to iCloud users.
+   */
+  calendarProvider?: string;
 }
 
 function hexToRgba(hex: string, alpha: number): string {
@@ -194,6 +204,7 @@ export function CalendarEventDetailSheet({
   rangeFrom,
   rangeTo,
   calendarReadOnly = false,
+  calendarProvider,
 }: CalendarEventDetailSheetProps) {
   // Render nothing until first open so the sheet doesn't allocate DOM
   // before a user actually clicks an event.
@@ -382,30 +393,50 @@ export function CalendarEventDetailSheet({
 
           {event && (
             <div className="mt-6 space-y-5">
-              {/* Recurring-event disclosure. Edits and deletes from
-                  this sheet apply to THIS instance only — Google and
-                  Outlook both interpret a PATCH/DELETE on an instance
-                  id as an exception, not a series modification. We
-                  surface the badge plus a one-line note so users
-                  aren't surprised when the next occurrence still
-                  shows the old title or still exists after delete. */}
-              {(event.recurringEventId || event.recurrenceRule) && (
-                <div className="flex items-start gap-2 rounded-md border border-dashed border-border/60 bg-muted/30 px-3 py-2">
-                  <Repeat
-                    className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground"
-                    aria-hidden
-                  />
-                  <div className="text-xs">
-                    <p className="font-medium text-foreground/80">
-                      Recurring event · this instance
-                    </p>
-                    <p className="mt-0.5 text-muted-foreground">
-                      Changes here apply to this occurrence only. To
-                      edit the whole series, use the calendar provider.
-                    </p>
+              {/* Recurring-event disclosure. Behavior diverges by
+                  provider:
+                    - Google / Outlook: PATCH/DELETE on an instance id
+                      creates an exception → "this instance only".
+                    - iCloud (CalDAV): PUT replaces the master VEVENT
+                      including RRULE → "this entire series". The
+                      copy is amber/warning-tinted because the
+                      blast radius is bigger than the user might
+                      expect from a single-event UI affordance. */}
+              {(event.recurringEventId || event.recurrenceRule) &&
+                (calendarProvider === "icloud" ? (
+                  <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2">
+                    <Repeat
+                      className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-600 dark:text-amber-400"
+                      aria-hidden
+                    />
+                    <div className="text-xs">
+                      <p className="font-medium text-amber-700 dark:text-amber-300">
+                        Recurring event · entire series
+                      </p>
+                      <p className="mt-0.5 text-amber-700/80 dark:text-amber-300/80">
+                        iCloud doesn't support per-instance edits —
+                        any change here applies to every occurrence.
+                        To edit just one, use the iCloud Calendar app.
+                      </p>
+                    </div>
                   </div>
-                </div>
-              )}
+                ) : (
+                  <div className="flex items-start gap-2 rounded-md border border-dashed border-border/60 bg-muted/30 px-3 py-2">
+                    <Repeat
+                      className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground"
+                      aria-hidden
+                    />
+                    <div className="text-xs">
+                      <p className="font-medium text-foreground/80">
+                        Recurring event · this instance
+                      </p>
+                      <p className="mt-0.5 text-muted-foreground">
+                        Changes here apply to this occurrence only. To
+                        edit the whole series, use the calendar provider.
+                      </p>
+                    </div>
+                  </div>
+                ))}
               {isEditing && editState ? (
                 <EditForm
                   state={editState}

--- a/apps/web/src/components/calendar/calendar-view.tsx
+++ b/apps/web/src/components/calendar/calendar-view.tsx
@@ -288,6 +288,18 @@ export function CalendarView({
     return m;
   }, [calendarsList, accountProviderById]);
 
+  // Per-calendar provider map — passed to the detail sheet so the
+  // recurring-event disclosure copy can branch on provider (iCloud
+  // edits hit the entire series; Google/Outlook hit one instance).
+  const calendarProviderById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of calendarsList) {
+      const provider = accountProviderById.get(c.accountId);
+      if (provider) m.set(c.id, provider);
+    }
+    return m;
+  }, [calendarsList, accountProviderById]);
+
   // Mutations
   const createTimeBlock = useCreateTimeBlock();
   const moveTimeBlock = useMoveTimeBlock();
@@ -760,6 +772,11 @@ export function CalendarView({
                 selectedExternalEvent.calendarId
               ) ?? true)
             : true
+        }
+        calendarProvider={
+          selectedExternalEvent
+            ? calendarProviderById.get(selectedExternalEvent.calendarId)
+            : undefined
         }
       />
 

--- a/apps/web/src/components/calendar/create-dialog/event-form.tsx
+++ b/apps/web/src/components/calendar/create-dialog/event-form.tsx
@@ -19,7 +19,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui";
-import { PROVIDERS_WITH_WRITE_BACK } from "@/lib/calendar-providers";
+import { isCalendarReadOnlyForUi } from "@/lib/calendar-providers";
 
 /**
  * Calendar event sub-form for the create dialog. Picks among the
@@ -48,10 +48,7 @@ export function EventForm({
       .filter((c) => {
         const provider = providerByAccount.get(c.accountId);
         return (
-          !!provider &&
-          PROVIDERS_WITH_WRITE_BACK.has(provider) &&
-          !c.isReadOnly &&
-          c.isEnabled
+          !isCalendarReadOnlyForUi(provider, c.isReadOnly) && c.isEnabled
         );
       })
       .sort((a, b) => {

--- a/apps/web/src/components/kanban/kanban-calendar-panel.tsx
+++ b/apps/web/src/components/kanban/kanban-calendar-panel.tsx
@@ -29,7 +29,7 @@ import {
   layoutOverlappingItems,
   type LayoutResult,
 } from "@/components/calendar/event-layout";
-import { PROVIDERS_WITH_WRITE_BACK } from "@/lib/calendar-providers";
+import { isCalendarReadOnlyForUi } from "@/lib/calendar-providers";
 import {
   useCalendarDnd,
   HOUR_HEIGHT,
@@ -80,23 +80,31 @@ export function KanbanCalendarPanel({
   const toDate = dayEnd.toISOString();
   const { data: calendarEvents = [] } = useCalendarEvents(fromDate, toDate);
 
-  // For the read-only-calendar gating in the detail sheet.
+  // For the read-only-calendar gating + recurring-event disclosure in
+  // the detail sheet.
   const { data: calendarsList = [] } = useCalendars();
   const { data: calendarAccounts = [] } = useCalendarAccounts();
+  const accountProviderById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const a of calendarAccounts) m.set(a.id, a.provider);
+    return m;
+  }, [calendarAccounts]);
   const calendarReadOnlyById = React.useMemo(() => {
-    const providerByAccount = new Map<string, string>();
-    for (const a of calendarAccounts) providerByAccount.set(a.id, a.provider);
     const m = new Map<string, boolean>();
     for (const c of calendarsList) {
-      const provider = providerByAccount.get(c.accountId);
-      const writable =
-        !!provider &&
-        PROVIDERS_WITH_WRITE_BACK.has(provider) &&
-        !c.isReadOnly;
-      m.set(c.id, !writable);
+      const provider = accountProviderById.get(c.accountId);
+      m.set(c.id, isCalendarReadOnlyForUi(provider, c.isReadOnly));
     }
     return m;
-  }, [calendarsList, calendarAccounts]);
+  }, [calendarsList, accountProviderById]);
+  const calendarProviderById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of calendarsList) {
+      const provider = accountProviderById.get(c.accountId);
+      if (provider) m.set(c.id, provider);
+    }
+    return m;
+  }, [calendarsList, accountProviderById]);
 
   // External-event detail sheet state — opens when the user clicks a
   // calendar event in the panel. Self-contained inside the panel so the
@@ -523,6 +531,11 @@ export function KanbanCalendarPanel({
                 selectedExternalEvent.calendarId
               ) ?? true)
             : true
+        }
+        calendarProvider={
+          selectedExternalEvent
+            ? calendarProviderById.get(selectedExternalEvent.calendarId)
+            : undefined
         }
       />
     </div>

--- a/apps/web/src/components/mobile/mobile-calendar-view.tsx
+++ b/apps/web/src/components/mobile/mobile-calendar-view.tsx
@@ -34,7 +34,7 @@ import {
   useUpdateCalendarEvent,
 } from "@/hooks/useCalendars";
 import { useMobileTouchDrag } from "./use-mobile-touch-drag";
-import { PROVIDERS_WITH_WRITE_BACK } from "@/lib/calendar-providers";
+import { isCalendarReadOnlyForUi } from "@/lib/calendar-providers";
 import {
   HOUR_HEIGHT,
   TIMELINE_START_HOUR,
@@ -159,23 +159,31 @@ export function MobileCalendarView({
   // External calendar events
   const { data: calendarEvents = [] } = useCalendarEvents(fromDate, toDate);
 
-  // Per-calendar editability for the detail sheet's read-only gate.
+  // Per-calendar editability + provider maps for the detail sheet
+  // (read-only gate + recurring-event disclosure copy).
   const { data: calendarsList = [] } = useCalendars();
   const { data: calendarAccounts = [] } = useCalendarAccounts();
+  const accountProviderById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const a of calendarAccounts) m.set(a.id, a.provider);
+    return m;
+  }, [calendarAccounts]);
   const calendarReadOnlyById = React.useMemo(() => {
-    const providerByAccount = new Map<string, string>();
-    for (const a of calendarAccounts) providerByAccount.set(a.id, a.provider);
     const m = new Map<string, boolean>();
     for (const c of calendarsList) {
-      const provider = providerByAccount.get(c.accountId);
-      const writable =
-        !!provider &&
-        PROVIDERS_WITH_WRITE_BACK.has(provider) &&
-        !c.isReadOnly;
-      m.set(c.id, !writable);
+      const provider = accountProviderById.get(c.accountId);
+      m.set(c.id, isCalendarReadOnlyForUi(provider, c.isReadOnly));
     }
     return m;
-  }, [calendarsList, calendarAccounts]);
+  }, [calendarsList, accountProviderById]);
+  const calendarProviderById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of calendarsList) {
+      const provider = accountProviderById.get(c.accountId);
+      if (provider) m.set(c.id, provider);
+    }
+    return m;
+  }, [calendarsList, accountProviderById]);
 
   // Long-press-to-drag for external events. Same write-back path the
   // desktop uses — useUpdateCalendarEvent handles optimistic update +
@@ -617,6 +625,11 @@ export function MobileCalendarView({
                 selectedExternalEvent.calendarId
               ) ?? true)
             : true
+        }
+        calendarProvider={
+          selectedExternalEvent
+            ? calendarProviderById.get(selectedExternalEvent.calendarId)
+            : undefined
         }
       />
     </div>


### PR DESCRIPTION
## Summary

- The recurring-event disclosure in the calendar event detail sheet was lying to iCloud users. It said "Changes here apply to this occurrence only" — but for iCloud, our CalDAV `PUT` replaces the master VEVENT, so a title/start/end edit silently mutates **every** instance of the series.
- Branch the copy by provider: Google/Outlook keep the per-instance phrasing (their server-side PATCH on an instance ID creates an exception); iCloud now shows an amber-tinted "entire series" warning and points users to iCloud Calendar for per-instance edits.
- Plumb a new `calendarProvider` prop from all three sheet mount sites (calendar-view, mobile-calendar-view, kanban-calendar-panel) via the calendar→account→provider lookup.
- Finish the helper migration from PR #50: the 3 remaining inline `PROVIDERS_WITH_WRITE_BACK + isReadOnly` joins (event-form, kanban-calendar-panel, mobile-calendar-view) now use `isCalendarReadOnlyForUi` so the per-provider read-only logic lives in one place.

## Why this matters

User taps a recurring iCloud event → renames it to "Q2 Sync" → sheet says "this occurrence only" → user closes the sheet expecting one rename → every instance for the next 5 years now reads "Q2 Sync". Silent data corruption from a UX standpoint.

## Test plan

- [ ] Tap a recurring Google event → disclosure copy reads "this instance" (neutral muted box)
- [ ] Tap a recurring iCloud event → disclosure copy reads "entire series" (amber warning box)
- [ ] Tap a recurring Outlook event → disclosure copy reads "this instance"
- [ ] Tap a non-recurring event (any provider) → no disclosure shown
- [ ] Read-only iCloud calendars still grey-out the Edit/Delete buttons (helper migration didn't regress)
- [ ] Create-event dialog still excludes read-only and read-only-provider calendars
- [ ] Mobile calendar view + kanban calendar panel both display the correct disclosure

🤖 Generated with [Claude Code](https://claude.com/claude-code)