### PR TITLE
fix(calendar): preserve RRULE + bump SEQUENCE on iCloud event update

### DIFF
--- a/apps/api/src/services/calendar-providers/icloud-helpers.ts
+++ b/apps/api/src/services/calendar-providers/icloud-helpers.ts
@@ -14,6 +14,11 @@ export interface VCalendarComponent {
   rrule?: string;
   status?: string;
   etag?: string;
+  // Parsed from the existing VEVENT so we can bump it on the next
+  // PUT — required for RFC 5546 update semantics. Kept as a number
+  // so `+1` stays trivial; `parseVCalendar` defaults to undefined
+  // when the existing VEVENT didn't have SEQUENCE.
+  sequence?: number;
 }
 
 /**
@@ -98,6 +103,13 @@ export function parseVCalendar(icalData: string): VCalendarComponent | null {
       case 'STATUS':
         event.status = value;
         break;
+      case 'SEQUENCE': {
+        const n = parseInt(value, 10);
+        if (Number.isFinite(n) && n >= 0) {
+          event.sequence = n;
+        }
+        break;
+      }
     }
   }
 
@@ -119,13 +131,34 @@ export function mapCalDavStatus(status?: string): 'confirmed' | 'tentative' | 'c
 }
 
 /**
- * Parse a CalDAV event object into our ExternalEvent format
+ * Parse a CalDAV event object into our ExternalEvent format.
+ *
+ * The update path needs access to the raw `VCalendarComponent` too
+ * (for SEQUENCE — iCloud-specific, not a cross-provider concept) so
+ * we expose `parseCalDavEventWithRaw`. `parseCalDavEvent` is the
+ * thin wrapper used by the sync read path that doesn't care about
+ * sequence.
  */
-export function parseCalDavEvent(obj: DAVObject): ExternalEvent | null {
+export function parseCalDavEventWithRaw(
+  obj: DAVObject
+): { event: ExternalEvent; raw: VCalendarComponent } | null {
   if (!obj.data) return null;
 
-  const event = parseVCalendar(obj.data);
-  if (!event?.uid || !event.dtstart) return null;
+  const raw = parseVCalendar(obj.data);
+  if (!raw?.uid || !raw.dtstart) return null;
+  const event = buildExternalEventFromComponent(obj, raw);
+  return event ? { event, raw } : null;
+}
+
+export function parseCalDavEvent(obj: DAVObject): ExternalEvent | null {
+  return parseCalDavEventWithRaw(obj)?.event ?? null;
+}
+
+function buildExternalEventFromComponent(
+  obj: DAVObject,
+  event: VCalendarComponent
+): ExternalEvent | null {
+  if (!event.uid || !event.dtstart) return null;
 
   const isAllDay = event.dtstart.length === 8;
   const startTime = parseICalDateTime(event.dtstart, isAllDay);
@@ -170,6 +203,16 @@ export function parseCalDavEvent(obj: DAVObject): ExternalEvent | null {
  * This is enough for create/update — iCloud accepts a full VCALENDAR
  * envelope around a single VEVENT. We don't write timezone components
  * (VTIMEZONE) because iCloud accepts UTC dateTimes via the Z suffix.
+ *
+ * IMPORTANT — RRULE preservation: CalDAV PUT replaces the entire
+ * calendar object (RFC 4791 §5.3.2). Any property the existing
+ * VEVENT had but we omit on PUT is treated as deleted. Callers
+ * updating a recurring event MUST pass `rrule` (the raw RRULE value
+ * read back from `parseVCalendar`) so the series isn't silently
+ * destroyed. Same goes for `sequence` — RFC 5546 §3.1.4 says
+ * downstream clients can ignore an update whose SEQUENCE didn't
+ * increment, so iOS Calendar / shared participants may stay stale
+ * unless we bump it.
  */
 export function buildVCalendar(input: {
   uid: string;
@@ -179,6 +222,8 @@ export function buildVCalendar(input: {
   startTime: Date;
   endTime: Date;
   isAllDay: boolean;
+  rrule?: string | null;
+  sequence?: number | null;
 }): string {
   const lines: string[] = [
     'BEGIN:VCALENDAR',
@@ -202,6 +247,16 @@ export function buildVCalendar(input: {
   } else {
     lines.push(`DTSTART:${formatICalUtc(input.startTime)}`);
     lines.push(`DTEND:${formatICalUtc(input.endTime)}`);
+  }
+  // RRULE values are technically structured (FREQ=...;BYDAY=...) but
+  // we treat them opaquely — the server gave them to us, we hand
+  // them back unchanged. No escaping: RRULE values use literal `;`
+  // and `=` as syntax, not text content.
+  if (input.rrule) {
+    lines.push(`RRULE:${input.rrule}`);
+  }
+  if (typeof input.sequence === 'number') {
+    lines.push(`SEQUENCE:${input.sequence}`);
   }
   lines.push('END:VEVENT', 'END:VCALENDAR');
   // CRLF line endings per RFC 5545.

--- a/apps/api/src/services/calendar-providers/icloud.ts
+++ b/apps/api/src/services/calendar-providers/icloud.ts
@@ -15,7 +15,11 @@ import {
   ProviderAuthError,
   ProviderEventNotFoundError,
 } from './index';
-import { buildVCalendar, parseCalDavEvent } from './icloud-helpers';
+import {
+  buildVCalendar,
+  parseCalDavEvent,
+  parseCalDavEventWithRaw,
+} from './icloud-helpers';
 // Node's built-in randomUUID — used when generating UIDs for new events.
 import { randomUUID } from 'node:crypto';
 
@@ -269,13 +273,22 @@ export class ICloudCalendarProvider implements CalendarProvider {
     const credentials =
       this.credentials || (JSON.parse(accessToken) as CalDavCredentials);
     const client = await getCalDavClient(credentials);
-    // CalDAV PUT replaces the entire object — we need to send the
-    // FULL ICS, not just the changed fields. Fetch the current
-    // object, parse it, merge the patch, then re-serialise.
-    const existing = await fetchSingleObject(client, calendarId, patch.eventUrl);
-    if (!existing) {
+    // CalDAV PUT replaces the entire object (RFC 4791 §5.3.2) — we
+    // must send the FULL ICS, not just the changed fields. Anything
+    // we omit gets deleted server-side. The most catastrophic case
+    // is RRULE: dropping it on update silently destroys a recurring
+    // series everywhere it syncs (iPhone, Mac Calendar, shared
+    // attendees), so the existing VEVENT's recurrence + sequence
+    // must be carried forward by hand.
+    const existingPair = await fetchSingleObjectWithRaw(
+      client,
+      calendarId,
+      patch.eventUrl
+    );
+    if (!existingPair) {
       throw new ProviderEventNotFoundError('icloud');
     }
+    const { event: existing, raw } = existingPair;
     const merged = mergePatchIntoEvent(existing, patch);
     const ics = buildVCalendar({
       uid: existing.externalId,
@@ -285,6 +298,14 @@ export class ICloudCalendarProvider implements CalendarProvider {
       startTime: merged.startTime,
       endTime: merged.endTime,
       isAllDay: merged.isAllDay,
+      // Preserve the recurrence rule so the series stays intact.
+      // Per RFC 5545 §3.6.1, RRULE is a property of the master
+      // VEVENT — omitting it on PUT means "no longer recurring".
+      rrule: existing.recurrenceRule,
+      // Bump SEQUENCE per RFC 5546 §3.1.4 so downstream clients
+      // (iOS Calendar, shared attendees) accept the update instead
+      // of treating it as stale.
+      sequence: (raw.sequence ?? 0) + 1,
     });
     let response: Response;
     try {
@@ -309,9 +330,8 @@ export class ICloudCalendarProvider implements CalendarProvider {
       startTime: merged.startTime,
       endTime: merged.endTime,
       isAllDay: merged.isAllDay,
-      // Carry the rest forward from the existing event — CalDAV
-      // doesn't surface RRULE/timezone changes through this path
-      // so they stay as they were.
+      // Carry the rest forward — RRULE was preserved on the wire
+      // above, and timezone isn't exposed through our patch shape.
       timezone: existing.timezone,
       recurrenceRule: existing.recurrenceRule,
       recurringEventId: existing.recurringEventId,
@@ -373,19 +393,24 @@ async function getCalDavClient(
   return client;
 }
 
-/** Re-fetch a single CalDAV object so we can merge a partial patch. */
-async function fetchSingleObject(
+/**
+ * Re-fetch a single CalDAV object and return both the parsed
+ * `ExternalEvent` and its raw `VCalendarComponent`. Update needs the
+ * raw component for iCloud-specific properties (SEQUENCE) that
+ * aren't part of the cross-provider `ExternalEvent` shape.
+ */
+async function fetchSingleObjectWithRaw(
   client: DAVClient,
   calendarUrl: string,
   objectUrl: string
-): Promise<ExternalEvent | null> {
+) {
   const objects = await client.fetchCalendarObjects({
     calendar: { url: calendarUrl },
     objectUrls: [objectUrl],
   });
   const obj = objects[0];
   if (!obj) return null;
-  return parseCalDavEvent(obj);
+  return parseCalDavEventWithRaw(obj);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Critical data-loss fix.** Editing *any* field of a recurring iCloud event (title, drag-to-reschedule, resize, all-day toggle) silently destroyed the entire recurrence series on iCloud, iPhone Calendar, Mac Calendar, and every shared attendee's calendar. CalDAV PUT replaces the full VEVENT (RFC 4791 §5.3.2); our \`buildVCalendar\` never emitted RRULE, so every PUT stripped recurrence. The local UI hid the loss for one render cycle by synthesising \`recurrenceRule: existing.recurrenceRule\` on the response, leaving no signal to the user.
- Thread the existing event's RRULE through \`buildVCalendar\` so it's emitted unchanged on update.
- Bump SEQUENCE per RFC 5546 §3.1.4 so downstream clients (iOS Calendar, shared attendees) accept the revision instead of ignoring it as stale.
- Expose \`parseCalDavEventWithRaw\` so the update path can read iCloud-specific properties (SEQUENCE) without polluting the cross-provider \`ExternalEvent\` type.

## Why this matters

PR #52 landed an amber warning telling iCloud users "any change here applies to every occurrence." That copy was *about to become a lie* — the actual server-side outcome was "any change destroys every occurrence, leaving a single one-off event." After this PR, the disclosure tells the truth: edits propagate to every occurrence and the recurrence rule is preserved.

## Test plan

- [ ] Create a recurring event in iCloud Calendar (e.g. weekly, every Tuesday)
- [ ] In Open Sunsama, click any instance and rename it → reload from iCloud → series stays recurring, all instances now show the new title
- [ ] Drag a recurring iCloud event to a new time → series stays recurring, time shift applies to all
- [ ] Edit description / location → no regression
- [ ] Resize a recurring iCloud event → series stays recurring
- [ ] Delete still works (no impact)
- [ ] Non-recurring iCloud edits unchanged
- [ ] Google + Outlook recurring edits unchanged (this fix is iCloud-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)