### PR TITLE
fix(calendar): Outlook event deletions never propagated to local DB

### DIFF
--- a/apps/api/src/services/calendar-providers/outlook.ts
+++ b/apps/api/src/services/calendar-providers/outlook.ts
@@ -160,7 +160,16 @@ export class OutlookCalendarProvider implements CalendarProvider {
       if (options.timeMin && options.timeMax) {
         params.set('startDateTime', options.timeMin.toISOString());
         params.set('endDateTime', options.timeMax.toISOString());
-        url = `${GRAPH_API}/me/calendars/${encodeURIComponent(calendarId)}/calendarView?${params.toString()}`;
+        // calendarView/delta — NOT calendarView. The plain endpoint
+        // returns "current state" with no `@removed` markers, so
+        // events deleted upstream become permanent ghosts in our DB
+        // (the user only sees them disappear after Settings → Reset
+        // & re-sync). The `/delta` variant accepts the same window
+        // params, returns the full set on first call with a
+        // `@odata.deltaLink` at the end, then emits `@removed` on
+        // subsequent calls — which our existing branch at the
+        // event-loop below already handles.
+        url = `${GRAPH_API}/me/calendars/${encodeURIComponent(calendarId)}/calendarView/delta?${params.toString()}`;
       } else {
         url = `${GRAPH_API}/me/calendars/${encodeURIComponent(calendarId)}/events/delta?${params.toString()}`;
       }


### PR DESCRIPTION
## Summary

Outlook events deleted upstream (web / desktop / mobile) became permanent ghosts in Open Sunsama's local DB. Microsoft Graph's plain \`/calendarView\` endpoint returns "current state" with no \`@removed\` markers and no \`@odata.deltaLink\`. Our existing parser branches on both — but they were never present for \`/calendarView\` responses, so \`result.deleted\` was permanently empty and \`nextSyncToken\` permanently null.

Switching the URL to \`/calendarView/delta\` (same query params, same first-call shape) makes the existing \`@removed\` branch live AND gives us free incremental sync via the persisted deltaLink.

## Why this matters

Reproduction was trivial: connect Outlook → wait for sync → delete an event in Outlook web → click "Sync now" in Open Sunsama. The deleted event remained in the calendar view, draggable, openable, lying about your schedule. Recovery required Settings → Reset & re-sync (hidden, slow).

Every sync path was affected: manual sync, post-OAuth initial sync, the background worker. Same shape as the iCloud bugs in PRs #52–#54 (provider feature parity), now closed for Outlook.

## Test plan

- [ ] Connect an Outlook account → wait for initial sync → events appear
- [ ] Delete an event in Outlook web → trigger Open Sunsama sync → ghost is gone
- [ ] Move an event in Outlook web (date or time) → sync → event reflects new position
- [ ] Disconnect & reconnect → initial sync still pulls the full window
- [ ] Existing accounts with stale syncTokens migrate without manual intervention (Graph returns 410 → our \`SYNC_TOKEN_INVALID\` branch already resets)
- [ ] Background worker keeps running on the new endpoint (no infinite \`@odata.nextLink\` loop)

## Code

One-line URL change at \`apps/api/src/services/calendar-providers/outlook.ts:163\`. Comment block explains the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)