### PR TITLE
fix(calendar): typed ProviderAuthError on Google/Outlook refresh failures

### DIFF
--- a/apps/api/src/routes/calendar-accounts.ts
+++ b/apps/api/src/routes/calendar-accounts.ts
@@ -27,6 +27,7 @@ import {
   updateSyncStatus,
   publishSyncEvent,
 } from '../services/calendar-sync.js';
+import { ProviderAuthError } from '../services/calendar-providers/index.js';
 import { publishEvent } from '../lib/websocket/index.js';
 
 const calendarAccountsRouter = new Hono<{ Variables: AuthVariables }>();
@@ -242,6 +243,23 @@ calendarAccountsRouter.post(
       const errorMessage = err instanceof Error ? err.message : 'Unknown error';
       await updateSyncStatus(id, 'error', null, errorMessage);
       console.error(`[Calendar Sync] Error syncing account ${id}: ${errorMessage}`);
+
+      // Surface auth failures with the same shape the per-event
+      // routes use (calendar-events.ts) so the web client can show
+      // its "Reconnect your calendar" toast on a 401 instead of a
+      // generic 500 sync error.
+      if (err instanceof ProviderAuthError) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: 'PROVIDER_AUTH_FAILED',
+              message: errorMessage,
+            },
+          },
+          401
+        );
+      }
 
       return c.json({
         success: false,

--- a/apps/api/src/services/calendar-providers/google.ts
+++ b/apps/api/src/services/calendar-providers/google.ts
@@ -95,6 +95,20 @@ export class GoogleCalendarProvider implements CalendarProvider {
     });
 
     if (!response.ok) {
+      // Google returns 400 with `error: "invalid_grant"` when the
+      // refresh token has been revoked, expired, or the user changed
+      // their password. 401/403 are the textbook auth-failed shapes.
+      // All three mean "the user needs to reconnect" — surface as the
+      // typed `ProviderAuthError` so the route layer can emit a 401
+      // with a clean "Reconnect your calendar" toast instead of a
+      // 500 with raw Google JSON in the body.
+      if (
+        response.status === 400 ||
+        response.status === 401 ||
+        response.status === 403
+      ) {
+        throw new ProviderAuthError('google');
+      }
       const error = await response.text();
       throw new Error(`Failed to refresh token: ${error}`);
     }

--- a/apps/api/src/services/calendar-providers/outlook.ts
+++ b/apps/api/src/services/calendar-providers/outlook.ts
@@ -95,6 +95,21 @@ export class OutlookCalendarProvider implements CalendarProvider {
     });
 
     if (!response.ok) {
+      // Microsoft Graph identity returns 400 with `error:
+      // "invalid_grant"` (refresh token revoked or expired),
+      // `"interaction_required"` (consent rescinded), or
+      // `"unauthorized_client"` (app deauthorized). 401 covers token
+      // signature failures. All mean "user must reconnect" — surface
+      // as the typed `ProviderAuthError` so the route layer can emit
+      // a 401 with a clean "Reconnect" toast instead of a 500 with
+      // the raw Microsoft Graph JSON.
+      if (
+        response.status === 400 ||
+        response.status === 401 ||
+        response.status === 403
+      ) {
+        throw new ProviderAuthError('outlook');
+      }
       const error = await response.text();
       throw new Error(`Failed to refresh token: ${error}`);
     }


### PR DESCRIPTION
## Summary

When a user's Google or Outlook refresh token gets revoked (most commonly: they changed their password, deauthorized the app, or the token simply expired), the next sync would surface as a **500 with raw Google / Microsoft Graph JSON in the response body** instead of a clean 401 with a "Reconnect your calendar" toast. The route layer's \`instanceof ProviderAuthError\` mapping was correct — but the providers' \`refreshTokens\` methods threw a generic \`Error\` for non-OK responses, so the typed-error catch never fired.

## Fix

- \`Google.refreshTokens\`: branch 400/401/403 → \`ProviderAuthError('google')\`. The textbook revoked-token shape is 400 + \`error: "invalid_grant"\`.
- \`Outlook.refreshTokens\`: branch 400/401/403 → \`ProviderAuthError('outlook')\`. Microsoft Graph identity emits the same 400 \`invalid_grant\` plus \`interaction_required\` (consent rescinded) and \`unauthorized_client\` (app deauthorized).
- All four mean "user must reconnect" — surface as the typed error so the existing route-layer mapping fires.
- Generic Error path remains for transient 5xx / network failures so we don't false-positive a "reconnect" prompt on a Google outage.

## Why this matters

The flow was: user changes Google password → next time their access token expires → \`refreshTokensIfNeeded\` calls \`provider.refreshTokens\` → 400 \`invalid_grant\` → generic Error with raw JSON → 500 to the client → toast says "Failed to refresh token: {\\"error\\":\\"invalid_grant\\",...}". User has no idea what to do; the only recovery was to disconnect and reconnect from Settings, which the toast doesn't suggest. Background worker would also persist the raw JSON into the per-account sync status row.

## Test plan

- [ ] Connect a Google account, force-revoke at https://myaccount.google.com/permissions → trigger sync → 401 with "Reconnect your calendar" toast
- [ ] Same for Outlook (revoke at https://account.microsoft.com/privacy/app-access)
- [ ] Connect with a fresh account → no spurious 401s on healthy refresh paths
- [ ] Simulate transient 5xx (e.g., point GOOGLE_TOKEN_URL at a sink that returns 503) → generic error, not "Reconnect"
- [ ] Background worker records the cleaner message in \`calendar_accounts.sync_status\`
- [ ] iCloud (CalDAV) unaffected — its own \`mapCalDavError\` already covers this

🤖 Generated with [Claude Code](https://claude.com/claude-code)