### PR TITLE
fix(calendar): re-home misattributed events on sync upsert

### DIFF
--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -323,7 +323,9 @@ export async function upsertEvents(
 
   for (const slice of perCalendar) {
     for (const event of slice.events) {
-      const [existing] = await db
+      // Look up first in this slice's own calendar (the normal case
+      // for an incremental update on a steady-state account).
+      const [existingInSlice] = await db
         .select({ id: calendarEvents.id })
         .from(calendarEvents)
         .where(
@@ -334,7 +336,7 @@ export async function upsertEvents(
         )
         .limit(1);
 
-      if (existing) {
+      if (existingInSlice) {
         await db
           .update(calendarEvents)
           .set({
@@ -353,27 +355,74 @@ export async function upsertEvents(
             etag: event.etag,
             updatedAt: new Date(),
           })
-          .where(eq(calendarEvents.id, existing.id));
-      } else {
-        await db.insert(calendarEvents).values({
-          calendarId: slice.calendarId,
-          userId,
-          externalId: event.externalId,
-          title: event.title,
-          description: event.description,
-          location: event.location,
-          startTime: event.startTime,
-          endTime: event.endTime,
-          isAllDay: event.isAllDay,
-          timezone: event.timezone,
-          recurrenceRule: event.recurrenceRule,
-          recurringEventId: event.recurringEventId,
-          status: event.status,
-          responseStatus: event.responseStatus,
-          htmlLink: event.htmlLink,
-          etag: event.etag,
-        });
+          .where(eq(calendarEvents.id, existingInSlice.id));
+        continue;
       }
+
+      // Fallback: the event might already exist in our DB but
+      // attributed to a DIFFERENT calendar than the one it just
+      // arrived on. This happens when a row was misattributed by
+      // the legacy flat-array sync (see the PerCalendarSyncResult
+      // doc comment above) — the upstream calendar didn't change,
+      // we just stored it in the wrong bucket. Re-home rather than
+      // insert a duplicate. Scoped to this user — provider event ids
+      // are user-globally unique for Google/Outlook, and for iCloud
+      // a UID could in theory collide across calendars on the same
+      // account, but in practice doesn't (each VEVENT object has a
+      // unique UID per RFC 5545).
+      const [misattributed] = await db
+        .select({ id: calendarEvents.id, calendarId: calendarEvents.calendarId })
+        .from(calendarEvents)
+        .where(
+          and(
+            eq(calendarEvents.userId, userId),
+            eq(calendarEvents.externalId, event.externalId)
+          )
+        )
+        .limit(1);
+
+      if (misattributed) {
+        await db
+          .update(calendarEvents)
+          .set({
+            calendarId: slice.calendarId,
+            title: event.title,
+            description: event.description,
+            location: event.location,
+            startTime: event.startTime,
+            endTime: event.endTime,
+            isAllDay: event.isAllDay,
+            timezone: event.timezone,
+            recurrenceRule: event.recurrenceRule,
+            recurringEventId: event.recurringEventId,
+            status: event.status,
+            responseStatus: event.responseStatus,
+            htmlLink: event.htmlLink,
+            etag: event.etag,
+            updatedAt: new Date(),
+          })
+          .where(eq(calendarEvents.id, misattributed.id));
+        continue;
+      }
+
+      await db.insert(calendarEvents).values({
+        calendarId: slice.calendarId,
+        userId,
+        externalId: event.externalId,
+        title: event.title,
+        description: event.description,
+        location: event.location,
+        startTime: event.startTime,
+        endTime: event.endTime,
+        isAllDay: event.isAllDay,
+        timezone: event.timezone,
+        recurrenceRule: event.recurrenceRule,
+        recurringEventId: event.recurringEventId,
+        status: event.status,
+        responseStatus: event.responseStatus,
+        htmlLink: event.htmlLink,
+        etag: event.etag,
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

Every external calendar event in the detail sheet was labelled with the same calendar (e.g. "Family") regardless of which calendar it actually lived on. Verified against production — all 135 events on the test account were attributed to one Family calendar, even though the htmlLinks resolved to \`kai@blink.new\`, \`en.china#holiday\`, etc.

This was legacy data corruption from before the per-calendar slicing landed (see the \`PerCalendarSyncResult\` comment block in calendar-sync.ts). The slicing fix prevented NEW corruption, but \`upsertEvents\` did a \`(calendarId, externalId)\` lookup — so legacy misattributed rows were invisible to the correct slice. SyncToken-based incrementals never re-fetched those events, so the bad attribution persisted indefinitely.

## Fix

When the slice-scoped \`(calendarId, externalId)\` lookup misses, fall back to a \`(userId, externalId)\` lookup. If a row exists in a different calendar, treat it as misattributed and **re-home** (\`UPDATE calendarId\`) to the slice that just returned it. Provider event ids are user-globally unique for Google/Outlook, and effectively unique for iCloud (RFC 5545 UIDs are per-VEVENT-object), so this is safe.

## Recovery for affected users

- New events sync into the correct calendar from now on (no behavior change there).
- Existing misattributed events get auto-re-homed the next time the provider returns them — most events are touched within a few weeks of a window-shift / recurrence-expansion / etag-bump, so the corruption self-heals over normal sync activity.
- For instant recovery, "Reset & re-sync" from Settings clears the syncToken and forces a full window fetch. Every event in the window gets re-homed in one pass.

## Investigation trail

\`\`\`
SELECT name, COUNT(e.id) AS event_count
FROM calendars c
LEFT JOIN calendar_events e ON e.calendar_id = c.id
WHERE c.account_id = <test-account>
GROUP BY name;

→ Family: 135, all others: 0
\`\`\`

\`\`\`
SELECT title, html_link, calendar_id FROM calendar_events LIMIT 5;
→ "Code w/ Claude SF" → eid decodes to "kai@blink.new" calendar
→ "Dragon Boat Festival" → eid decodes to "en.china#holiday@v" calendar
→ all stored with calendar_id = <Family row>
\`\`\`

## Test plan

- [ ] Existing affected user: trigger sync → after one or more cycles, events appear under their true calendars, no duplicates
- [ ] Force re-sync (\`?force=true\`) recovers in one pass
- [ ] Fresh user: every event lands on the correct calendar from the first sync
- [ ] iCloud accounts: shared UIDs across calendars (rare, possible per RFC 5545) — confirm no false re-home if user genuinely has the same UID in two calendars

🤖 Generated with [Claude Code](https://claude.com/claude-code)