### PR TITLE
feat(calendar): Google Calendar push notifications (events.watch)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -28,6 +28,7 @@ import { calendarsRouter } from "./routes/calendars.js";
 import { calendarEventsRouter } from "./routes/calendar-events.js";
 import { releasesRouter } from "./routes/releases.js";
 import { taskSeriesRouter } from "./routes/task-series.js";
+import { webhooksRouter } from "./routes/webhooks.js";
 import { registerAllWorkers } from "./workers/index.js";
 import {
   stopPgBoss,
@@ -162,6 +163,9 @@ app.route("/calendars", calendarsRouter);
 app.route("/calendar-events", calendarEventsRouter);
 app.route("/releases", releasesRouter);
 app.route("/task-series", taskSeriesRouter);
+// Public — no auth (provider webhooks). Identity verified by per-
+// channel state stored when we registered the watch.
+app.route("/webhooks", webhooksRouter);
 
 // Error handling
 app.onError(errorHandler);

--- a/apps/api/src/routes/calendar-accounts.ts
+++ b/apps/api/src/routes/calendar-accounts.ts
@@ -26,6 +26,7 @@ import {
   upsertEvents,
   updateSyncStatus,
   publishSyncEvent,
+  ensureGoogleWatches,
 } from '../services/calendar-sync.js';
 import { ProviderAuthError } from '../services/calendar-providers/index.js';
 import { publishEvent } from '../lib/websocket/index.js';
@@ -94,6 +95,42 @@ calendarAccountsRouter.delete(
 
     if (!account) {
       throw new NotFoundError('Calendar account', id);
+    }
+
+    // Best-effort: tear down any Google push channels we own for
+    // this account's calendars before the cascade-delete drops the
+    // rows. Stop calls are async-fire-and-forget — even if Google
+    // refuses, channels expire on their own within 7 days.
+    if (account.provider === 'google' && account.accessTokenEncrypted) {
+      try {
+        const provider = getProvider('google');
+        if (provider) {
+          const accessToken = await refreshTokensIfNeeded(account, provider);
+          const watched = await db
+            .select({
+              channelId: calendars.watchChannelId,
+              resourceId: calendars.watchResourceId,
+            })
+            .from(calendars)
+            .where(eq(calendars.accountId, id));
+          const { stopWatch } = await import(
+            '../services/google-calendar-watch.js'
+          );
+          for (const w of watched) {
+            if (!w.channelId || !w.resourceId) continue;
+            await stopWatch({
+              accessToken,
+              channelId: w.channelId,
+              resourceId: w.resourceId,
+            });
+          }
+        }
+      } catch (err) {
+        console.warn(
+          `[Google Watch] stop-on-disconnect failed for account ${id}:`,
+          err instanceof Error ? err.message : err
+        );
+      }
     }
 
     await db
@@ -201,6 +238,10 @@ calendarAccountsRouter.post(
 
       const syncOptions = { timeMin, timeMax };
 
+      // Hold onto the OAuth access token so we can register Google
+      // push-notification watches after the sync. iCloud doesn't
+      // need this — CalDAV has no equivalent.
+      let oauthAccessToken: string | null = null;
       const syncResult =
         account.provider === 'icloud'
           ? await syncICloudAccount(account, accountCalendars, syncOptions)
@@ -213,6 +254,7 @@ calendarAccountsRouter.post(
                 account,
                 provider
               );
+              oauthAccessToken = accessToken;
               return syncOAuthAccount(
                 accessToken,
                 provider,
@@ -224,6 +266,16 @@ calendarAccountsRouter.post(
       await deleteRemovedEvents(userId, syncResult.perCalendar);
       await upsertEvents(userId, syncResult.perCalendar);
       await updateSyncStatus(id, 'idle', syncResult.nextSyncToken);
+
+      // Register Google `events.watch` channels for any calendars
+      // that don't yet have one — gives us seconds-latency push
+      // notifications instead of waiting for the 5-min poll. Outlook
+      // gets the same treatment in a follow-up via Microsoft Graph
+      // subscriptions; iCloud has no push-notification protocol.
+      if (account.provider === 'google' && oauthAccessToken) {
+        await ensureGoogleWatches(id, oauthAccessToken);
+      }
+
       publishSyncEvent(
         userId,
         id,

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,0 +1,130 @@
+/**
+ * Public webhook endpoints for provider push notifications.
+ *
+ * No `auth` middleware — providers can't authenticate against our
+ * user system. Identity is established via the per-channel state
+ * stored when we registered the watch:
+ *   - Google sends `X-Goog-Channel-ID`; we look up the calendar by
+ *     `watch_channel_id`, which acts as a 128-bit unguessable token.
+ *   - We also confirm `X-Goog-Resource-ID` matches the persisted
+ *     `watch_resource_id` so a stolen channel ID alone isn't enough.
+ *
+ * Handlers must respond fast — Google retries with exponential
+ * backoff on non-2xx OR slow responses, and we don't want to be the
+ * source of duplicate sync jobs. We enqueue via PG Boss with a
+ * singleton key per account so concurrent webhooks for the same
+ * account collapse into one sync job.
+ */
+
+import { Hono } from 'hono';
+import {
+  getDb,
+  eq,
+  calendars,
+  calendarAccounts,
+} from '@open-sunsama/database';
+import { getPgBoss, JOBS } from '../lib/pgboss.js';
+import type { SyncAccountPayload } from '../workers/calendar-sync/sync-account.js';
+
+const webhooksRouter = new Hono();
+
+/**
+ * Google Calendar push notifications.
+ *
+ * Headers Google sends (per
+ * https://developers.google.com/calendar/api/guides/push):
+ *   X-Goog-Channel-ID         — our channel UUID
+ *   X-Goog-Channel-Token      — optional verification token
+ *   X-Goog-Resource-ID        — Google's resource handle
+ *   X-Goog-Resource-State     — "sync" (initial) | "exists" (changed)
+ *                              | "not_exists" (deleted)
+ *   X-Goog-Resource-URI       — the watched resource URL
+ *   X-Goog-Message-Number     — strictly increasing sequence
+ *
+ * Body is empty for `sync` and `exists`; we ignore it.
+ */
+webhooksRouter.post('/google/calendar', async (c) => {
+  const channelId = c.req.header('x-goog-channel-id');
+  const resourceId = c.req.header('x-goog-resource-id');
+  const resourceState = c.req.header('x-goog-resource-state');
+
+  if (!channelId || !resourceId || !resourceState) {
+    return c.json({ ok: false, reason: 'missing_headers' }, 400);
+  }
+
+  // Google's first POST after registering a channel is `sync` and
+  // doesn't represent a change — just acknowledge and bail. The
+  // channel is now active.
+  if (resourceState === 'sync') {
+    return c.json({ ok: true, ignored: 'sync_handshake' }, 200);
+  }
+
+  // Look up the calendar row by the channel id we generated. If no
+  // match (channel was stopped on our side, or this is a stale
+  // notification for a deleted account), 200 + ignore. Returning
+  // 4xx would just trigger Google retries and pollute logs without
+  // achieving anything.
+  const db = getDb();
+  const [cal] = await db
+    .select({
+      id: calendars.id,
+      accountId: calendars.accountId,
+      userId: calendars.userId,
+      watchResourceId: calendars.watchResourceId,
+    })
+    .from(calendars)
+    .where(eq(calendars.watchChannelId, channelId))
+    .limit(1);
+
+  if (!cal) {
+    return c.json({ ok: true, ignored: 'unknown_channel' }, 200);
+  }
+
+  // Reject mismatched resourceId — defends against a leaked/guessed
+  // channel id being replayed against a different calendar.
+  if (cal.watchResourceId !== resourceId) {
+    return c.json({ ok: false, reason: 'resource_mismatch' }, 403);
+  }
+
+  // Find the account so we can enqueue an account-level sync. Going
+  // calendar-by-calendar on every webhook would multiply sync-job
+  // overhead on accounts with many watched calendars.
+  const [account] = await db
+    .select({
+      id: calendarAccounts.id,
+      userId: calendarAccounts.userId,
+      provider: calendarAccounts.provider,
+    })
+    .from(calendarAccounts)
+    .where(eq(calendarAccounts.id, cal.accountId))
+    .limit(1);
+
+  if (!account) {
+    return c.json({ ok: true, ignored: 'no_account' }, 200);
+  }
+
+  // Enqueue with `singletonKey` per account: if a sync job is
+  // already queued (e.g. burst of webhooks for many calendars), the
+  // additional sends collapse into the existing job. The synced
+  // window picks up all changes via syncToken-based delta in one
+  // pass, so we don't lose anything by deduping.
+  const boss = await getPgBoss();
+  await boss.send(
+    JOBS.SYNC_CALENDAR_ACCOUNT,
+    {
+      accountId: account.id,
+      userId: account.userId,
+      provider: account.provider,
+    } satisfies SyncAccountPayload,
+    {
+      singletonKey: `webhook-sync-${account.id}`,
+      // Short window — collapse webhooks within a few seconds, but
+      // don't suppress legitimately-spaced changes.
+      singletonSeconds: 10,
+    }
+  );
+
+  return c.json({ ok: true }, 200);
+});
+
+export { webhooksRouter };

--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -464,3 +464,72 @@ export function publishSyncEvent(
     deletedCount,
   });
 }
+
+/**
+ * Opportunistically register Google `events.watch` push channels
+ * for an account's enabled calendars that don't already have an
+ * active watch. Idempotent — calendars with a non-expired watch are
+ * skipped. Failures are swallowed (push notifications are an upgrade
+ * over the 5-min poll, not a hard requirement).
+ *
+ * Called after every successful manual or worker sync, so a freshly-
+ * connected account picks up its watches on the first sync, and
+ * accounts that were synced before this code shipped pick them up on
+ * their next sync without any manual action.
+ */
+export async function ensureGoogleWatches(
+  accountId: string,
+  accessToken: string
+): Promise<void> {
+  // Lazy import keeps the watch service out of the hot sync path
+  // when nothing needs registering — the dynamic import is cached
+  // after the first call.
+  const { registerWatch } = await import('./google-calendar-watch.js');
+  const db = getDb();
+  // Refresh window: re-register anything expiring within the next 24h
+  // so we don't drop coverage between sync runs. Renewal happens
+  // here instead of in a separate cron until the dedicated renewal
+  // worker lands in a follow-up PR.
+  const refreshThreshold = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const targets = await db
+    .select({
+      id: calendars.id,
+      externalId: calendars.externalId,
+      watchChannelId: calendars.watchChannelId,
+      watchExpiresAt: calendars.watchExpiresAt,
+    })
+    .from(calendars)
+    .where(
+      and(eq(calendars.accountId, accountId), eq(calendars.isEnabled, true))
+    );
+  for (const cal of targets) {
+    const hasActive =
+      cal.watchChannelId &&
+      cal.watchExpiresAt &&
+      cal.watchExpiresAt > refreshThreshold;
+    if (hasActive) continue;
+    try {
+      const watch = await registerWatch({
+        accessToken,
+        externalCalendarId: cal.externalId,
+      });
+      if (!watch) continue; // calendar doesn't accept watches (read-only, etc.)
+      await db
+        .update(calendars)
+        .set({
+          watchChannelId: watch.channelId,
+          watchResourceId: watch.resourceId,
+          watchExpiresAt: watch.expiresAt,
+          updatedAt: new Date(),
+        })
+        .where(eq(calendars.id, cal.id));
+    } catch (err) {
+      // Push channels are best-effort. Log and move on so a single
+      // bad calendar doesn't block the rest of the account's sync.
+      console.warn(
+        `[Google Watch] register failed for calendar ${cal.id}:`,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+}

--- a/apps/api/src/services/google-calendar-watch.ts
+++ b/apps/api/src/services/google-calendar-watch.ts
@@ -1,0 +1,157 @@
+/**
+ * Google Calendar push notifications (events.watch).
+ *
+ * Sets up webhook channels so we hear about event changes within
+ * seconds instead of polling every 5 minutes. Each watched calendar
+ * gets a 7-day channel; Google POSTs to our webhook on every change
+ * with `X-Goog-Resource-State: exists`. The webhook handler enqueues
+ * an immediate sync job, which then uses our existing syncToken-based
+ * delta path to fetch the actual changes.
+ *
+ * Lifecycle:
+ *   1. After a calendar's first successful sync we call `registerWatch`
+ *      to create the channel.
+ *   2. Channel state (id, resourceId, expiresAt) is persisted on the
+ *      `calendars` row.
+ *   3. A daily renewal worker re-registers any channel expiring within
+ *      24h (PR follow-up — without it watches die after 7 days and
+ *      we silently fall back to the 5-min poll).
+ *   4. On account/calendar disconnect we call `stopWatch` to tear down
+ *      the channel (the actual stop is best-effort — Google forgets
+ *      about expired channels anyway).
+ *
+ * Reference: https://developers.google.com/calendar/api/guides/push
+ */
+
+import { randomUUID } from 'node:crypto';
+
+const GOOGLE_CALENDAR_API = 'https://www.googleapis.com/calendar/v3';
+
+/**
+ * Channel TTL on Google's side. They cap at 7 days; we ask for the
+ * max minus a little so the renewal worker has slack.
+ */
+const WATCH_TTL_SECONDS = 7 * 24 * 60 * 60 - 60 * 60; // 7d - 1h
+
+/**
+ * Resolve the public webhook URL Google should POST to. Falls back
+ * to the API's own host when WEBHOOK_BASE_URL isn't set, so a fresh
+ * deploy without the env var still works as long as
+ * `https://api.opensunsama.com` is reachable.
+ */
+function getWebhookUrl(): string {
+  const base =
+    process.env.WEBHOOK_BASE_URL ?? 'https://api.opensunsama.com';
+  return `${base.replace(/\/$/, '')}/webhooks/google/calendar`;
+}
+
+export interface RegisteredWatch {
+  channelId: string;
+  resourceId: string;
+  expiresAt: Date;
+}
+
+/**
+ * Register a Google `events.watch` channel for the given calendar.
+ *
+ * Returns null when Google rejects the request (common for read-only
+ * holiday calendars that don't accept push channels — `events.watch`
+ * is forbidden on subscribed calendars). Caller should treat null as
+ * "watch not available, keep using the poll" rather than an error.
+ *
+ * Throws on auth failures so the existing token-refresh / reconnect
+ * pipeline kicks in.
+ */
+export async function registerWatch(params: {
+  accessToken: string;
+  externalCalendarId: string;
+}): Promise<RegisteredWatch | null> {
+  // Channel ID is our token — it must be globally unique and we use
+  // it to look up the owning calendar when Google POSTs the webhook.
+  // Random UUID is plenty.
+  const channelId = randomUUID();
+
+  const response = await fetch(
+    `${GOOGLE_CALENDAR_API}/calendars/${encodeURIComponent(
+      params.externalCalendarId
+    )}/events/watch`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${params.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: channelId,
+        type: 'web_hook',
+        address: getWebhookUrl(),
+        params: {
+          ttl: String(WATCH_TTL_SECONDS),
+        },
+      }),
+    }
+  );
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(`google_watch_auth_failed_${response.status}`);
+  }
+
+  // Google rejects watches on shared/read-only calendars (holiday
+  // calendars, freeBusy-only, etc.) with a 403 + "channelUnsupported"
+  // — but we already auth-branched above. 400/404 likely means the
+  // calendar is gone or the body shape is wrong. Either way the
+  // safe degradation is "no watch, keep polling."
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = (await response.json()) as {
+    id: string;
+    resourceId: string;
+    expiration?: string;
+  };
+
+  // Google returns expiration as a Unix-millis string. When absent
+  // (some sandbox responses), assume the TTL we asked for.
+  const expiresAtMs = data.expiration
+    ? parseInt(data.expiration, 10)
+    : Date.now() + WATCH_TTL_SECONDS * 1000;
+
+  return {
+    channelId: data.id,
+    resourceId: data.resourceId,
+    expiresAt: new Date(expiresAtMs),
+  };
+}
+
+/**
+ * Tear down an existing watch channel. Best-effort — if Google has
+ * already expired it, the call returns 404 which we swallow.
+ */
+export async function stopWatch(params: {
+  accessToken: string;
+  channelId: string;
+  resourceId: string;
+}): Promise<void> {
+  const response = await fetch(`${GOOGLE_CALENDAR_API}/channels/stop`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      id: params.channelId,
+      resourceId: params.resourceId,
+    }),
+  });
+
+  // 404 / 410 — already gone. Anything else and we don't really
+  // care; the channel will expire on its own within 7 days.
+  if (!response.ok && response.status !== 404 && response.status !== 410) {
+    // Don't throw — disconnect flows shouldn't fail just because
+    // Google's stop endpoint is unhappy.
+    console.warn(
+      `[Google Watch] stopWatch failed (${response.status}) for channel ${params.channelId}`
+    );
+  }
+}

--- a/apps/api/src/workers/calendar-sync/sync-account.ts
+++ b/apps/api/src/workers/calendar-sync/sync-account.ts
@@ -15,6 +15,7 @@ import {
   upsertEvents,
   updateSyncStatus,
   publishSyncEvent,
+  ensureGoogleWatches,
   type AccountSyncResult,
 } from '../../services/calendar-sync.js';
 
@@ -119,6 +120,13 @@ export async function processSyncAccount(
         accountCalendars,
         syncOptions
       );
+
+      // Register Google `events.watch` push channels for any
+      // calendars that don't yet have one. Idempotent and best-
+      // effort — failures don't affect the rest of the sync.
+      if (providerName === 'google') {
+        await ensureGoogleWatches(accountId, accessToken);
+      }
     }
 
     // Delete removed events (per-calendar scoped)

--- a/packages/database/drizzle/0012_nebulous_maximus.sql
+++ b/packages/database/drizzle/0012_nebulous_maximus.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "calendars" ADD COLUMN "watch_channel_id" varchar(255);--> statement-breakpoint
+ALTER TABLE "calendars" ADD COLUMN "watch_resource_id" varchar(255);--> statement-breakpoint
+ALTER TABLE "calendars" ADD COLUMN "watch_expires_at" timestamp;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "calendars_watch_channel_idx" ON "calendars" USING btree ("watch_channel_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "calendars_watch_expires_idx" ON "calendars" USING btree ("watch_expires_at");

--- a/packages/database/drizzle/meta/0012_snapshot.json
+++ b/packages/database/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2154 @@
+{
+  "id": "00b503ed-e4bd-457b-a240-ff5e44231a18",
+  "prevId": "7bec9143-cfe2-4e3c-b2b7-51afd7c80228",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_prefix_idx": {
+          "name": "api_keys_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_task_id_idx": {
+          "name": "attachments_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_user_id_idx": {
+          "name": "attachments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachments_task_id_tasks_id_fk": {
+          "name": "attachments_task_id_tasks_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachments_user_id_users_id_fk": {
+          "name": "attachments_user_id_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_accounts": {
+      "name": "calendar_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caldav_password_encrypted": {
+          "name": "caldav_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caldav_url": {
+          "name": "caldav_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'idle'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_subscription_id": {
+          "name": "webhook_subscription_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_expires_at": {
+          "name": "webhook_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_accounts_user_id_idx": {
+          "name": "calendar_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_webhook_sub_idx": {
+          "name": "calendar_accounts_webhook_sub_idx",
+          "columns": [
+            {
+              "expression": "webhook_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_accounts_user_id_users_id_fk": {
+          "name": "calendar_accounts_user_id_users_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_all_day": {
+          "name": "is_all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_event_id": {
+          "name": "recurring_event_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'confirmed'"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_link": {
+          "name": "html_link",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_events_user_time_idx": {
+          "name": "calendar_events_user_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_calendar_external_idx": {
+          "name": "calendar_events_calendar_external_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_calendar_idx": {
+          "name": "calendar_events_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_calendar_id_calendars_id_fk": {
+          "name": "calendar_events_calendar_id_calendars_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_user_id_users_id_fk": {
+          "name": "calendar_events_user_id_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendars": {
+      "name": "calendars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default_for_events": {
+          "name": "is_default_for_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_for_tasks": {
+          "name": "is_default_for_tasks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_read_only": {
+          "name": "is_read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_channel_id": {
+          "name": "watch_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_resource_id": {
+          "name": "watch_resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_expires_at": {
+          "name": "watch_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendars_user_idx": {
+          "name": "calendars_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_account_idx": {
+          "name": "calendars_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_account_external_idx": {
+          "name": "calendars_account_external_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_watch_channel_idx": {
+          "name": "calendars_watch_channel_idx",
+          "columns": [
+            {
+              "expression": "watch_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_watch_expires_idx": {
+          "name": "calendars_watch_expires_idx",
+          "columns": [
+            {
+              "expression": "watch_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendars_account_id_calendar_accounts_id_fk": {
+          "name": "calendars_account_id_calendar_accounts_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "calendar_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendars_user_id_users_id_fk": {
+          "name": "calendars_user_id_users_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_reminders_enabled": {
+          "name": "task_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_timing": {
+          "name": "reminder_timing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "email_notifications_enabled": {
+          "name": "email_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "push_notifications_enabled": {
+          "name": "push_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rollover_destination": {
+          "name": "rollover_destination",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "rollover_position": {
+          "name": "rollover_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'top'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_user_id_unique": {
+          "name": "notification_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_states_state_idx": {
+          "name": "oauth_states_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_states_state_unique": {
+          "name": "oauth_states_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh_key": {
+          "name": "p256dh_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_time": {
+          "name": "expiration_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.releases": {
+      "name": "releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updater_url": {
+          "name": "updater_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_notes": {
+          "name": "release_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollover_logs": {
+      "name": "rollover_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_date": {
+          "name": "rollover_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_processed": {
+          "name": "users_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tasks_rolled_over": {
+          "name": "tasks_rolled_over",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rollover_logs_tz_date_idx": {
+          "name": "rollover_logs_tz_date_idx",
+          "columns": [
+            {
+              "expression": "timezone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rollover_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtasks": {
+      "name": "subtasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtasks_task_id_idx": {
+          "name": "subtasks_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtasks_task_id_tasks_id_fk": {
+          "name": "subtasks_task_id_tasks_id_fk",
+          "tableFrom": "subtasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_series": {
+      "name": "task_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_mins": {
+          "name": "estimated_mins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'P2'"
+        },
+        "recurrence_type": {
+          "name": "recurrence_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "week_of_month": {
+          "name": "week_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week_monthly": {
+          "name": "day_of_week_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generated_date": {
+          "name": "last_generated_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_series_user_active_idx": {
+          "name": "task_series_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"task_series\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_series_generation_idx": {
+          "name": "task_series_generation_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_generated_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_series_user_id_users_id_fk": {
+          "name": "task_series_user_id_users_id_fk",
+          "tableFrom": "task_series",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_mins": {
+          "name": "estimated_mins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_mins": {
+          "name": "actual_mins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'P2'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subtasks_hidden": {
+          "name": "subtasks_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_instance_number": {
+          "name": "series_instance_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timer_started_at": {
+          "name": "timer_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timer_accumulated_seconds": {
+          "name": "timer_accumulated_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_user_scheduled_incomplete_idx": {
+          "name": "tasks_user_scheduled_incomplete_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"completed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_series_idx": {
+          "name": "tasks_series_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_series_date_unique_idx": {
+          "name": "tasks_series_date_unique_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tasks\".\"series_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_active_timer_idx": {
+          "name": "tasks_active_timer_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"timer_started_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_series_id_task_series_id_fk": {
+          "name": "tasks_series_id_task_series_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "task_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_blocks": {
+      "name": "time_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_mins": {
+          "name": "duration_mins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#3B82F6'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "time_blocks_user_date_idx": {
+          "name": "time_blocks_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_blocks_task_id_idx": {
+          "name": "time_blocks_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_blocks_user_id_users_id_fk": {
+          "name": "time_blocks_user_id_users_id_fk",
+          "tableFrom": "time_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_blocks_task_id_tasks_id_fk": {
+          "name": "time_blocks_task_id_tasks_id_fk",
+          "tableFrom": "time_blocks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "password_reset_token": {
+          "name": "password_reset_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_reset_expires": {
+          "name": "password_reset_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777723799233,
       "tag": "0011_bitter_squadron_supreme",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1777840058951,
+      "tag": "0012_nebulous_maximus",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/calendars.ts
+++ b/packages/database/src/schema/calendars.ts
@@ -25,12 +25,27 @@ export const calendars = pgTable('calendars', {
   isReadOnly: boolean('is_read_only').notNull().default(false), // Provider-level permission
 
   syncToken: varchar('sync_token', { length: 500 }), // Calendar-level sync token
+
+  // Google `events.watch` push-notification channel state. NULL when
+  // we don't have an active watch for the calendar (provider doesn't
+  // support watch, watch was stopped, or we haven't registered one
+  // yet). Channels expire on the provider side after ~7 days; the
+  // renewal worker queries `watch_expires_at` to know when to renew.
+  watchChannelId: varchar('watch_channel_id', { length: 255 }),
+  watchResourceId: varchar('watch_resource_id', { length: 255 }),
+  watchExpiresAt: timestamp('watch_expires_at'),
+
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 }, (table) => [
   index('calendars_user_idx').on(table.userId),
   index('calendars_account_idx').on(table.accountId),
   index('calendars_account_external_idx').on(table.accountId, table.externalId),
+  // Webhook lookup: incoming push notifications carry the channel_id
+  // and we need to find the owning calendar in O(1).
+  index('calendars_watch_channel_idx').on(table.watchChannelId),
+  // Renewal worker scans by expiry.
+  index('calendars_watch_expires_idx').on(table.watchExpiresAt),
 ]);
 
 export const calendarsRelations = relations(calendars, ({ one, many }) => ({


### PR DESCRIPTION
## Summary

Replaces 5-minute polling for Google calendars with **seconds-latency push notifications** via Google's \`events.watch\` channels. When the user edits an event in Google Calendar (web/mobile/native), Google POSTs our webhook within a few seconds → we enqueue an immediate sync → existing syncToken-delta + WebSocket-push pipeline lights up the UI without a manual refresh.

The existing 5-min polling stays in place as a safety net for the iCloud/Outlook providers and for any window where a watch isn't active.

## How it works

1. **Register**: after every successful Google sync, \`ensureGoogleWatches\` registers a channel for any of the account's enabled calendars that don't have one.
2. **Persist**: channel id (a fresh UUID acting as a 128-bit unguessable token), Google's resourceId, and expiration go onto the \`calendars\` row.
3. **Receive**: \`POST /webhooks/google/calendar\` looks up the row by channel id, verifies resourceId matches (defends against replayed/leaked channel ids), enqueues \`SYNC_CALENDAR_ACCOUNT\` with \`singletonKey\` per account so webhook bursts collapse into a single sync.
4. **Stop**: on account disconnect, \`stopWatch\` tears down each channel (best-effort — Google forgets after 7 days anyway).

## Out of scope (follow-ups)

- **Dedicated daily renewal worker.** Until it ships, watches survive via the opportunistic re-registration in \`ensureGoogleWatches\` (re-registers anything expiring within 24h on the next sync). Worst case: a Google account that goes silent for >7 days falls back to the 5-min poll.
- **Outlook subscriptions.** Same shape via Microsoft Graph \`/subscriptions\`. Separate PR.
- **iCloud.** CalDAV has no push-notification equivalent. Stays on polling.

## ⚠️ Deploy steps

This PR adds 3 new columns to the \`calendars\` table. Order matters:

1. **Apply the migration BEFORE deploying the new code:**
   \`\`\`bash
   bun run --filter=@open-sunsama/database db:migrate
   \`\`\`
   Otherwise every Google sync errors on \"column watch_channel_id does not exist\".
2. \`WEBHOOK_BASE_URL=https://api.opensunsama.com\` (defaults to that if unset).
3. Confirm \`https://api.opensunsama.com/webhooks/google/calendar\` is publicly reachable (it should be — same host as the rest of the API).
4. After deploy: trigger a Google sync and watch the \`calendars\` table populate \`watch_channel_id\`.

## Test plan

- [ ] Migration applies cleanly to prod
- [ ] After deploy + first Google sync, calendars rows have \`watch_channel_id\` set
- [ ] Edit an event in Google Calendar web → web app updates within ~5s without refresh
- [ ] Delete an event in Google Calendar web → web app removes it within ~5s
- [ ] Account disconnect tears down channels (no log spam)
- [ ] Read-only/holiday calendars don't error out (Google rejects \`watch\` for those — we degrade silently)
- [ ] Webhook handler returns 200 < 200ms (synchronous DB lookup + enqueue, no sync work in handler)
- [ ] iCloud + Outlook unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)