### PR TITLE
fix(calendar): typed ProviderAuthError on listCalendars/listEvents 401/403

### DIFF
--- a/apps/api/src/services/calendar-providers/google.ts
+++ b/apps/api/src/services/calendar-providers/google.ts
@@ -130,6 +130,14 @@ export class GoogleCalendarProvider implements CalendarProvider {
     });
 
     if (!response.ok) {
+      // 401 = access token rejected (expired/revoked between
+      // refresh and this call); 403 = scope rescinded. Both mean
+      // "user must reconnect" — surface as the typed error so the
+      // route layer emits the clean 401 + reconnect toast instead
+      // of a 500 with raw Google JSON.
+      if (response.status === 401 || response.status === 403) {
+        throw new ProviderAuthError('google');
+      }
       const error = await response.text();
       throw new Error(`Failed to list calendars: ${error}`);
     }
@@ -187,12 +195,18 @@ export class GoogleCalendarProvider implements CalendarProvider {
       );
 
       if (!response.ok) {
-        const error = await response.text();
-
         if (response.status === 410) {
           throw new Error('SYNC_TOKEN_INVALID');
         }
-
+        // 401/403: access token rejected or scope rescinded.
+        // Surface as the typed `ProviderAuthError` so the route
+        // layer + worker write a clean "Reconnect your calendar"
+        // message instead of dumping the raw Google JSON into the
+        // sync-status row (which the UI then can't act on).
+        if (response.status === 401 || response.status === 403) {
+          throw new ProviderAuthError('google');
+        }
+        const error = await response.text();
         throw new Error(`Failed to list events: ${error}`);
       }
 

--- a/apps/api/src/services/calendar-providers/outlook.ts
+++ b/apps/api/src/services/calendar-providers/outlook.ts
@@ -131,6 +131,12 @@ export class OutlookCalendarProvider implements CalendarProvider {
     });
 
     if (!response.ok) {
+      // Same shape as Google — 401/403 means the user must reconnect.
+      // Surface as the typed error so the route layer's mapping fires
+      // and the UI shows a clean "Reconnect" toast.
+      if (response.status === 401 || response.status === 403) {
+        throw new ProviderAuthError('outlook');
+      }
       const error = await response.text();
       throw new Error(`Failed to list calendars: ${error}`);
     }
@@ -199,12 +205,17 @@ export class OutlookCalendarProvider implements CalendarProvider {
       });
 
       if (!response.ok) {
-        const error = await response.text();
-
         if (response.status === 410 || response.status === 400) {
           throw new Error('SYNC_TOKEN_INVALID');
         }
-
+        // 401/403: token rejected or scope rescinded — typed error
+        // so the route layer + worker write a clean "Reconnect"
+        // message instead of dumping raw Microsoft Graph JSON into
+        // the sync-status row.
+        if (response.status === 401 || response.status === 403) {
+          throw new ProviderAuthError('outlook');
+        }
+        const error = await response.text();
         throw new Error(`Failed to list events: ${error}`);
       }
 


### PR DESCRIPTION
## Summary

Closes the typed-error gap PR #56 left open. Both Google and Outlook providers were still throwing generic \`Error("Failed to list...: <raw JSON>")\` on 401/403 from \`listCalendars\` and \`listEvents\` — so when an access token got rejected mid-sync, the user saw a generic sync error instead of the clean "Reconnect your calendar" toast that the \`ProviderAuthError\` path emits.

## How I found it

Verifying recovery for the misattributed-events fix (PR #57): the test account's sync was stuck in \`error\` state with this in \`sync_error\`:

\`\`\`
Failed to list events: {"error":{"code":401,"message":"Request had invalid authentication credentials...","status":"UNAUTHENTICATED"}}
\`\`\`

\`refreshTokens\` succeeded (token refresh path), but the freshly-issued access token came back rejected on the very next \`listEvents\` call — likely clock-skew or propagation between Google's auth server and the calendar API. The 401 fell through to the generic Error path, the typed-error mapping in route + worker missed, and the user got no actionable signal.

## Fix

- \`Google.listCalendars\`: 401/403 → \`ProviderAuthError('google')\`
- \`Google.listEvents\`: 401/403 → \`ProviderAuthError('google')\`
- \`Outlook.listCalendars\`: 401/403 → \`ProviderAuthError('outlook')\`
- \`Outlook.listEvents\`: 401/403 → \`ProviderAuthError('outlook')\`

Generic \`Error\` path preserved for 5xx so we don't false-positive a "reconnect" prompt on a Google/Microsoft outage. \`SYNC_TOKEN_INVALID\` branch for 410/400 on Outlook \`listEvents\` preserved (different recovery: clear token + retry, not reconnect).

## Test plan

- [ ] Account with revoked OAuth token → manual sync → 401 with PROVIDER_AUTH_FAILED + reconnect toast
- [ ] Worker sync against revoked token → cleaner \`sync_error\` message in DB ("google authentication failed — please reconnect")
- [ ] Healthy account → no spurious 401s from healthy listCalendars/listEvents
- [ ] iCloud unaffected (separate \`mapCalDavError\` path)
- [ ] Outlook 410 SYNC_TOKEN_INVALID branch still triggers token-clear + retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)