### PR TITLE
feat(ideas): add-idea modal + rich text notes

### DIFF
--- a/apps/web/src/components/ideas/add-idea-modal.tsx
+++ b/apps/web/src/components/ideas/add-idea-modal.tsx
@@ -1,0 +1,145 @@
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Button,
+  Input,
+  Label,
+} from "@/components/ui";
+import { RichTextEditor } from "@/components/ui/rich-text-editor.lazy";
+import { useCreateIdea } from "@/hooks/useIdeas";
+
+interface AddIdeaModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  boardId: string;
+  columnId: string;
+  columnName: string;
+}
+
+/**
+ * Add-idea modal — the same Dialog chrome + rich text editor as AddTaskModal
+ * (add-task-modal.tsx), trimmed to the Ideas model (title + notes, scoped to
+ * a column).
+ */
+export function AddIdeaModal({
+  open,
+  onOpenChange,
+  boardId,
+  columnId,
+  columnName,
+}: AddIdeaModalProps) {
+  const [title, setTitle] = React.useState("");
+  const [description, setDescription] = React.useState("");
+  const createIdea = useCreateIdea(boardId);
+
+  const titleInputRef = React.useRef<HTMLInputElement>(null);
+  const formRef = React.useRef<HTMLFormElement>(null);
+
+  // Focus title when opening.
+  React.useEffect(() => {
+    if (open) setTimeout(() => titleInputRef.current?.focus(), 100);
+  }, [open]);
+
+  // Reset on close.
+  React.useEffect(() => {
+    if (!open) {
+      setTitle("");
+      setDescription("");
+    }
+  }, [open]);
+
+  // ⌘/Ctrl+Enter to submit.
+  React.useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        formRef.current?.requestSubmit();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    await createIdea.mutateAsync({
+      boardId,
+      columnId,
+      title: title.trim(),
+      notes: description || undefined,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md gap-0 overflow-hidden p-0">
+        <form ref={formRef} onSubmit={handleSubmit}>
+          {/* Header — title input */}
+          <div className="border-b px-4 pb-3 pt-4">
+            <Input
+              ref={titleInputRef}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Idea title..."
+              required
+              className="h-auto border-none p-0 pr-6 text-base font-medium shadow-none focus-visible:ring-0"
+            />
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              Adding to <span className="font-medium">{columnName}</span>
+            </p>
+          </div>
+
+          {/* Body — notes */}
+          <div className="max-h-[50vh] space-y-2 overflow-y-auto px-4 py-4">
+            <Label className="text-sm font-medium text-muted-foreground">
+              Notes
+            </Label>
+            <RichTextEditor
+              value={description}
+              onChange={setDescription}
+              placeholder="Add details..."
+              minHeight="80px"
+            />
+          </div>
+
+          {/* Footer */}
+          <DialogFooter className="flex-row items-center justify-between gap-2 border-t bg-muted/20 px-4 py-3">
+            <span className="hidden items-center gap-1 text-xs text-muted-foreground/50 sm:inline-flex">
+              <kbd className="inline-flex h-5 select-none items-center rounded border bg-muted px-1 font-mono text-[10px] font-medium">
+                ⌘
+              </kbd>
+              <kbd className="inline-flex h-5 select-none items-center rounded border bg-muted px-1 font-mono text-[10px] font-medium">
+                ↵
+              </kbd>
+              <span className="ml-0.5">add idea</span>
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                size="sm"
+                className="h-8"
+                disabled={!title.trim() || createIdea.isPending}
+              >
+                {createIdea.isPending ? "Adding..." : "Add idea"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ideas/idea-card.tsx
+++ b/apps/web/src/components/ideas/idea-card.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
 } from "@/components/ui";
+import { HtmlContent } from "@/components/ui/html-content";
 import {
   useDeleteIdea,
   usePromoteIdea,
@@ -59,6 +60,9 @@ export function IdeaCard({ idea, boardId, columns, overlay }: IdeaCardProps) {
 
   const isCompleted = !!idea.completedAt;
   const inPlanner = !!idea.promotedTaskId;
+  // Notes are rich-text HTML; only show a preview when there's real text.
+  const hasNotes =
+    !!idea.notes && idea.notes.replace(/<[^>]*>/g, "").trim().length > 0;
 
   const style: React.CSSProperties = overlay
     ? {}
@@ -122,11 +126,12 @@ export function IdeaCard({ idea, boardId, columns, overlay }: IdeaCardProps) {
           </p>
         </div>
 
-        {/* Optional muted note line */}
-        {idea.notes && !isCompleted && (
-          <p className="pl-6 text-xs leading-snug text-muted-foreground line-clamp-2">
-            {idea.notes}
-          </p>
+        {/* Optional notes preview (rich text) */}
+        {hasNotes && !isCompleted && (
+          <HtmlContent
+            html={idea.notes!}
+            className="pl-6 text-xs leading-snug text-muted-foreground line-clamp-2 [&_p]:m-0"
+          />
         )}
 
         {/* "In backlog" marker once promoted */}

--- a/apps/web/src/components/ideas/idea-column.tsx
+++ b/apps/web/src/components/ideas/idea-column.tsx
@@ -8,20 +8,15 @@ import { Plus, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import type { Idea, IdeaColumn as IdeaColumnType } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import {
-  Button,
   Input,
-  Textarea,
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui";
-import {
-  useCreateIdea,
-  useDeleteIdeaColumn,
-  useUpdateIdeaColumn,
-} from "@/hooks/useIdeas";
+import { useDeleteIdeaColumn, useUpdateIdeaColumn } from "@/hooks/useIdeas";
 import { IdeaCard } from "./idea-card";
+import { AddIdeaModal } from "./add-idea-modal";
 
 interface IdeaColumnProps {
   boardId: string;
@@ -38,12 +33,10 @@ export function IdeaColumnView({
   allColumns,
   canDelete,
 }: IdeaColumnProps) {
-  const [composing, setComposing] = React.useState(false);
-  const [draft, setDraft] = React.useState("");
+  const [addOpen, setAddOpen] = React.useState(false);
   const [renaming, setRenaming] = React.useState(false);
   const [nameDraft, setNameDraft] = React.useState(column.name);
 
-  const createIdea = useCreateIdea(boardId);
   const updateColumn = useUpdateIdeaColumn(boardId);
   const deleteColumn = useDeleteIdeaColumn(boardId);
 
@@ -53,17 +46,6 @@ export function IdeaColumnView({
   });
 
   const ideaIds = React.useMemo(() => ideas.map((i) => i.id), [ideas]);
-
-  const submitDraft = () => {
-    const trimmed = draft.trim();
-    if (!trimmed) return;
-    createIdea.mutate({
-      boardId,
-      columnId: column.id,
-      title: trimmed,
-    });
-    setDraft(""); // keep composer open for rapid entry
-  };
 
   const submitRename = () => {
     const trimmed = nameDraft.trim();
@@ -156,7 +138,7 @@ export function IdeaColumnView({
           ))}
         </SortableContext>
 
-        {ideas.length === 0 && !composing && (
+        {ideas.length === 0 && (
           <div className="rounded-lg border border-dashed border-border/60 px-2.5 py-4 text-center text-xs leading-relaxed text-muted-foreground">
             Drag cards here,
             <br />
@@ -165,55 +147,23 @@ export function IdeaColumnView({
         )}
       </div>
 
-      {/* Inline add composer */}
-      {composing ? (
-        <div className="rounded-lg border border-ring bg-card p-2 shadow-sm ring-2 ring-ring/20">
-          <Textarea
-            autoFocus
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                submitDraft();
-              }
-              if (e.key === "Escape") {
-                setDraft("");
-                setComposing(false);
-              }
-            }}
-            placeholder="Idea title…"
-            rows={2}
-            className="min-h-[44px] resize-none border-none p-0 text-sm shadow-none focus-visible:ring-0"
-          />
-          <div className="mt-2 flex items-center gap-2">
-            <Button size="sm" className="h-7" onClick={submitDraft}>
-              Add
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="h-7"
-              onClick={() => {
-                setDraft("");
-                setComposing(false);
-              }}
-            >
-              Cancel
-            </Button>
-            <span className="ml-auto text-[11px] text-muted-foreground">
-              ⏎ add · ⇧⏎ newline
-            </span>
-          </div>
-        </div>
-      ) : (
-        <button
-          onClick={() => setComposing(true)}
-          className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
-        >
-          <Plus className="h-4 w-4" />
-          Add idea
-        </button>
+      {/* Add idea — opens the modal (same chrome as Add Task) */}
+      <button
+        onClick={() => setAddOpen(true)}
+        className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+      >
+        <Plus className="h-4 w-4" />
+        Add idea
+      </button>
+
+      {addOpen && (
+        <AddIdeaModal
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          boardId={boardId}
+          columnId={column.id}
+          columnName={column.name}
+        />
       )}
     </section>
   );

--- a/apps/web/src/components/ideas/idea-edit-dialog.tsx
+++ b/apps/web/src/components/ideas/idea-edit-dialog.tsx
@@ -8,8 +8,9 @@ import {
   DialogFooter,
   Button,
   Input,
-  Textarea,
+  Label,
 } from "@/components/ui";
+import { RichTextEditor } from "@/components/ui/rich-text-editor.lazy";
 import { useUpdateIdea } from "@/hooks/useIdeas";
 
 interface IdeaEditDialogProps {
@@ -62,13 +63,17 @@ export function IdeaEditDialog({
               placeholder="Idea title…"
               maxLength={500}
             />
-            <Textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              placeholder="Add a note (optional)…"
-              rows={3}
-              className="resize-none"
-            />
+            <div className="space-y-2">
+              <Label className="text-sm font-medium text-muted-foreground">
+                Notes
+              </Label>
+              <RichTextEditor
+                value={notes}
+                onChange={setNotes}
+                placeholder="Add details..."
+                minHeight="80px"
+              />
+            </div>
           </div>
           <DialogFooter className="mt-5">
             <Button


### PR DESCRIPTION
Follow-up to #62.

Replaces the inline add-idea composer with a **modal** matching the Add Task UX (same Dialog chrome, `⌘↵` to submit), and switches idea notes to the shared **Tiptap RichTextEditor**. Card note previews now render the rich HTML.

Frontend-only — no API/DB changes.

- `add-idea-modal.tsx` (new) — mirrors `AddTaskModal`
- `idea-column.tsx` — "Add idea" button opens the modal
- `idea-edit-dialog.tsx` — notes use RichTextEditor
- `idea-card.tsx` — note preview via HtmlContent

✅ typecheck · lint · web build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)