### PR TITLE
feat(ideas): right-click menu, send-to-board/backlog, subtasks, richer editor

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -29,6 +29,7 @@ import { calendarEventsRouter } from "./routes/calendar-events.js";
 import { releasesRouter } from "./routes/releases.js";
 import { taskSeriesRouter } from "./routes/task-series.js";
 import { ideasRouter } from "./routes/ideas.js";
+import { ideaSubtasksRouter } from "./routes/idea-subtasks.js";
 import { webhooksRouter } from "./routes/webhooks.js";
 import { registerAllWorkers } from "./workers/index.js";
 import {
@@ -166,6 +167,7 @@ app.route("/calendar-events", calendarEventsRouter);
 app.route("/releases", releasesRouter);
 app.route("/task-series", taskSeriesRouter);
 app.route("/ideas", ideasRouter);
+app.route("/ideas", ideaSubtasksRouter); // /ideas/:ideaId/subtasks
 // Public — no auth (provider webhooks). Identity verified by per-
 // channel state stored when we registered the watch.
 app.route("/webhooks", webhooksRouter);

--- a/apps/api/src/routes/idea-subtasks.ts
+++ b/apps/api/src/routes/idea-subtasks.ts
@@ -1,0 +1,196 @@
+/**
+ * Idea subtask routes — checklist items under an idea card.
+ * Mirrors the task subtasks router; mounted under /ideas.
+ * Paths: /ideas/:ideaId/subtasks(/...)
+ */
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import {
+  getDb,
+  eq,
+  and,
+  asc,
+  sql,
+  ideas,
+  ideaSubtasks,
+} from "@open-sunsama/database";
+import { NotFoundError } from "@open-sunsama/utils";
+import { auth, requireScopes, type AuthVariables } from "../middleware/auth.js";
+import {
+  createIdeaSubtaskSchema,
+  updateIdeaSubtaskSchema,
+  reorderIdeaSubtasksSchema,
+  ideaIdParamSchema,
+  ideaSubtaskIdParamSchema,
+} from "../validation/ideas.js";
+import { publishEvent } from "../lib/websocket/index.js";
+
+const ideaSubtasksRouter = new Hono<{ Variables: AuthVariables }>();
+ideaSubtasksRouter.use("*", auth);
+
+const READ = requireScopes("ideas:read");
+const WRITE = requireScopes("ideas:write");
+
+/** Verify the idea belongs to the user; returns it (for boardId/columnId). */
+async function getOwnedIdea(userId: string, ideaId: string) {
+  const db = getDb();
+  const [idea] = await db
+    .select()
+    .from(ideas)
+    .where(and(eq(ideas.id, ideaId), eq(ideas.userId, userId)))
+    .limit(1);
+  if (!idea) throw new NotFoundError("Idea", ideaId);
+  return idea;
+}
+
+/** Publish an idea:updated so clients refresh the card + its subtasks. */
+function notifyIdea(
+  userId: string,
+  idea: { id: string; boardId: string; columnId: string }
+) {
+  publishEvent(userId, "idea:updated", {
+    ideaId: idea.id,
+    boardId: idea.boardId,
+    columnId: idea.columnId,
+  });
+}
+
+/** GET /ideas/:ideaId/subtasks - list subtasks for an idea */
+ideaSubtasksRouter.get(
+  "/:ideaId/subtasks",
+  READ,
+  zValidator("param", ideaIdParamSchema),
+  async (c) => {
+    const userId = c.get("userId");
+    const { ideaId } = c.req.valid("param");
+    await getOwnedIdea(userId, ideaId);
+    const db = getDb();
+    const data = await db
+      .select()
+      .from(ideaSubtasks)
+      .where(eq(ideaSubtasks.ideaId, ideaId))
+      .orderBy(asc(ideaSubtasks.position), asc(ideaSubtasks.createdAt));
+    return c.json({ success: true, data });
+  }
+);
+
+/** POST /ideas/:ideaId/subtasks - create a subtask */
+ideaSubtasksRouter.post(
+  "/:ideaId/subtasks",
+  WRITE,
+  zValidator("param", ideaIdParamSchema),
+  zValidator("json", createIdeaSubtaskSchema),
+  async (c) => {
+    const userId = c.get("userId");
+    const { ideaId } = c.req.valid("param");
+    const data = c.req.valid("json");
+    const idea = await getOwnedIdea(userId, ideaId);
+    const db = getDb();
+
+    let position = data.position;
+    if (position === undefined) {
+      const [maxPos] = await db
+        .select({
+          max: sql<number>`COALESCE(MAX(${ideaSubtasks.position}), -1)`,
+        })
+        .from(ideaSubtasks)
+        .where(eq(ideaSubtasks.ideaId, ideaId));
+      position = (maxPos?.max ?? -1) + 1;
+    }
+
+    const [subtask] = await db
+      .insert(ideaSubtasks)
+      .values({ ideaId, title: data.title, position })
+      .returning();
+    if (!subtask) throw new Error("Failed to create subtask");
+
+    notifyIdea(userId, idea);
+    return c.json({ success: true, data: subtask }, 201);
+  }
+);
+
+/** PATCH /ideas/:ideaId/subtasks/:id - update a subtask */
+ideaSubtasksRouter.patch(
+  "/:ideaId/subtasks/:id",
+  WRITE,
+  zValidator("param", ideaSubtaskIdParamSchema),
+  zValidator("json", updateIdeaSubtaskSchema),
+  async (c) => {
+    const userId = c.get("userId");
+    const { ideaId, id } = c.req.valid("param");
+    const updates = c.req.valid("json");
+    const idea = await getOwnedIdea(userId, ideaId);
+    const db = getDb();
+
+    const updateData: Record<string, unknown> = { updatedAt: new Date() };
+    if (updates.title !== undefined) updateData.title = updates.title;
+    if (updates.completed !== undefined)
+      updateData.completed = updates.completed;
+    if (updates.position !== undefined) updateData.position = updates.position;
+
+    const [subtask] = await db
+      .update(ideaSubtasks)
+      .set(updateData)
+      .where(and(eq(ideaSubtasks.id, id), eq(ideaSubtasks.ideaId, ideaId)))
+      .returning();
+    if (!subtask) throw new NotFoundError("Subtask", id);
+
+    notifyIdea(userId, idea);
+    return c.json({ success: true, data: subtask });
+  }
+);
+
+/** DELETE /ideas/:ideaId/subtasks/:id - delete a subtask */
+ideaSubtasksRouter.delete(
+  "/:ideaId/subtasks/:id",
+  WRITE,
+  zValidator("param", ideaSubtaskIdParamSchema),
+  async (c) => {
+    const userId = c.get("userId");
+    const { ideaId, id } = c.req.valid("param");
+    const idea = await getOwnedIdea(userId, ideaId);
+    const db = getDb();
+
+    await db
+      .delete(ideaSubtasks)
+      .where(and(eq(ideaSubtasks.id, id), eq(ideaSubtasks.ideaId, ideaId)));
+
+    notifyIdea(userId, idea);
+    return c.json({ success: true, message: "Subtask deleted successfully" });
+  }
+);
+
+/** POST /ideas/:ideaId/subtasks/reorder - reorder subtasks */
+ideaSubtasksRouter.post(
+  "/:ideaId/subtasks/reorder",
+  WRITE,
+  zValidator("param", ideaIdParamSchema),
+  zValidator("json", reorderIdeaSubtasksSchema),
+  async (c) => {
+    const userId = c.get("userId");
+    const { ideaId } = c.req.valid("param");
+    const { subtaskIds } = c.req.valid("json");
+    const idea = await getOwnedIdea(userId, ideaId);
+    const db = getDb();
+
+    await Promise.all(
+      subtaskIds.map((id, index) =>
+        db
+          .update(ideaSubtasks)
+          .set({ position: index, updatedAt: new Date() })
+          .where(and(eq(ideaSubtasks.id, id), eq(ideaSubtasks.ideaId, ideaId)))
+      )
+    );
+
+    const data = await db
+      .select()
+      .from(ideaSubtasks)
+      .where(eq(ideaSubtasks.ideaId, ideaId))
+      .orderBy(asc(ideaSubtasks.position));
+
+    notifyIdea(userId, idea);
+    return c.json({ success: true, data });
+  }
+);
+
+export { ideaSubtasksRouter };

--- a/apps/api/src/routes/ideas.ts
+++ b/apps/api/src/routes/ideas.ts
@@ -13,10 +13,12 @@ import {
   asc,
   isNull,
   isNotNull,
+  inArray,
   sql,
   ideaBoards,
   ideaColumns,
   ideas,
+  ideaSubtasks,
   tasks,
 } from "@open-sunsama/database";
 import { NotFoundError, uuidSchema } from "@open-sunsama/utils";
@@ -370,11 +372,34 @@ ideasRouter.get(
     else if (filters.completed === "false")
       conditions.push(isNull(ideas.completedAt));
 
-    const data = await db
+    const rows = await db
       .select()
       .from(ideas)
       .where(and(...conditions))
       .orderBy(asc(ideas.position), asc(ideas.createdAt));
+
+    // Attach subtask totals for the card badge (single grouped query).
+    if (rows.length === 0) return c.json({ success: true, data: rows });
+    const counts = await db
+      .select({
+        ideaId: ideaSubtasks.ideaId,
+        total: sql<number>`count(*)::int`,
+        done: sql<number>`count(*) filter (where ${ideaSubtasks.completed})::int`,
+      })
+      .from(ideaSubtasks)
+      .where(
+        inArray(
+          ideaSubtasks.ideaId,
+          rows.map((r) => r.id)
+        )
+      )
+      .groupBy(ideaSubtasks.ideaId);
+    const byId = new Map(counts.map((c2) => [c2.ideaId, c2]));
+    const data = rows.map((r) => ({
+      ...r,
+      subtaskCount: byId.get(r.id)?.total ?? 0,
+      subtaskDoneCount: byId.get(r.id)?.done ?? 0,
+    }));
 
     return c.json({ success: true, data });
   }

--- a/apps/api/src/validation/ideas.ts
+++ b/apps/api/src/validation/ideas.ts
@@ -82,3 +82,28 @@ export const reorderIdeasSchema = z.object({
 export const promoteIdeaSchema = z.object({
   scheduledDate: dateSchema.optional().nullable(),
 });
+
+// ───────────────────────── idea subtasks ─────────────────────────
+export const createIdeaSubtaskSchema = z.object({
+  title: z.string().min(1, "Title is required").max(500),
+  position: z.number().int().nonnegative().optional(),
+});
+
+export const updateIdeaSubtaskSchema = z.object({
+  title: z.string().min(1).max(500).optional(),
+  completed: z.boolean().optional(),
+  position: z.number().int().nonnegative().optional(),
+});
+
+export const reorderIdeaSubtasksSchema = z.object({
+  subtaskIds: z.array(uuidSchema).min(1),
+});
+
+export const ideaIdParamSchema = z.object({
+  ideaId: uuidSchema,
+});
+
+export const ideaSubtaskIdParamSchema = z.object({
+  ideaId: uuidSchema,
+  id: uuidSchema,
+});

--- a/apps/web/src/components/ideas/add-idea-modal.tsx
+++ b/apps/web/src/components/ideas/add-idea-modal.tsx
@@ -8,7 +8,9 @@ import {
   Label,
 } from "@/components/ui";
 import { RichTextEditor } from "@/components/ui/rich-text-editor.lazy";
+import { SubtaskList, type Subtask } from "@/components/kanban/subtask-list";
 import { useCreateIdea } from "@/hooks/useIdeas";
+import { useCreateIdeaSubtask } from "@/hooks/useIdeaSubtasks";
 
 interface AddIdeaModalProps {
   open: boolean;
@@ -32,7 +34,9 @@ export function AddIdeaModal({
 }: AddIdeaModalProps) {
   const [title, setTitle] = React.useState("");
   const [description, setDescription] = React.useState("");
+  const [subtasks, setSubtasks] = React.useState<Subtask[]>([]);
   const createIdea = useCreateIdea(boardId);
+  const createSubtask = useCreateIdeaSubtask();
 
   const titleInputRef = React.useRef<HTMLInputElement>(null);
   const formRef = React.useRef<HTMLFormElement>(null);
@@ -47,6 +51,7 @@ export function AddIdeaModal({
     if (!open) {
       setTitle("");
       setDescription("");
+      setSubtasks([]);
     }
   }, [open]);
 
@@ -66,12 +71,23 @@ export function AddIdeaModal({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
-    await createIdea.mutateAsync({
+    const idea = await createIdea.mutateAsync({
       boardId,
       columnId,
       title: title.trim(),
       notes: description || undefined,
     });
+    // Persist subtasks once we have the idea id.
+    if (subtasks.length > 0) {
+      await Promise.all(
+        subtasks.map((st) =>
+          createSubtask.mutateAsync({
+            ideaId: idea.id,
+            input: { title: st.title },
+          })
+        )
+      );
+    }
     onOpenChange(false);
   };
 
@@ -94,17 +110,25 @@ export function AddIdeaModal({
             </p>
           </div>
 
-          {/* Body — notes */}
-          <div className="max-h-[50vh] space-y-2 overflow-y-auto px-4 py-4">
-            <Label className="text-sm font-medium text-muted-foreground">
-              Notes
-            </Label>
-            <RichTextEditor
-              value={description}
-              onChange={setDescription}
-              placeholder="Add details..."
-              minHeight="80px"
-            />
+          {/* Body — subtasks + notes */}
+          <div className="max-h-[50vh] space-y-4 overflow-y-auto px-4 py-4">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium text-muted-foreground">
+                Subtasks
+              </Label>
+              <SubtaskList subtasks={subtasks} onSubtasksChange={setSubtasks} />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-sm font-medium text-muted-foreground">
+                Notes
+              </Label>
+              <RichTextEditor
+                value={description}
+                onChange={setDescription}
+                placeholder="Add details..."
+                minHeight="80px"
+              />
+            </div>
           </div>
 
           {/* Footer */}

--- a/apps/web/src/components/ideas/idea-card.tsx
+++ b/apps/web/src/components/ideas/idea-card.tsx
@@ -1,15 +1,17 @@
 import * as React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { format, addDays } from "date-fns";
+import { format, addDays, startOfWeek } from "date-fns";
 import {
   Check,
   MoreHorizontal,
-  ArrowRight,
+  LayoutGrid,
+  Inbox,
   Calendar,
   Pencil,
   Columns3,
   Trash2,
+  ListChecks,
 } from "lucide-react";
 import type { Idea, IdeaColumn } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
@@ -22,6 +24,14 @@ import {
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
 } from "@/components/ui";
 import { HtmlContent } from "@/components/ui/html-content";
 import {
@@ -39,10 +49,116 @@ interface IdeaCardProps {
   overlay?: boolean;
 }
 
+/** Menu family — lets one render path drive both the ⋯ dropdown and the
+ * right-click context menu without duplicating the item list. */
+interface MenuFamily {
+  Item: React.ElementType;
+  Separator: React.ElementType;
+  Sub: React.ElementType;
+  SubTrigger: React.ElementType;
+  SubContent: React.ElementType;
+}
+
+const DROPDOWN_FAMILY: MenuFamily = {
+  Item: DropdownMenuItem,
+  Separator: DropdownMenuSeparator,
+  Sub: DropdownMenuSub,
+  SubTrigger: DropdownMenuSubTrigger,
+  SubContent: DropdownMenuSubContent,
+};
+
+const CONTEXT_FAMILY: MenuFamily = {
+  Item: ContextMenuItem,
+  Separator: ContextMenuSeparator,
+  Sub: ContextMenuSub,
+  SubTrigger: ContextMenuSubTrigger,
+  SubContent: ContextMenuSubContent,
+};
+
+interface IdeaMenuHandlers {
+  onAddToToday: () => void;
+  onSendToBacklog: () => void;
+  onScheduleTomorrow: () => void;
+  onScheduleNextWeek: () => void;
+  onEdit: () => void;
+  onMoveToColumn: (columnId: string) => void;
+  onDelete: () => void;
+}
+
+/** The shared item list for both menu families. */
+function IdeaMenuItems({
+  family: C,
+  handlers,
+  otherColumns,
+}: {
+  family: MenuFamily;
+  handlers: IdeaMenuHandlers;
+  otherColumns: IdeaColumn[];
+}) {
+  return (
+    <>
+      <C.Item onSelect={handlers.onAddToToday}>
+        <LayoutGrid className="mr-2 h-4 w-4" />
+        Add to Today
+      </C.Item>
+      <C.Item onSelect={handlers.onSendToBacklog}>
+        <Inbox className="mr-2 h-4 w-4" />
+        Send to Backlog
+      </C.Item>
+      <C.Sub>
+        <C.SubTrigger>
+          <Calendar className="mr-2 h-4 w-4" />
+          Schedule
+        </C.SubTrigger>
+        <C.SubContent>
+          <C.Item onSelect={handlers.onScheduleTomorrow}>Tomorrow</C.Item>
+          <C.Item onSelect={handlers.onScheduleNextWeek}>Next week</C.Item>
+        </C.SubContent>
+      </C.Sub>
+
+      <C.Separator />
+
+      <C.Item onSelect={handlers.onEdit}>
+        <Pencil className="mr-2 h-4 w-4" />
+        Edit
+      </C.Item>
+      {otherColumns.length > 0 && (
+        <C.Sub>
+          <C.SubTrigger>
+            <Columns3 className="mr-2 h-4 w-4" />
+            Move to column
+          </C.SubTrigger>
+          <C.SubContent>
+            {otherColumns.map((col) => (
+              <C.Item
+                key={col.id}
+                onSelect={() => handlers.onMoveToColumn(col.id)}
+              >
+                {col.name}
+              </C.Item>
+            ))}
+          </C.SubContent>
+        </C.Sub>
+      )}
+
+      <C.Separator />
+
+      <C.Item
+        onSelect={handlers.onDelete}
+        className="text-destructive focus:text-destructive focus:bg-destructive/10"
+      >
+        <Trash2 className="mr-2 h-4 w-4" />
+        Delete
+      </C.Item>
+    </>
+  );
+}
+
 /**
  * An idea card. Visually the same component as the kanban task card
  * (task-card-content.tsx): circle checkbox + title + optional muted note,
- * with the ⋯ menu mirroring task-context-menu, adapted for Ideas.
+ * a subtask counter, and both a ⋯ menu and a right-click context menu that
+ * mirror the task actions, adapted for Ideas.
  */
 export function IdeaCard({ idea, boardId, columns, overlay }: IdeaCardProps) {
   const [menuOpen, setMenuOpen] = React.useState(false);
@@ -60,9 +176,10 @@ export function IdeaCard({ idea, boardId, columns, overlay }: IdeaCardProps) {
 
   const isCompleted = !!idea.completedAt;
   const inPlanner = !!idea.promotedTaskId;
-  // Notes are rich-text HTML; only show a preview when there's real text.
   const hasNotes =
     !!idea.notes && idea.notes.replace(/<[^>]*>/g, "").trim().length > 0;
+  const subtaskTotal = idea.subtaskCount ?? 0;
+  const subtaskDone = idea.subtaskDoneCount ?? 0;
 
   const style: React.CSSProperties = overlay
     ? {}
@@ -80,182 +197,156 @@ export function IdeaCard({ idea, boardId, columns, overlay }: IdeaCardProps) {
     });
   };
 
-  // Click the card to edit — but not at the tail of a drag.
   const handleClick = () => {
     if (!sortable.isDragging) setEditOpen(true);
   };
 
   const otherColumns = columns.filter((c) => c.id !== idea.columnId);
 
-  return (
-    <>
-      <div
-        ref={overlay ? undefined : sortable.setNodeRef}
-        style={style}
-        {...(overlay ? {} : sortable.attributes)}
-        {...(overlay ? {} : sortable.listeners)}
-        onClick={overlay ? undefined : handleClick}
-        className={cn(
-          "group relative flex flex-col gap-1.5 rounded-lg px-3 py-2.5 transition-all duration-200",
-          "bg-card hover:bg-card/80",
-          "border border-border/40 hover:border-border/60",
-          "cursor-grab active:cursor-grabbing touch-none select-none",
-          overlay &&
-            "shadow-xl ring-2 ring-primary/20 rotate-[0.5deg] cursor-grabbing",
-          isCompleted && "opacity-50 hover:opacity-60 bg-card/50"
-        )}
-      >
-        {/* Main row: checkbox + title */}
-        <div className="flex items-start gap-2">
-          <div
-            role="checkbox"
-            aria-checked={isCompleted}
-            onClick={toggleComplete}
-            onPointerDown={(e) => e.stopPropagation()}
-            className={cn(
-              "relative mt-0.5 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-full border-[1.5px] transition-all duration-150",
-              isCompleted
-                ? "border-primary bg-primary text-primary-foreground"
-                : "border-muted-foreground/40 hover:border-primary hover:bg-primary/10"
-            )}
-          >
-            {isCompleted && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
-          </div>
+  const handlers: IdeaMenuHandlers = {
+    onAddToToday: () =>
+      promoteIdea.mutate({
+        id: idea.id,
+        input: { scheduledDate: format(new Date(), "yyyy-MM-dd") },
+      }),
+    onSendToBacklog: () => promoteIdea.mutate({ id: idea.id }),
+    onScheduleTomorrow: () =>
+      promoteIdea.mutate({
+        id: idea.id,
+        input: { scheduledDate: format(addDays(new Date(), 1), "yyyy-MM-dd") },
+      }),
+    onScheduleNextWeek: () =>
+      promoteIdea.mutate({
+        id: idea.id,
+        input: {
+          scheduledDate: format(
+            addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), 7),
+            "yyyy-MM-dd"
+          ),
+        },
+      }),
+    onEdit: () => setEditOpen(true),
+    onMoveToColumn: (columnId) =>
+      updateIdea.mutate({ id: idea.id, input: { columnId } }),
+    onDelete: () => deleteIdea.mutate(idea.id),
+  };
 
-          <p
-            className={cn(
-              "min-w-0 flex-1 text-sm leading-snug text-foreground break-words line-clamp-3",
-              isCompleted && "line-through text-muted-foreground"
-            )}
-          >
-            {idea.title}
-          </p>
+  const cardInner = (
+    <div
+      ref={overlay ? undefined : sortable.setNodeRef}
+      style={style}
+      {...(overlay ? {} : sortable.attributes)}
+      {...(overlay ? {} : sortable.listeners)}
+      onClick={overlay ? undefined : handleClick}
+      className={cn(
+        "group relative flex flex-col gap-1.5 rounded-lg px-3 py-2.5 transition-all duration-200",
+        "bg-card hover:bg-card/80",
+        "border border-border/40 hover:border-border/60",
+        "cursor-grab active:cursor-grabbing touch-none select-none",
+        overlay &&
+          "shadow-xl ring-2 ring-primary/20 rotate-[0.5deg] cursor-grabbing",
+        isCompleted && "opacity-50 hover:opacity-60 bg-card/50"
+      )}
+    >
+      {/* Main row: checkbox + title */}
+      <div className="flex items-start gap-2">
+        <div
+          role="checkbox"
+          aria-checked={isCompleted}
+          onClick={toggleComplete}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={cn(
+            "relative mt-0.5 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-full border-[1.5px] transition-all duration-150",
+            isCompleted
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-muted-foreground/40 hover:border-primary hover:bg-primary/10"
+          )}
+        >
+          {isCompleted && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
         </div>
 
-        {/* Optional notes preview (rich text) */}
-        {hasNotes && !isCompleted && (
-          <HtmlContent
-            html={idea.notes!}
-            className="pl-6 text-xs leading-snug text-muted-foreground line-clamp-2 [&_p]:m-0"
-          />
-        )}
+        <p
+          className={cn(
+            "min-w-0 flex-1 text-sm leading-snug text-foreground break-words line-clamp-3",
+            isCompleted && "line-through text-muted-foreground"
+          )}
+        >
+          {idea.title}
+        </p>
+      </div>
 
-        {/* "In backlog" marker once promoted */}
-        {inPlanner && (
-          <div className="flex items-center gap-1 pl-6">
+      {/* Optional notes preview (rich text) */}
+      {hasNotes && !isCompleted && (
+        <HtmlContent
+          html={idea.notes!}
+          className="pl-6 text-xs leading-snug text-muted-foreground line-clamp-2 [&_p]:m-0"
+        />
+      )}
+
+      {/* Meta row: subtasks + in-planner marker */}
+      {(subtaskTotal > 0 || inPlanner) && !isCompleted && (
+        <div className="flex items-center gap-3 pl-6">
+          {subtaskTotal > 0 && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground tabular-nums">
+              <ListChecks className="h-3 w-3" />
+              {subtaskDone}/{subtaskTotal}
+            </span>
+          )}
+          {inPlanner && (
             <span className="inline-flex items-center gap-1 text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
               <Check className="h-3 w-3" strokeWidth={2.5} />
               In planner
             </span>
-          </div>
-        )}
+          )}
+        </div>
+      )}
 
-        {/* ⋯ menu — appears on hover */}
-        {!overlay && (
-          <div
-            className={cn(
-              "absolute right-1.5 top-1.5 transition-opacity",
-              menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100"
-            )}
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-              <DropdownMenuTrigger asChild>
-                <button
-                  className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-                  aria-label="Idea actions"
-                >
-                  <MoreHorizontal className="h-3.5 w-3.5" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuItem
-                  onClick={() => promoteIdea.mutate({ id: idea.id })}
-                >
-                  <ArrowRight className="mr-2 h-4 w-4" />
-                  Send to backlog
-                </DropdownMenuItem>
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    <Calendar className="mr-2 h-4 w-4" />
-                    Schedule
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    <DropdownMenuItem
-                      onClick={() =>
-                        promoteIdea.mutate({
-                          id: idea.id,
-                          input: {
-                            scheduledDate: format(new Date(), "yyyy-MM-dd"),
-                          },
-                        })
-                      }
-                    >
-                      Today
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() =>
-                        promoteIdea.mutate({
-                          id: idea.id,
-                          input: {
-                            scheduledDate: format(
-                              addDays(new Date(), 1),
-                              "yyyy-MM-dd"
-                            ),
-                          },
-                        })
-                      }
-                    >
-                      Tomorrow
-                    </DropdownMenuItem>
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
+      {/* ⋯ menu — appears on hover */}
+      {!overlay && (
+        <div
+          className={cn(
+            "absolute right-1.5 top-1.5 transition-opacity",
+            menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+          )}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Idea actions"
+              >
+                <MoreHorizontal className="h-3.5 w-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-52">
+              <IdeaMenuItems
+                family={DROPDOWN_FAMILY}
+                handlers={handlers}
+                otherColumns={otherColumns}
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+    </div>
+  );
 
-                <DropdownMenuSeparator />
+  if (overlay) return cardInner;
 
-                <DropdownMenuItem onClick={() => setEditOpen(true)}>
-                  <Pencil className="mr-2 h-4 w-4" />
-                  Edit
-                </DropdownMenuItem>
-                {otherColumns.length > 0 && (
-                  <DropdownMenuSub>
-                    <DropdownMenuSubTrigger>
-                      <Columns3 className="mr-2 h-4 w-4" />
-                      Move to column
-                    </DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent>
-                      {otherColumns.map((col) => (
-                        <DropdownMenuItem
-                          key={col.id}
-                          onClick={() =>
-                            updateIdea.mutate({
-                              id: idea.id,
-                              input: { columnId: col.id },
-                            })
-                          }
-                        >
-                          {col.name}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuSub>
-                )}
-
-                <DropdownMenuSeparator />
-
-                <DropdownMenuItem
-                  className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                  onClick={() => deleteIdea.mutate(idea.id)}
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        )}
-      </div>
+  return (
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{cardInner}</ContextMenuTrigger>
+        <ContextMenuContent className="w-52">
+          <IdeaMenuItems
+            family={CONTEXT_FAMILY}
+            handlers={handlers}
+            otherColumns={otherColumns}
+          />
+        </ContextMenuContent>
+      </ContextMenu>
 
       {editOpen && (
         <IdeaEditDialog

--- a/apps/web/src/components/ideas/idea-edit-dialog.tsx
+++ b/apps/web/src/components/ideas/idea-edit-dialog.tsx
@@ -1,17 +1,16 @@
 import * as React from "react";
+import { Check } from "lucide-react";
 import type { Idea } from "@open-sunsama/types";
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
-  DialogFooter,
-  Button,
-  Input,
   Label,
 } from "@/components/ui";
 import { RichTextEditor } from "@/components/ui/rich-text-editor.lazy";
+import { cn } from "@/lib/utils";
 import { useUpdateIdea } from "@/hooks/useIdeas";
+import { IdeaSubtaskList } from "./idea-subtask-list";
 
 interface IdeaEditDialogProps {
   boardId: string;
@@ -20,6 +19,11 @@ interface IdeaEditDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+/**
+ * Idea editor — a richer, mostly-live editor that mirrors the task modal:
+ * completion checkbox + title (saved on blur), live subtasks, and rich
+ * notes (saved on close).
+ */
 export function IdeaEditDialog({
   boardId,
   idea,
@@ -37,60 +41,101 @@ export function IdeaEditDialog({
     }
   }, [open, idea]);
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const isCompleted = !!idea.completedAt;
+
+  const saveTitle = () => {
     const trimmed = title.trim();
-    if (!trimmed) return;
-    await updateIdea.mutateAsync({
+    if (!trimmed) {
+      setTitle(idea.title);
+      return;
+    }
+    if (trimmed !== idea.title) {
+      updateIdea.mutate({ id: idea.id, input: { title: trimmed } });
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      // Persist notes on close.
+      const cleaned = notes.replace(/<[^>]*>/g, "").trim().length ? notes : "";
+      if (cleaned !== (idea.notes ?? "")) {
+        updateIdea.mutate({
+          id: idea.id,
+          input: { notes: cleaned || null },
+        });
+      }
+    }
+    onOpenChange(next);
+  };
+
+  const toggleComplete = () => {
+    updateIdea.mutate({
       id: idea.id,
-      input: { title: trimmed, notes: notes.trim() ? notes.trim() : null },
+      input: { completedAt: isCompleted ? null : new Date() },
     });
-    onOpenChange(false);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <form onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>Edit idea</DialogTitle>
-          </DialogHeader>
-          <div className="mt-4 space-y-3">
-            <Input
-              autoFocus
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Idea title…"
-              maxLength={500}
-            />
-            <div className="space-y-2">
-              <Label className="text-sm font-medium text-muted-foreground">
-                Notes
-              </Label>
-              <RichTextEditor
-                value={notes}
-                onChange={setNotes}
-                placeholder="Add details..."
-                minHeight="80px"
-              />
-            </div>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg gap-0 overflow-hidden p-0">
+        <DialogTitle className="sr-only">Edit idea</DialogTitle>
+
+        {/* Header: checkbox + title */}
+        <div className="flex items-start gap-3 px-5 pb-3 pt-5">
+          <button
+            type="button"
+            onClick={toggleComplete}
+            aria-checked={isCompleted}
+            role="checkbox"
+            className={cn(
+              "mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-[1.5px] transition-all",
+              isCompleted
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-muted-foreground/40 hover:border-primary"
+            )}
+          >
+            {isCompleted && <Check className="h-3 w-3" strokeWidth={3} />}
+          </button>
+          <textarea
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onBlur={saveTitle}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                (e.target as HTMLTextAreaElement).blur();
+              }
+            }}
+            rows={1}
+            placeholder="Idea title"
+            className={cn(
+              "mt-0.5 min-w-0 flex-1 resize-none border-none bg-transparent p-0 pr-6 text-lg font-semibold outline-none focus:ring-0",
+              isCompleted && "text-muted-foreground line-through"
+            )}
+          />
+        </div>
+
+        {/* Body: subtasks + notes */}
+        <div className="max-h-[60vh] space-y-4 overflow-y-auto border-t border-border/40 px-5 py-4">
+          <div className="space-y-1.5">
+            <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Subtasks
+            </Label>
+            <IdeaSubtaskList ideaId={idea.id} />
           </div>
-          <DialogFooter className="mt-5">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={!title.trim() || updateIdea.isPending}
-            >
-              Save
-            </Button>
-          </DialogFooter>
-        </form>
+
+          <div className="space-y-1.5">
+            <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Notes
+            </Label>
+            <RichTextEditor
+              value={notes}
+              onChange={setNotes}
+              placeholder="Add details..."
+              minHeight="120px"
+            />
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/ideas/idea-subtask-list.tsx
+++ b/apps/web/src/components/ideas/idea-subtask-list.tsx
@@ -1,0 +1,221 @@
+import * as React from "react";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Check, GripVertical, Plus, X } from "lucide-react";
+import type { IdeaSubtask } from "@open-sunsama/types";
+import { cn } from "@/lib/utils";
+import { Button, Input } from "@/components/ui";
+import {
+  useIdeaSubtasks,
+  useCreateIdeaSubtask,
+  useUpdateIdeaSubtask,
+  useDeleteIdeaSubtask,
+  useReorderIdeaSubtasks,
+} from "@/hooks/useIdeaSubtasks";
+
+interface IdeaSubtaskItemProps {
+  subtask: IdeaSubtask;
+  onToggle: () => void;
+  onDelete: () => void;
+  onRename: (title: string) => void;
+}
+
+function IdeaSubtaskItem({
+  subtask,
+  onToggle,
+  onDelete,
+  onRename,
+}: IdeaSubtaskItemProps) {
+  const [editing, setEditing] = React.useState(false);
+  const [value, setValue] = React.useState(subtask.title);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: subtask.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const save = () => {
+    const trimmed = value.trim();
+    if (trimmed && trimmed !== subtask.title) onRename(trimmed);
+    else setValue(subtask.title);
+    setEditing(false);
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "group flex items-center gap-2 rounded-md px-1 py-1.5 transition-colors hover:bg-muted/40",
+        isDragging && "opacity-50"
+      )}
+    >
+      <span
+        {...attributes}
+        {...listeners}
+        className="cursor-grab touch-none text-muted-foreground/40 opacity-0 transition-opacity group-hover:opacity-100 active:cursor-grabbing"
+      >
+        <GripVertical className="h-4 w-4" />
+      </span>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={cn(
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-[1.5px] transition-all",
+          subtask.completed
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-muted-foreground/40 hover:border-primary"
+        )}
+      >
+        {subtask.completed && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
+      </button>
+      {editing ? (
+        <input
+          autoFocus
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={save}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              save();
+            } else if (e.key === "Escape") {
+              setValue(subtask.title);
+              setEditing(false);
+            }
+          }}
+          className="flex-1 border-none bg-transparent p-0 text-sm outline-none focus:ring-0"
+        />
+      ) : (
+        <span
+          onClick={() => setEditing(true)}
+          className={cn(
+            "flex-1 cursor-text text-sm",
+            subtask.completed && "text-muted-foreground line-through"
+          )}
+        >
+          {subtask.title}
+        </span>
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+        onClick={onDelete}
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+/** Live subtask list for the idea editor — add / toggle / rename / reorder. */
+export function IdeaSubtaskList({ ideaId }: { ideaId: string }) {
+  const { data: subtasks = [] } = useIdeaSubtasks(ideaId);
+  const createSubtask = useCreateIdeaSubtask();
+  const updateSubtask = useUpdateIdeaSubtask();
+  const deleteSubtask = useDeleteIdeaSubtask();
+  const reorderSubtasks = useReorderIdeaSubtasks();
+
+  const [draft, setDraft] = React.useState("");
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const ids = React.useMemo(() => subtasks.map((s) => s.id), [subtasks]);
+
+  const add = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    createSubtask.mutate({ ideaId, input: { title: trimmed } });
+    setDraft("");
+  };
+
+  const onDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = subtasks.findIndex((s) => s.id === active.id);
+    const newIndex = subtasks.findIndex((s) => s.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+    const next = arrayMove(subtasks, oldIndex, newIndex);
+    reorderSubtasks.mutate({ ideaId, subtaskIds: next.map((s) => s.id) });
+  };
+
+  return (
+    <div className="space-y-1">
+      {subtasks.length > 0 && (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={onDragEnd}
+        >
+          <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+            <div className="space-y-0.5">
+              {subtasks.map((subtask) => (
+                <IdeaSubtaskItem
+                  key={subtask.id}
+                  subtask={subtask}
+                  onToggle={() =>
+                    updateSubtask.mutate({
+                      ideaId,
+                      subtaskId: subtask.id,
+                      input: { completed: !subtask.completed },
+                    })
+                  }
+                  onDelete={() =>
+                    deleteSubtask.mutate({ ideaId, subtaskId: subtask.id })
+                  }
+                  onRename={(title) =>
+                    updateSubtask.mutate({
+                      ideaId,
+                      subtaskId: subtask.id,
+                      input: { title },
+                    })
+                  }
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      {/* Add subtask */}
+      <div className="flex items-center gap-2 px-1 py-1">
+        <Plus className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              add();
+            }
+          }}
+          onBlur={add}
+          placeholder="Add a subtask..."
+          className="h-auto border-none p-0 text-sm shadow-none focus-visible:ring-0"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useIdeaSubtasks.ts
+++ b/apps/web/src/hooks/useIdeaSubtasks.ts
@@ -1,0 +1,190 @@
+/**
+ * React Query hooks for idea subtasks (checklist items under an idea card).
+ * Mirrors useSubtasks/useSubtaskMutations with optimistic updates.
+ */
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type {
+  IdeaSubtask,
+  CreateIdeaSubtaskInput,
+  UpdateIdeaSubtaskInput,
+} from "@open-sunsama/types";
+import { getApi } from "@/lib/api";
+import { ideaSubtaskKeys } from "@/lib/query-keys";
+
+export { ideaSubtaskKeys };
+
+export function useIdeaSubtasks(
+  ideaId: string,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: ideaSubtaskKeys.list(ideaId),
+    queryFn: async () => {
+      const api = getApi();
+      return await api.ideas.subtasks.list(ideaId);
+    },
+    enabled: !!ideaId && options?.enabled !== false,
+  });
+}
+
+export function useCreateIdeaSubtask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      ideaId,
+      input,
+    }: {
+      ideaId: string;
+      input: CreateIdeaSubtaskInput;
+    }) => {
+      const api = getApi();
+      return await api.ideas.subtasks.create(ideaId, input);
+    },
+    onMutate: async ({ ideaId, input }) => {
+      const key = ideaSubtaskKeys.list(ideaId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<IdeaSubtask[]>(key);
+      const now = new Date();
+      const optimistic: IdeaSubtask = {
+        id: `temp-${now.getTime()}-${Math.random().toString(36).slice(2)}`,
+        ideaId,
+        title: input.title,
+        completed: false,
+        position: previous?.length ?? 0,
+        createdAt: now,
+        updatedAt: now,
+      };
+      queryClient.setQueryData<IdeaSubtask[]>(key, (old) => [
+        ...(old ?? []),
+        optimistic,
+      ]);
+      return { previous, tempId: optimistic.id };
+    },
+    onSuccess: (created, { ideaId }, context) => {
+      queryClient.setQueryData<IdeaSubtask[]>(
+        ideaSubtaskKeys.list(ideaId),
+        (old) =>
+          (old ?? []).map((s) => (s.id === context?.tempId ? created : s))
+      );
+    },
+    onError: (_e, { ideaId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          ideaSubtaskKeys.list(ideaId),
+          context.previous
+        );
+      }
+    },
+  });
+}
+
+export function useUpdateIdeaSubtask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      ideaId,
+      subtaskId,
+      input,
+    }: {
+      ideaId: string;
+      subtaskId: string;
+      input: UpdateIdeaSubtaskInput;
+    }) => {
+      const api = getApi();
+      return await api.ideas.subtasks.update(ideaId, subtaskId, input);
+    },
+    onMutate: async ({ ideaId, subtaskId, input }) => {
+      const key = ideaSubtaskKeys.list(ideaId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<IdeaSubtask[]>(key);
+      queryClient.setQueryData<IdeaSubtask[]>(key, (old) =>
+        (old ?? []).map((s) =>
+          s.id === subtaskId ? { ...s, ...input } : s
+        )
+      );
+      return { previous };
+    },
+    onError: (_e, { ideaId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          ideaSubtaskKeys.list(ideaId),
+          context.previous
+        );
+      }
+    },
+  });
+}
+
+export function useDeleteIdeaSubtask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      ideaId,
+      subtaskId,
+    }: {
+      ideaId: string;
+      subtaskId: string;
+    }) => {
+      const api = getApi();
+      await api.ideas.subtasks.delete(ideaId, subtaskId);
+      return subtaskId;
+    },
+    onMutate: async ({ ideaId, subtaskId }) => {
+      const key = ideaSubtaskKeys.list(ideaId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<IdeaSubtask[]>(key);
+      queryClient.setQueryData<IdeaSubtask[]>(key, (old) =>
+        (old ?? []).filter((s) => s.id !== subtaskId)
+      );
+      return { previous };
+    },
+    onError: (_e, { ideaId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          ideaSubtaskKeys.list(ideaId),
+          context.previous
+        );
+      }
+    },
+  });
+}
+
+export function useReorderIdeaSubtasks() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      ideaId,
+      subtaskIds,
+    }: {
+      ideaId: string;
+      subtaskIds: string[];
+    }) => {
+      const api = getApi();
+      return await api.ideas.subtasks.reorder(ideaId, subtaskIds);
+    },
+    onMutate: async ({ ideaId, subtaskIds }) => {
+      const key = ideaSubtaskKeys.list(ideaId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<IdeaSubtask[]>(key);
+      if (previous) {
+        const byId = new Map(previous.map((s) => [s.id, s]));
+        const reordered = subtaskIds
+          .map((id, index) => {
+            const s = byId.get(id);
+            return s ? { ...s, position: index } : undefined;
+          })
+          .filter((s): s is IdeaSubtask => !!s);
+        queryClient.setQueryData<IdeaSubtask[]>(key, reordered);
+      }
+      return { previous };
+    },
+    onError: (_e, { ideaId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          ideaSubtaskKeys.list(ideaId),
+          context.previous
+        );
+      }
+    },
+  });
+}

--- a/apps/web/src/hooks/useIdeas.ts
+++ b/apps/web/src/hooks/useIdeas.ts
@@ -539,10 +539,15 @@ export function usePromoteIdea(boardId: string | undefined) {
       }
       // The promote created a real task — refresh task lists.
       queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
+      const scheduled = result.task.scheduledDate;
+      const today = new Date().toISOString().slice(0, 10);
+      const title = !scheduled
+        ? "Added to Backlog"
+        : scheduled === today
+          ? "Added to Today"
+          : "Scheduled";
       toast({
-        title: result.task.scheduledDate
-          ? "Scheduled as a task"
-          : "Added to backlog",
+        title,
         description: `"${result.task.title}" is now in your planner.`,
       });
     },

--- a/apps/web/src/hooks/useWebSocket.ts
+++ b/apps/web/src/hooks/useWebSocket.ts
@@ -15,6 +15,7 @@ import {
   calendarKeys,
   ideaBoardKeys,
   ideaKeys,
+  ideaSubtaskKeys,
 } from "@/lib/query-keys";
 
 /**
@@ -213,7 +214,7 @@ function handleWebSocketEvent(
       batcher.schedule(ideaBoardKeys.lists());
       const payload =
         event.payload && typeof event.payload === "object"
-          ? (event.payload as { boardId?: string })
+          ? (event.payload as { boardId?: string; ideaId?: string })
           : undefined;
       if (payload?.boardId) {
         batcher.schedule(ideaBoardKeys.columns(payload.boardId));
@@ -221,6 +222,11 @@ function handleWebSocketEvent(
       } else {
         // Board-level events without a boardId (rare) — refetch all ideas.
         batcher.schedule(ideaKeys.lists());
+      }
+      // idea:updated also fires on subtask changes — keep the card's
+      // subtask list in sync across tabs.
+      if (payload?.ideaId) {
+        batcher.schedule(ideaSubtaskKeys.list(payload.ideaId));
       }
       break;
     }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -67,3 +67,9 @@ export const ideaKeys = {
   lists: () => [...ideaKeys.all, "list"] as const,
   byBoard: (boardId: string) => [...ideaKeys.lists(), boardId] as const,
 };
+
+export const ideaSubtaskKeys = {
+  all: ["ideaSubtasks"] as const,
+  lists: () => [...ideaSubtaskKeys.all, "list"] as const,
+  list: (ideaId: string) => [...ideaSubtaskKeys.lists(), ideaId] as const,
+};

--- a/packages/api-client/src/ideas.ts
+++ b/packages/api-client/src/ideas.ts
@@ -19,6 +19,9 @@ import type {
   ReorderIdeaBoardsInput,
   PromoteIdeaInput,
   IdeaFilterInput,
+  IdeaSubtask,
+  CreateIdeaSubtaskInput,
+  UpdateIdeaSubtaskInput,
 } from "@open-sunsama/types";
 import type { OpenSunsamaClient, RequestOptions } from "./client.js";
 
@@ -68,10 +71,37 @@ export interface IdeaColumnsApi {
   ): Promise<IdeaColumn[]>;
 }
 
+/** Idea subtasks sub-API */
+export interface IdeaSubtasksApi {
+  list(ideaId: string, options?: RequestOptions): Promise<IdeaSubtask[]>;
+  create(
+    ideaId: string,
+    input: CreateIdeaSubtaskInput,
+    options?: RequestOptions
+  ): Promise<IdeaSubtask>;
+  update(
+    ideaId: string,
+    subtaskId: string,
+    input: UpdateIdeaSubtaskInput,
+    options?: RequestOptions
+  ): Promise<IdeaSubtask>;
+  delete(
+    ideaId: string,
+    subtaskId: string,
+    options?: RequestOptions
+  ): Promise<void>;
+  reorder(
+    ideaId: string,
+    subtaskIds: string[],
+    options?: RequestOptions
+  ): Promise<IdeaSubtask[]>;
+}
+
 /** Full Ideas API */
 export interface IdeasApi {
   boards: IdeaBoardsApi;
   columns: IdeaColumnsApi;
+  subtasks: IdeaSubtasksApi;
   list(filters?: IdeaFilterInput, options?: RequestOptions): Promise<Idea[]>;
   create(input: CreateIdeaInput, options?: RequestOptions): Promise<Idea>;
   update(
@@ -268,6 +298,66 @@ export function createIdeasApi(client: OpenSunsamaClient): IdeasApi {
         ApiResponseWrapper<{ idea: Idea; task: Task }>
       >(`ideas/${id}/promote`, input ?? {}, options);
       return res.data;
+    },
+
+    subtasks: {
+      async list(
+        ideaId: string,
+        options?: RequestOptions
+      ): Promise<IdeaSubtask[]> {
+        const res = await client.get<ApiResponseWrapper<IdeaSubtask[]>>(
+          `ideas/${ideaId}/subtasks`,
+          options
+        );
+        return res.data ?? [];
+      },
+      async create(
+        ideaId: string,
+        input: CreateIdeaSubtaskInput,
+        options?: RequestOptions
+      ): Promise<IdeaSubtask> {
+        const res = await client.post<ApiResponseWrapper<IdeaSubtask>>(
+          `ideas/${ideaId}/subtasks`,
+          input,
+          options
+        );
+        return res.data;
+      },
+      async update(
+        ideaId: string,
+        subtaskId: string,
+        input: UpdateIdeaSubtaskInput,
+        options?: RequestOptions
+      ): Promise<IdeaSubtask> {
+        const res = await client.patch<ApiResponseWrapper<IdeaSubtask>>(
+          `ideas/${ideaId}/subtasks/${subtaskId}`,
+          input,
+          options
+        );
+        return res.data;
+      },
+      async delete(
+        ideaId: string,
+        subtaskId: string,
+        options?: RequestOptions
+      ): Promise<void> {
+        await client.delete<ApiResponseWrapper<void>>(
+          `ideas/${ideaId}/subtasks/${subtaskId}`,
+          options
+        );
+      },
+      async reorder(
+        ideaId: string,
+        subtaskIds: string[],
+        options?: RequestOptions
+      ): Promise<IdeaSubtask[]> {
+        const res = await client.post<ApiResponseWrapper<IdeaSubtask[]>>(
+          `ideas/${ideaId}/subtasks/reorder`,
+          { subtaskIds },
+          options
+        );
+        return res.data ?? [];
+      },
     },
   };
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -81,6 +81,7 @@ import {
   type IdeasApi,
   type IdeaBoardsApi,
   type IdeaColumnsApi,
+  type IdeaSubtasksApi,
   type IdeaBoardWithColumns,
 } from "./ideas.js";
 export {
@@ -88,6 +89,7 @@ export {
   type IdeasApi,
   type IdeaBoardsApi,
   type IdeaColumnsApi,
+  type IdeaSubtasksApi,
   type IdeaBoardWithColumns,
 };
 

--- a/packages/database/drizzle/0014_loud_random.sql
+++ b/packages/database/drizzle/0014_loud_random.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "idea_subtasks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"idea_id" uuid NOT NULL,
+	"title" varchar(500) NOT NULL,
+	"completed" boolean DEFAULT false NOT NULL,
+	"position" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "idea_subtasks" ADD CONSTRAINT "idea_subtasks_idea_id_ideas_id_fk" FOREIGN KEY ("idea_id") REFERENCES "public"."ideas"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idea_subtasks_idea_id_idx" ON "idea_subtasks" USING btree ("idea_id");

--- a/packages/database/drizzle/meta/0014_snapshot.json
+++ b/packages/database/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2658 @@
+{
+  "id": "5b94356d-6a67-47d4-9b97-0eae531b1fd2",
+  "prevId": "6f8f4455-8909-4fc8-a1f7-af42bbda179c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_prefix_idx": {
+          "name": "api_keys_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_task_id_idx": {
+          "name": "attachments_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_user_id_idx": {
+          "name": "attachments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachments_task_id_tasks_id_fk": {
+          "name": "attachments_task_id_tasks_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachments_user_id_users_id_fk": {
+          "name": "attachments_user_id_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_accounts": {
+      "name": "calendar_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caldav_password_encrypted": {
+          "name": "caldav_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caldav_url": {
+          "name": "caldav_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'idle'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_subscription_id": {
+          "name": "webhook_subscription_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_expires_at": {
+          "name": "webhook_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_accounts_user_id_idx": {
+          "name": "calendar_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_accounts_webhook_sub_idx": {
+          "name": "calendar_accounts_webhook_sub_idx",
+          "columns": [
+            {
+              "expression": "webhook_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_accounts_user_id_users_id_fk": {
+          "name": "calendar_accounts_user_id_users_id_fk",
+          "tableFrom": "calendar_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_all_day": {
+          "name": "is_all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_event_id": {
+          "name": "recurring_event_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'confirmed'"
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_link": {
+          "name": "html_link",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_events_user_time_idx": {
+          "name": "calendar_events_user_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_calendar_external_idx": {
+          "name": "calendar_events_calendar_external_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_calendar_idx": {
+          "name": "calendar_events_calendar_idx",
+          "columns": [
+            {
+              "expression": "calendar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_calendar_id_calendars_id_fk": {
+          "name": "calendar_events_calendar_id_calendars_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "calendars",
+          "columnsFrom": [
+            "calendar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_user_id_users_id_fk": {
+          "name": "calendar_events_user_id_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendars": {
+      "name": "calendars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default_for_events": {
+          "name": "is_default_for_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_for_tasks": {
+          "name": "is_default_for_tasks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_read_only": {
+          "name": "is_read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_channel_id": {
+          "name": "watch_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_resource_id": {
+          "name": "watch_resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_expires_at": {
+          "name": "watch_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendars_user_idx": {
+          "name": "calendars_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_account_idx": {
+          "name": "calendars_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_account_external_idx": {
+          "name": "calendars_account_external_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_watch_channel_idx": {
+          "name": "calendars_watch_channel_idx",
+          "columns": [
+            {
+              "expression": "watch_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendars_watch_expires_idx": {
+          "name": "calendars_watch_expires_idx",
+          "columns": [
+            {
+              "expression": "watch_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendars_account_id_calendar_accounts_id_fk": {
+          "name": "calendars_account_id_calendar_accounts_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "calendar_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendars_user_id_users_id_fk": {
+          "name": "calendars_user_id_users_id_fk",
+          "tableFrom": "calendars",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idea_boards": {
+      "name": "idea_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Lightbulb'"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6366F1'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idea_boards_user_idx": {
+          "name": "idea_boards_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idea_boards_user_id_users_id_fk": {
+          "name": "idea_boards_user_id_users_id_fk",
+          "tableFrom": "idea_boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idea_columns": {
+      "name": "idea_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idea_columns_board_idx": {
+          "name": "idea_columns_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idea_columns_user_idx": {
+          "name": "idea_columns_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idea_columns_user_id_users_id_fk": {
+          "name": "idea_columns_user_id_users_id_fk",
+          "tableFrom": "idea_columns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idea_columns_board_id_idea_boards_id_fk": {
+          "name": "idea_columns_board_id_idea_boards_id_fk",
+          "tableFrom": "idea_columns",
+          "tableTo": "idea_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idea_subtasks": {
+      "name": "idea_subtasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idea_id": {
+          "name": "idea_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idea_subtasks_idea_id_idx": {
+          "name": "idea_subtasks_idea_id_idx",
+          "columns": [
+            {
+              "expression": "idea_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idea_subtasks_idea_id_ideas_id_fk": {
+          "name": "idea_subtasks_idea_id_ideas_id_fk",
+          "tableFrom": "idea_subtasks",
+          "tableTo": "ideas",
+          "columnsFrom": [
+            "idea_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ideas": {
+      "name": "ideas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_task_id": {
+          "name": "promoted_task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ideas_column_idx": {
+          "name": "ideas_column_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ideas_board_idx": {
+          "name": "ideas_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ideas_user_idx": {
+          "name": "ideas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ideas_user_id_users_id_fk": {
+          "name": "ideas_user_id_users_id_fk",
+          "tableFrom": "ideas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ideas_board_id_idea_boards_id_fk": {
+          "name": "ideas_board_id_idea_boards_id_fk",
+          "tableFrom": "ideas",
+          "tableTo": "idea_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ideas_column_id_idea_columns_id_fk": {
+          "name": "ideas_column_id_idea_columns_id_fk",
+          "tableFrom": "ideas",
+          "tableTo": "idea_columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ideas_promoted_task_id_tasks_id_fk": {
+          "name": "ideas_promoted_task_id_tasks_id_fk",
+          "tableFrom": "ideas",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "promoted_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_reminders_enabled": {
+          "name": "task_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_timing": {
+          "name": "reminder_timing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "email_notifications_enabled": {
+          "name": "email_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_summary_enabled": {
+          "name": "daily_summary_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "push_notifications_enabled": {
+          "name": "push_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rollover_destination": {
+          "name": "rollover_destination",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "rollover_position": {
+          "name": "rollover_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'top'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_user_id_unique": {
+          "name": "notification_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_states_state_idx": {
+          "name": "oauth_states_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_states_state_unique": {
+          "name": "oauth_states_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh_key": {
+          "name": "p256dh_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_time": {
+          "name": "expiration_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.releases": {
+      "name": "releases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updater_url": {
+          "name": "updater_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_notes": {
+          "name": "release_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollover_logs": {
+      "name": "rollover_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_date": {
+          "name": "rollover_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_processed": {
+          "name": "users_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tasks_rolled_over": {
+          "name": "tasks_rolled_over",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rollover_logs_tz_date_idx": {
+          "name": "rollover_logs_tz_date_idx",
+          "columns": [
+            {
+              "expression": "timezone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rollover_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtasks": {
+      "name": "subtasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtasks_task_id_idx": {
+          "name": "subtasks_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtasks_task_id_tasks_id_fk": {
+          "name": "subtasks_task_id_tasks_id_fk",
+          "tableFrom": "subtasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_series": {
+      "name": "task_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_mins": {
+          "name": "estimated_mins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'P2'"
+        },
+        "recurrence_type": {
+          "name": "recurrence_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "week_of_month": {
+          "name": "week_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week_monthly": {
+          "name": "day_of_week_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generated_date": {
+          "name": "last_generated_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_series_user_active_idx": {
+          "name": "task_series_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"task_series\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_series_generation_idx": {
+          "name": "task_series_generation_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_generated_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_series_user_id_users_id_fk": {
+          "name": "task_series_user_id_users_id_fk",
+          "tableFrom": "task_series",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_mins": {
+          "name": "estimated_mins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_mins": {
+          "name": "actual_mins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'P2'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subtasks_hidden": {
+          "name": "subtasks_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_instance_number": {
+          "name": "series_instance_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timer_started_at": {
+          "name": "timer_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timer_accumulated_seconds": {
+          "name": "timer_accumulated_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_user_scheduled_incomplete_idx": {
+          "name": "tasks_user_scheduled_incomplete_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"completed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_series_idx": {
+          "name": "tasks_series_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_series_date_unique_idx": {
+          "name": "tasks_series_date_unique_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tasks\".\"series_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_active_timer_idx": {
+          "name": "tasks_active_timer_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"tasks\".\"timer_started_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_series_id_task_series_id_fk": {
+          "name": "tasks_series_id_task_series_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "task_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_blocks": {
+      "name": "time_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_mins": {
+          "name": "duration_mins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#3B82F6'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "time_blocks_user_date_idx": {
+          "name": "time_blocks_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_blocks_task_id_idx": {
+          "name": "time_blocks_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_blocks_user_id_users_id_fk": {
+          "name": "time_blocks_user_id_users_id_fk",
+          "tableFrom": "time_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_blocks_task_id_tasks_id_fk": {
+          "name": "time_blocks_task_id_tasks_id_fk",
+          "tableFrom": "time_blocks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "password_reset_token": {
+          "name": "password_reset_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_reset_expires": {
+          "name": "password_reset_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1782785595597,
       "tag": "0013_chubby_wraith",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1782792785793,
+      "tag": "0014_loud_random",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/idea-subtasks.ts
+++ b/packages/database/src/schema/idea-subtasks.ts
@@ -1,0 +1,53 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  boolean,
+  integer,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { ideas } from "./ideas";
+
+/** Checklist items under an idea card — mirrors the task `subtasks` table. */
+export const ideaSubtasks = pgTable(
+  "idea_subtasks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    ideaId: uuid("idea_id")
+      .notNull()
+      .references(() => ideas.id, { onDelete: "cascade" }),
+    title: varchar("title", { length: 500 }).notNull(),
+    completed: boolean("completed").notNull().default(false),
+    position: integer("position").notNull().default(0),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    ideaIdIdx: index("idea_subtasks_idea_id_idx").on(table.ideaId),
+  })
+);
+
+export const ideaSubtasksRelations = relations(ideaSubtasks, ({ one }) => ({
+  idea: one(ideas, {
+    fields: [ideaSubtasks.ideaId],
+    references: [ideas.id],
+  }),
+}));
+
+export const insertIdeaSubtaskSchema = createInsertSchema(ideaSubtasks, {
+  title: z.string().min(1, "Title is required").max(500),
+  completed: z.boolean().optional(),
+  position: z.number().int().nonnegative().optional(),
+});
+export const selectIdeaSubtaskSchema = createSelectSchema(ideaSubtasks);
+export const updateIdeaSubtaskSchema = insertIdeaSubtaskSchema
+  .partial()
+  .omit({ ideaId: true });
+
+export type IdeaSubtask = typeof ideaSubtasks.$inferSelect;
+export type NewIdeaSubtask = typeof ideaSubtasks.$inferInsert;
+export type UpdateIdeaSubtask = z.infer<typeof updateIdeaSubtaskSchema>;

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -200,5 +200,18 @@ export type {
   UpdateIdea,
 } from "./ideas";
 
+export {
+  ideaSubtasks,
+  ideaSubtasksRelations,
+  insertIdeaSubtaskSchema,
+  selectIdeaSubtaskSchema,
+  updateIdeaSubtaskSchema,
+} from "./idea-subtasks";
+export type {
+  IdeaSubtask,
+  NewIdeaSubtask,
+  UpdateIdeaSubtask,
+} from "./idea-subtasks";
+
 // Re-export relation helpers for query building
 export { relations } from "drizzle-orm";

--- a/packages/types/src/idea.ts
+++ b/packages/types/src/idea.ts
@@ -48,6 +48,9 @@ export interface Idea {
   promotedTaskId: string | null;
   createdAt: Date;
   updatedAt: Date;
+  /** Subtask totals, included by the list endpoint for the card badge. */
+  subtaskCount?: number;
+  subtaskDoneCount?: number;
 }
 
 // ───────────────────────── inputs ─────────────────────────
@@ -124,4 +127,32 @@ export interface IdeaFilterInput {
   boardId?: string;
   columnId?: string;
   completed?: boolean;
+}
+
+// ───────────────────────── idea subtasks ─────────────────────────
+
+/** A checklist item under an idea card. */
+export interface IdeaSubtask {
+  id: string;
+  ideaId: string;
+  title: string;
+  completed: boolean;
+  position: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateIdeaSubtaskInput {
+  title: string;
+  position?: number;
+}
+
+export interface UpdateIdeaSubtaskInput {
+  title?: string;
+  completed?: boolean;
+  position?: number;
+}
+
+export interface ReorderIdeaSubtasksInput {
+  subtaskIds: string[];
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -176,4 +176,8 @@ export type {
   ReorderIdeaBoardsInput,
   PromoteIdeaInput,
   IdeaFilterInput,
+  IdeaSubtask,
+  CreateIdeaSubtaskInput,
+  UpdateIdeaSubtaskInput,
+  ReorderIdeaSubtasksInput,
 } from "./idea.js";


### PR DESCRIPTION
Addresses the reported parity gaps with tasks.

## Fixes
1. **Right-click works** — idea cards now have a Radix `ContextMenu` (same items as the ⋯ menu, shared via one render path).
2. **Send into Board / Tasks** — promote redesigned to **Add to Today** (creates a task scheduled today → shows on the Board) and **Send to Backlog** (unscheduled task), plus **Schedule → Tomorrow / Next week**. (Board = scheduled today/future, Backlog = unscheduled.)
3. **Subtasks** — full vertical cloned from the task subtasks system: `idea_subtasks` table (migration **0014**), types, validation, `/ideas/:ideaId/subtasks` routes, api-client sub-API, optimistic hooks, websocket sync. Subtask totals are returned on the ideas list for the card badge (no per-card N+1).
4. **Richer editor** — the edit dialog now mirrors the task modal: completion checkbox + title (save on blur), **live sortable subtasks**, rich-text notes (save on close). The Add modal also gained a subtasks section.

## ⚠️ Migration
Ships `0014_loud_random.sql` (creates `idea_subtasks`). **Must be applied to the prod DB before this deploys**, or the subtasks endpoints 500. Additive/idempotent.

## Verification
✅ Full-repo typecheck (13/13) · web build · lint clean (new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)