### PR TITLE
fix: editor images, board DnD UX, and real undo/redo

### DIFF
--- a/apps/web/src/components/global-shortcuts-handler.tsx
+++ b/apps/web/src/components/global-shortcuts-handler.tsx
@@ -6,7 +6,7 @@ import {
   useShortcutsModal,
 } from "@/hooks/useKeyboardShortcuts";
 import { useSearch } from "@/hooks/useSearch";
-import { toast } from "@/hooks/use-toast";
+import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { prefetchCommandPalette } from "@/components/command-palette/command-palette.lazy";
 import { prefetchShortcutsModal } from "@/components/ui/shortcuts-modal.lazy";
 
@@ -22,6 +22,7 @@ interface GlobalShortcutsHandlerProps {
 export function GlobalShortcutsHandler({ onAddTask }: GlobalShortcutsHandlerProps) {
   const { setShowShortcutsModal } = useShortcutsModal();
   const { openSearch } = useSearch();
+  const { undo, redo } = useUndoRedo();
 
   React.useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -53,18 +54,24 @@ export function GlobalShortcutsHandler({ onAddTask }: GlobalShortcutsHandlerProp
         return;
       }
 
+      // Redo (Cmd+Shift+Z) — checked before undo since undo requires no shift
+      if (SHORTCUTS.redo && matchesShortcut(event, SHORTCUTS.redo)) {
+        event.preventDefault();
+        redo();
+        return;
+      }
+
       // Undo (Cmd+Z)
       if (SHORTCUTS.undo && matchesShortcut(event, SHORTCUTS.undo)) {
         event.preventDefault();
-        // TODO: Implement command history for actual undo functionality
-        toast({ title: "No commands to undo" });
+        undo();
         return;
       }
     }
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [setShowShortcutsModal, openSearch, onAddTask]);
+  }, [setShowShortcutsModal, openSearch, onAddTask, undo, redo]);
 
   return null; // This component renders nothing
 }

--- a/apps/web/src/components/ideas/idea-card.tsx
+++ b/apps/web/src/components/ideas/idea-card.tsx
@@ -184,10 +184,31 @@ export function IdeaCard({ idea, boardId, columns, overlay }: IdeaCardProps) {
   const style: React.CSSProperties = overlay
     ? {}
     : {
-        transform: CSS.Translate.toString(sortable.transform),
+        transform: CSS.Transform.toString(sortable.transform),
         transition: sortable.transition,
-        opacity: sortable.isDragging ? 0.4 : undefined,
       };
+
+  // Show a crisp drop-indicator line only on the card currently being hovered
+  // during a drag (matches the kanban task card) — not a persistent gap.
+  const showIndicator = sortable.isOver && sortable.active?.id !== idea.id;
+  let showDropAbove = false;
+  let showDropBelow = false;
+  if (showIndicator) {
+    const activeColumn = sortable.active?.data?.current?.columnId as
+      | string
+      | undefined;
+    if (activeColumn !== idea.columnId) {
+      // Cross-column drop inserts before the hovered card.
+      showDropAbove = true;
+    } else {
+      const activeIndex =
+        (sortable.active?.data?.current?.sortable?.index as
+          | number
+          | undefined) ?? -1;
+      showDropAbove = activeIndex > sortable.index;
+      showDropBelow = activeIndex < sortable.index && activeIndex !== -1;
+    }
+  }
 
   const toggleComplete = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -245,9 +266,18 @@ export function IdeaCard({ idea, boardId, columns, overlay }: IdeaCardProps) {
         "cursor-grab active:cursor-grabbing touch-none select-none",
         overlay &&
           "shadow-xl ring-2 ring-primary/20 rotate-[0.5deg] cursor-grabbing",
+        !overlay && sortable.isDragging && "opacity-30 z-50",
         isCompleted && "opacity-50 hover:opacity-60 bg-card/50"
       )}
     >
+      {/* Drop indicator lines (only on the hovered card during a drag) */}
+      {showDropAbove && (
+        <div className="absolute -top-1 left-0 right-0 z-10 h-0.5 rounded-full bg-primary" />
+      )}
+      {showDropBelow && (
+        <div className="absolute -bottom-1 left-0 right-0 z-10 h-0.5 rounded-full bg-primary" />
+      )}
+
       {/* Main row: checkbox + title */}
       <div className="flex items-start gap-2">
         <div

--- a/apps/web/src/components/ideas/idea-card.tsx
+++ b/apps/web/src/components/ideas/idea-card.tsx
@@ -279,7 +279,7 @@ export function IdeaCard({ idea, boardId, columns, overlay }: IdeaCardProps) {
       {hasNotes && !isCompleted && (
         <HtmlContent
           html={idea.notes!}
-          className="pl-6 text-xs leading-snug text-muted-foreground line-clamp-2 [&_p]:m-0"
+          className="pl-6 text-xs leading-snug text-muted-foreground line-clamp-2 [&_p]:m-0 [&_img]:hidden"
         />
       )}
 

--- a/apps/web/src/components/ideas/idea-column.tsx
+++ b/apps/web/src/components/ideas/idea-column.tsx
@@ -106,7 +106,7 @@ export function IdeaColumnView({
               {...attributes}
               {...listeners}
               aria-label="Drag to reorder column"
-              className="-ml-0.5 cursor-grab touch-none text-muted-foreground/30 transition-colors hover:text-muted-foreground active:cursor-grabbing"
+              className="-ml-0.5 cursor-grab touch-none text-muted-foreground opacity-0 transition-opacity group-hover/col:opacity-100 active:cursor-grabbing"
             >
               <GripVertical className="h-4 w-4" />
             </button>

--- a/apps/web/src/components/ideas/ideas-board-view.tsx
+++ b/apps/web/src/components/ideas/ideas-board-view.tsx
@@ -16,6 +16,7 @@ import {
   sortableKeyboardCoordinates,
   arrayMove,
 } from "@dnd-kit/sortable";
+import { snapCenterToCursor } from "@dnd-kit/modifiers";
 import { Plus, Loader2 } from "lucide-react";
 import type { Idea, IdeaColumn } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
@@ -231,7 +232,10 @@ export function IdeasBoardView({ boardId }: IdeasBoardViewProps) {
         )}
       </div>
 
-      <DragOverlay>
+      <DragOverlay
+        dropAnimation={null}
+        modifiers={activeIdea ? [snapCenterToCursor] : undefined}
+      >
         {activeIdea ? (
           <div className="w-[252px]">
             <IdeaCard

--- a/apps/web/src/components/ideas/ideas-board-view.tsx
+++ b/apps/web/src/components/ideas/ideas-board-view.tsx
@@ -17,7 +17,7 @@ import {
   arrayMove,
 } from "@dnd-kit/sortable";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
-import { Plus, Loader2 } from "lucide-react";
+import { Plus, Loader2, GripVertical } from "lucide-react";
 import type { Idea, IdeaColumn } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui";
@@ -246,14 +246,39 @@ export function IdeasBoardView({ boardId }: IdeasBoardViewProps) {
             />
           </div>
         ) : activeColumn ? (
-          <div className="w-[272px] rotate-[1deg] rounded-xl border border-primary/30 bg-muted/90 p-2.5 shadow-xl ring-2 ring-primary/20">
+          // Drag preview of the whole column (header + its cards), rotated +
+          // elevated. Cards are static (non-interactive) clones to avoid
+          // registering duplicate sortable ids during the column drag.
+          <div className="flex w-[272px] rotate-[2deg] flex-col gap-2 rounded-xl border border-primary/40 bg-muted/95 p-2.5 shadow-xl ring-2 ring-primary/20">
             <div className="flex items-center gap-2 px-1">
+              <GripVertical className="h-4 w-4 text-muted-foreground" />
               <span className="text-[13px] font-semibold">
                 {activeColumn.name}
               </span>
               <span className="grid h-[18px] min-w-[20px] place-items-center rounded-full border border-border/60 bg-background px-1.5 text-[11px] font-medium tabular-nums text-muted-foreground">
-                {ideasByColumn.get(activeColumn.id)?.length ?? 0}
+                {(ideasByColumn.get(activeColumn.id) ?? []).length}
               </span>
+            </div>
+            <div className="flex max-h-[440px] flex-col gap-2 overflow-hidden">
+              {(ideasByColumn.get(activeColumn.id) ?? []).map((idea) => (
+                <div
+                  key={idea.id}
+                  className="rounded-lg border border-border/40 bg-card px-3 py-2.5 shadow-sm"
+                >
+                  <div className="flex items-start gap-2">
+                    <span className="mt-0.5 h-4 w-4 shrink-0 rounded-full border-[1.5px] border-muted-foreground/40" />
+                    <p
+                      className={cn(
+                        "min-w-0 flex-1 text-sm leading-snug line-clamp-2",
+                        idea.completedAt &&
+                          "text-muted-foreground line-through"
+                      )}
+                    >
+                      {idea.title}
+                    </p>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         ) : null}

--- a/apps/web/src/components/kanban/task-card.tsx
+++ b/apps/web/src/components/kanban/task-card.tsx
@@ -58,7 +58,6 @@ export function SortableTaskCard({
     isOver,
     active,
     index,
-    setActivatorNodeRef,
   } = useSortable({
     id: task.id,
     data: {
@@ -136,6 +135,7 @@ export function SortableTaskCard({
         {...attributes}
         {...listeners}
         onClick={handleClick}
+        data-task-id={task.id}
         className={cn("relative", isCurrentlyDragging && "opacity-30 z-50")}
       >
         {/* Drop indicator line - above */}

--- a/apps/web/src/components/ui/file-upload-node.tsx
+++ b/apps/web/src/components/ui/file-upload-node.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { Download, X, FileText, Play, Loader2 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, resolveUploadUrl } from "@/lib/utils";
 import { formatFileSize, getFileIcon } from "@/hooks/useUploadAttachment";
 
 /**
@@ -34,7 +34,7 @@ export function ImageNodeView({ node, deleteNode, selected }: NodeViewProps) {
           </div>
         ) : (
           <img
-            src={src}
+            src={resolveUploadUrl(src) ?? src}
             alt={alt || ""}
             title={title || ""}
             className="max-w-full h-auto rounded-lg"
@@ -96,7 +96,7 @@ export function VideoNodeView({ node, deleteNode, selected }: NodeViewProps) {
         ) : (
           <video
             ref={videoRef}
-            src={src}
+            src={resolveUploadUrl(src) ?? src}
             title={title || ""}
             controls
             className="max-w-full rounded-lg"
@@ -135,7 +135,7 @@ export function FileAttachmentNodeView({ node, deleteNode, selected }: NodeViewP
 
   const handleDownload = () => {
     // Open in new tab / trigger download
-    window.open(src, "_blank");
+    window.open(resolveUploadUrl(src) ?? src, "_blank");
   };
 
   return (

--- a/apps/web/src/components/ui/html-content.tsx
+++ b/apps/web/src/components/ui/html-content.tsx
@@ -2,7 +2,7 @@
 
 import DOMPurify from "dompurify";
 import { useMemo } from "react";
-import { cn } from "@/lib/utils";
+import { cn, resolveUploadUrl } from "@/lib/utils";
 
 interface HtmlContentProps {
   html: string;
@@ -12,14 +12,20 @@ interface HtmlContentProps {
 export function HtmlContent({ html, className }: HtmlContentProps) {
   const sanitizedHtml = useMemo(() => {
     if (!html) return null;
-    return DOMPurify.sanitize(html, {
+    const clean = DOMPurify.sanitize(html, {
       ALLOWED_TAGS: [
         "p", "br", "strong", "b", "em", "i", "u", "s", "a",
-        "ul", "ol", "li", "blockquote", "pre", "code", "span", "div",
+        "ul", "ol", "li", "blockquote", "pre", "code", "span", "div", "img",
       ],
-      ALLOWED_ATTR: ["href", "target", "rel", "class"],
+      ALLOWED_ATTR: ["href", "target", "rel", "class", "src", "alt", "title"],
       ADD_ATTR: ["target"],
     });
+    // Uploads are stored as relative proxy paths — resolve to the API origin
+    // so <img> tags actually load when rendered on the frontend domain.
+    return clean.replace(
+      /src="(\/uploads\/[^"]*)"/g,
+      (_m, p1) => `src="${resolveUploadUrl(p1)}"`
+    );
   }, [html]);
 
   if (!sanitizedHtml) {

--- a/apps/web/src/hooks/useKeyboardShortcuts.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.tsx
@@ -122,6 +122,12 @@ export const SHORTCUTS: Record<string, ShortcutDefinition> = {
     description: "Undo last action",
     category: "general",
   },
+  redo: {
+    key: "z",
+    modifiers: { cmd: true, shift: true },
+    description: "Redo last action",
+    category: "general",
+  },
   // Focus Mode shortcuts
   toggleFocusTimer: {
     key: " ",

--- a/apps/web/src/hooks/useKeyboardShortcuts.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import type { Task } from "@open-sunsama/types";
+import { taskKeys } from "@/lib/query-keys";
 
 export interface ShortcutDefinition {
   key: string;
@@ -261,6 +263,65 @@ export function HoveredTaskProvider({
   const [hoveredSubtaskId, setHoveredSubtaskId] = React.useState<string | null>(
     null
   );
+  const queryClient = useQueryClient();
+  const lastCursor = React.useRef<{ x: number; y: number } | null>(null);
+
+  // Track the cursor so we can recompute the hovered card without a mouse move.
+  React.useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      lastCursor.current = { x: e.clientX, y: e.clientY };
+    };
+    document.addEventListener("mousemove", onMove, { passive: true });
+    return () => document.removeEventListener("mousemove", onMove);
+  }, []);
+
+  // Recompute which task card sits under the cursor, reading the fresh task
+  // object from the query cache. Used after a shortcut moves/removes a card:
+  // the DOM under a stationary cursor changes but no mouseenter fires, so the
+  // hovered target would otherwise go stale and the next shortcut would no-op.
+  const recomputeHoveredFromCursor = React.useCallback(() => {
+    const cur = lastCursor.current;
+    if (!cur) return;
+    const el = document.elementFromPoint(cur.x, cur.y);
+    const card =
+      el && "closest" in el
+        ? (el as Element).closest<HTMLElement>("[data-task-id]")
+        : null;
+    const id = card?.dataset.taskId ?? null;
+    if (!id) {
+      setHoveredTask((prev) => (prev ? null : prev));
+      return;
+    }
+    let next: Task | null = null;
+    const lists = queryClient.getQueriesData<Task[]>({
+      queryKey: taskKeys.lists(),
+    });
+    for (const [, data] of lists) {
+      const found = data?.find((t) => t.id === id);
+      if (found) {
+        next = found;
+        break;
+      }
+    }
+    setHoveredTask((prev) => (prev?.id === next?.id && prev === next ? prev : next));
+    setHoveredSubtaskId(null);
+  }, [queryClient]);
+
+  // Re-evaluate the hovered card whenever the task lists change (e.g. a
+  // shortcut completed/deferred/deleted a card), coalesced to one per frame.
+  React.useEffect(() => {
+    let raf = 0;
+    const unsub = queryClient.getQueryCache().subscribe((event) => {
+      const key = event?.query?.queryKey as unknown[] | undefined;
+      if (!key || key[0] !== "tasks" || key[1] !== "list") return;
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(recomputeHoveredFromCursor);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      unsub();
+    };
+  }, [queryClient, recomputeHoveredFromCursor]);
 
   const value = React.useMemo(
     () => ({

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import type {
   Task,
   CreateTaskInput,
@@ -9,7 +14,15 @@ import type {
 import { getApi } from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
+import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { taskKeys, timeBlockKeys } from "@/lib/query-keys";
+
+/** Refetch the task-related caches after an undo/redo applies a raw change. */
+function invalidateTaskCaches(qc: QueryClient) {
+  qc.invalidateQueries({ queryKey: taskKeys.lists() });
+  qc.invalidateQueries({ queryKey: ["tasks", "search", "infinite"] });
+  qc.invalidateQueries({ queryKey: timeBlockKeys.lists() });
+}
 
 // Canonical task keys live in lib/query-keys so the WebSocket listener
 // (mounted at the app shell) can import only the keys without dragging
@@ -174,6 +187,7 @@ export function useTask(id: string) {
  */
 export function useCreateTask() {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
 
   return useMutation({
     mutationFn: async (data: CreateTaskInput): Promise<Task> => {
@@ -275,7 +289,7 @@ export function useCreateTask() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSuccess: (newTask, _data, context) => {
+    onSuccess: (newTask, input, context) => {
       // Replace optimistic placeholder with real server task.
       if (context?.tempId) {
         queryClient.removeQueries({
@@ -301,6 +315,26 @@ export function useCreateTask() {
         queryKey: ["tasks", "search", "infinite"],
       });
 
+      // Undo a create by deleting it; redo re-creates. The id can change
+      // across redo, so track it in a holder.
+      try {
+        const holder = { id: newTask.id };
+        record({
+          label: "Create task",
+          undo: async () => {
+            await getApi().tasks.delete(holder.id);
+            invalidateTaskCaches(queryClient);
+          },
+          redo: async () => {
+            const recreated = await getApi().tasks.create(input);
+            holder.id = recreated.id;
+            invalidateTaskCaches(queryClient);
+          },
+        });
+      } catch {
+        // never let history bookkeeping break task creation
+      }
+
       toast({
         title: "Task created",
         description: `"${newTask.title}" has been created.`,
@@ -314,6 +348,7 @@ export function useCreateTask() {
  */
 export function useUpdateTask() {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
 
   return useMutation({
     mutationFn: async ({
@@ -401,7 +436,7 @@ export function useUpdateTask() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSuccess: (updatedTask) => {
+    onSuccess: (updatedTask, variables, context) => {
       // Update with actual server data. We deliberately do not invalidate
       // lists here — the optimistic update + this setQueryData already
       // produces the canonical state, and the WebSocket echo will reconcile
@@ -414,6 +449,50 @@ export function useUpdateTask() {
           return old.map((t) => (t.id === updatedTask.id ? updatedTask : t));
         }
       );
+
+      // Record an undo that restores the previous values of the changed
+      // fields. We read the pre-mutation task from the snapshot captured in
+      // onMutate.
+      try {
+        const prev =
+          context?.previousTask ??
+          context?.previousQueries
+            ?.map(([, list]) => list?.find((t) => t.id === variables.id))
+            .find((t): t is Task => t !== undefined);
+        const dataRec = variables.data as unknown as Record<string, unknown>;
+        const changedKeys = Object.keys(dataRec).filter(
+          (k) => dataRec[k] !== undefined
+        );
+        if (prev && changedKeys.length > 0) {
+          const prevRec = prev as unknown as Record<string, unknown>;
+          const prevPatch: Record<string, unknown> = {};
+          const nextPatch: Record<string, unknown> = {};
+          for (const k of changedKeys) {
+            prevPatch[k] = prevRec[k] ?? null;
+            nextPatch[k] = dataRec[k];
+          }
+          const id = variables.id;
+          const label =
+            changedKeys.length === 1 && changedKeys[0] === "scheduledDate"
+              ? "Move task"
+              : changedKeys.length === 1 && changedKeys[0] === "priority"
+                ? "Change priority"
+                : "Edit task";
+          record({
+            label,
+            undo: async () => {
+              await getApi().tasks.update(id, prevPatch as UpdateTaskInput);
+              invalidateTaskCaches(queryClient);
+            },
+            redo: async () => {
+              await getApi().tasks.update(id, nextPatch as UpdateTaskInput);
+              invalidateTaskCaches(queryClient);
+            },
+          });
+        }
+      } catch {
+        // history bookkeeping must never break the update
+      }
     },
   });
 }
@@ -423,6 +502,7 @@ export function useUpdateTask() {
  */
 export function useDeleteTask() {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
 
   return useMutation({
     mutationFn: async (id: string): Promise<string> => {
@@ -490,11 +570,46 @@ export function useDeleteTask() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSuccess: () => {
+    onSuccess: (_deletedId, id, context) => {
       // Time blocks may reference this task (calendar shows the title);
       // a single targeted invalidation keeps the calendar honest. The WS
       // echo also covers cross-device.
       queryClient.invalidateQueries({ queryKey: timeBlockKeys.lists() });
+
+      // Undo a delete by recreating the task from the snapshot. The recreated
+      // task gets a new id (subtasks/attachments are not restored), tracked in
+      // a holder so redo deletes the right one.
+      try {
+        const task =
+          context?.previousDetail ??
+          context?.previousQueries
+            ?.map(([, list]) => list?.find((t) => t.id === id))
+            .find((t): t is Task => t !== undefined);
+        if (task) {
+          const holder = { id: task.id };
+          record({
+            label: "Delete task",
+            undo: async () => {
+              const recreated = await getApi().tasks.create({
+                title: task.title,
+                notes: task.notes ?? undefined,
+                scheduledDate: task.scheduledDate ?? undefined,
+                estimatedMins: task.estimatedMins ?? undefined,
+                priority: task.priority,
+              });
+              holder.id = recreated.id;
+              invalidateTaskCaches(queryClient);
+            },
+            redo: async () => {
+              await getApi().tasks.delete(holder.id);
+              invalidateTaskCaches(queryClient);
+            },
+          });
+        }
+      } catch {
+        // history bookkeeping must never break delete
+      }
+
       toast({
         title: "Task deleted",
         description: "The task has been deleted.",
@@ -509,6 +624,7 @@ export function useDeleteTask() {
  */
 export function useCompleteTask() {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
 
   return useMutation({
     mutationFn: async ({
@@ -616,7 +732,7 @@ export function useCompleteTask() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSuccess: (updatedTask) => {
+    onSuccess: (updatedTask, variables) => {
       queryClient.setQueryData(taskKeys.detail(updatedTask.id), updatedTask);
       queryClient.setQueriesData<Task[]>(
         { queryKey: taskKeys.lists() },
@@ -647,6 +763,28 @@ export function useCompleteTask() {
           };
         }
       );
+
+      // Undo toggles completion back.
+      try {
+        const { id, completed } = variables;
+        record({
+          label: completed ? "Complete task" : "Uncomplete task",
+          undo: async () => {
+            const api = getApi();
+            if (completed) await api.tasks.uncomplete(id);
+            else await api.tasks.complete(id);
+            invalidateTaskCaches(queryClient);
+          },
+          redo: async () => {
+            const api = getApi();
+            if (completed) await api.tasks.complete(id);
+            else await api.tasks.uncomplete(id);
+            invalidateTaskCaches(queryClient);
+          },
+        });
+      } catch {
+        // history bookkeeping must never break completion
+      }
     },
   });
 }
@@ -755,6 +893,7 @@ export function useMoveTask() {
  */
 export function useReorderTasks() {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
 
   return useMutation({
     mutationFn: async ({
@@ -783,6 +922,19 @@ export function useReorderTasks() {
       const previousInfiniteQueries = queryClient.getQueriesData({
         queryKey: ["tasks", "search", "infinite"],
       });
+
+      // Capture the destination bucket's pending order *before* applying the
+      // reorder so undo can restore it exactly.
+      const prevDestOrder = (() => {
+        const entry = previousQueries.find(([key]) => {
+          const f = key[2] as ListFilter | undefined;
+          return isBacklog ? f?.backlog === true : f?.scheduledDate === date;
+        });
+        return (entry?.[1] ?? [])
+          .filter((t) => !t.completedAt)
+          .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+          .map((t) => t.id);
+      })();
 
       // Build a lookup of every task currently visible in any list cache so
       // we can resolve tasks that the destination cache may not yet know
@@ -899,6 +1051,7 @@ export function useReorderTasks() {
         previousInfiniteQueries,
         targetScheduledDate,
         taskIds,
+        prevDestOrder,
       };
     },
     onError: (error, _variables, context) => {
@@ -914,7 +1067,7 @@ export function useReorderTasks() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSuccess: (serverTasks, _variables, context) => {
+    onSuccess: (serverTasks, variables, context) => {
       // The server returns the canonical task list for the destination
       // bucket. Distribute it to every cache that classifies as a
       // destination for the target date / backlog, then update detail
@@ -938,6 +1091,29 @@ export function useReorderTasks() {
       });
       for (const t of serverTasks) {
         queryClient.setQueryData(taskKeys.detail(t.id), t);
+      }
+
+      // Undo a reorder by restoring the destination bucket's previous order.
+      // (Same-column reorders restore exactly; a cross-column move restores
+      // the destination order it had before the task arrived.)
+      try {
+        const { date, taskIds } = variables;
+        const prev = context?.prevDestOrder ?? [];
+        if (prev.length > 0) {
+          record({
+            label: "Reorder tasks",
+            undo: async () => {
+              await getApi().tasks.reorder({ date, taskIds: prev });
+              invalidateTaskCaches(queryClient);
+            },
+            redo: async () => {
+              await getApi().tasks.reorder({ date, taskIds });
+              invalidateTaskCaches(queryClient);
+            },
+          });
+        }
+      } catch {
+        // history bookkeeping must never break reorder
       }
     },
   });

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -795,6 +795,7 @@ export function useCompleteTask() {
  */
 export function useMoveTask() {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
 
   return useMutation({
     mutationFn: async ({
@@ -853,7 +854,10 @@ export function useMoveTask() {
         queryClient.setQueryData(taskKeys.detail(id), updatedTask);
       }
 
-      return { previousQueries };
+      return {
+        previousQueries,
+        previousScheduledDate: sourceTask?.scheduledDate ?? null,
+      };
     },
     onError: (_error, _variables, context) => {
       // Rollback all queries on error
@@ -866,7 +870,7 @@ export function useMoveTask() {
         description: _error instanceof Error ? _error.message : "Unknown error",
       });
     },
-    onSuccess: (movedTask) => {
+    onSuccess: (movedTask, variables, context) => {
       // Reconcile with the server-authoritative task. Importantly, this
       // populates the source/target lists with the canonical position the
       // server picked when only `targetDate` was provided.
@@ -878,6 +882,27 @@ export function useMoveTask() {
           return old.map((t) => (t.id === movedTask.id ? movedTask : t));
         }
       );
+
+      // Undo a move by sending the task back to its previous day.
+      try {
+        const { id, targetDate } = variables;
+        const prevDate = context?.previousScheduledDate ?? null;
+        if (prevDate !== targetDate) {
+          record({
+            label: "Move task",
+            undo: async () => {
+              await getApi().tasks.update(id, { scheduledDate: prevDate });
+              invalidateTaskCaches(queryClient);
+            },
+            redo: async () => {
+              await getApi().tasks.update(id, { scheduledDate: targetDate });
+              invalidateTaskCaches(queryClient);
+            },
+          });
+        }
+      } catch {
+        // history bookkeeping must never break a move
+      }
     },
   });
 }
@@ -923,18 +948,40 @@ export function useReorderTasks() {
         queryKey: ["tasks", "search", "infinite"],
       });
 
-      // Capture the destination bucket's pending order *before* applying the
-      // reorder so undo can restore it exactly.
-      const prevDestOrder = (() => {
+      // Capture the pending order of every bucket this reorder touches — the
+      // destination plus any source bucket a task is moving *out of* — so undo
+      // can restore them all. (A cross-day move otherwise wouldn't return the
+      // task to its original day.)
+      const orderForBucket = (bucketKey: string): string[] => {
         const entry = previousQueries.find(([key]) => {
           const f = key[2] as ListFilter | undefined;
-          return isBacklog ? f?.backlog === true : f?.scheduledDate === date;
+          return bucketKey === "backlog"
+            ? f?.backlog === true
+            : f?.scheduledDate === bucketKey;
         });
         return (entry?.[1] ?? [])
           .filter((t) => !t.completedAt)
           .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
           .map((t) => t.id);
-      })();
+      };
+      const prevBucketById = new Map<string, string>();
+      for (const [, list] of previousQueries) {
+        if (!list) continue;
+        for (const t of list) {
+          if (!prevBucketById.has(t.id)) {
+            prevBucketById.set(t.id, t.scheduledDate ?? "backlog");
+          }
+        }
+      }
+      const affectedBuckets = new Set<string>([date]);
+      for (const tid of taskIds) {
+        const src = prevBucketById.get(tid);
+        if (src && src !== date) affectedBuckets.add(src);
+      }
+      const prevBuckets: Record<string, string[]> = {};
+      for (const bucketKey of affectedBuckets) {
+        prevBuckets[bucketKey] = orderForBucket(bucketKey);
+      }
 
       // Build a lookup of every task currently visible in any list cache so
       // we can resolve tasks that the destination cache may not yet know
@@ -1051,7 +1098,7 @@ export function useReorderTasks() {
         previousInfiniteQueries,
         targetScheduledDate,
         taskIds,
-        prevDestOrder,
+        prevBuckets,
       };
     },
     onError: (error, _variables, context) => {
@@ -1093,17 +1140,24 @@ export function useReorderTasks() {
         queryClient.setQueryData(taskKeys.detail(t.id), t);
       }
 
-      // Undo a reorder by restoring the destination bucket's previous order.
-      // (Same-column reorders restore exactly; a cross-column move restores
-      // the destination order it had before the task arrived.)
+      // Undo by restoring the previous order of *every* bucket the reorder
+      // touched. For a within-day reorder that's just this day; for a
+      // cross-day move it's the destination day (minus the task) and the
+      // source day (with the task back in its old spot) — so the task
+      // actually returns to where it came from.
       try {
         const { date, taskIds } = variables;
-        const prev = context?.prevDestOrder ?? [];
-        if (prev.length > 0) {
+        const prevBuckets = context?.prevBuckets ?? {};
+        const buckets = Object.entries(prevBuckets).filter(
+          ([, order]) => order.length > 0
+        );
+        if (buckets.length > 0) {
           record({
-            label: "Reorder tasks",
+            label: buckets.length > 1 ? "Move task" : "Reorder tasks",
             undo: async () => {
-              await getApi().tasks.reorder({ date, taskIds: prev });
+              for (const [bucket, order] of buckets) {
+                await getApi().tasks.reorder({ date: bucket, taskIds: order });
+              }
               invalidateTaskCaches(queryClient);
             },
             redo: async () => {

--- a/apps/web/src/hooks/useUndoRedo.tsx
+++ b/apps/web/src/hooks/useUndoRedo.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+import { toast } from "@/hooks/use-toast";
+
+/**
+ * A single reversible action. `undo` reverts it, `redo` re-applies it. Both
+ * should be self-contained (call the API directly, not the recording mutation
+ * hooks) so running them never records new history entries.
+ */
+export interface UndoEntry {
+  label: string;
+  undo: () => void | Promise<void>;
+  redo: () => void | Promise<void>;
+}
+
+interface UndoRedoContextValue {
+  record: (entry: UndoEntry) => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+// No-op default so hooks that call useUndoRedo() outside the provider (e.g.
+// on a marketing page) don't throw and simply skip history.
+const NOOP: UndoRedoContextValue = {
+  record: () => {},
+  undo: () => {},
+  redo: () => {},
+};
+
+const UndoRedoContext = React.createContext<UndoRedoContextValue>(NOOP);
+
+const MAX_HISTORY = 100;
+
+export function UndoRedoProvider({ children }: { children: React.ReactNode }) {
+  const undoStack = React.useRef<UndoEntry[]>([]);
+  const redoStack = React.useRef<UndoEntry[]>([]);
+  const busy = React.useRef(false);
+
+  const record = React.useCallback((entry: UndoEntry) => {
+    // Don't capture history for the mutations triggered by undo/redo itself.
+    if (busy.current) return;
+    undoStack.current.push(entry);
+    if (undoStack.current.length > MAX_HISTORY) undoStack.current.shift();
+    // A fresh action invalidates the redo branch.
+    redoStack.current = [];
+  }, []);
+
+  const run = React.useCallback(
+    async (kind: "undo" | "redo") => {
+      if (busy.current) return;
+      const from = kind === "undo" ? undoStack : redoStack;
+      const to = kind === "undo" ? redoStack : undoStack;
+      const entry = from.current.pop();
+      if (!entry) {
+        toast({
+          title: kind === "undo" ? "Nothing to undo" : "Nothing to redo",
+        });
+        return;
+      }
+      busy.current = true;
+      try {
+        await (kind === "undo" ? entry.undo() : entry.redo());
+        to.current.push(entry);
+        toast({
+          title: kind === "undo" ? "Undone" : "Redone",
+          description: entry.label,
+        });
+      } catch (err) {
+        // Put it back so the user can retry, and surface the failure.
+        from.current.push(entry);
+        toast({
+          variant: "destructive",
+          title: kind === "undo" ? "Couldn't undo" : "Couldn't redo",
+          description: err instanceof Error ? err.message : "Unknown error",
+        });
+      } finally {
+        busy.current = false;
+      }
+    },
+    []
+  );
+
+  const undo = React.useCallback(() => {
+    void run("undo");
+  }, [run]);
+  const redo = React.useCallback(() => {
+    void run("redo");
+  }, [run]);
+
+  const value = React.useMemo(
+    () => ({ record, undo, redo }),
+    [record, undo, redo]
+  );
+
+  return (
+    <UndoRedoContext.Provider value={value}>
+      {children}
+    </UndoRedoContext.Provider>
+  );
+}
+
+export function useUndoRedo() {
+  return React.useContext(UndoRedoContext);
+}

--- a/apps/web/src/lib/dnd/tasks-dnd-context.tsx
+++ b/apps/web/src/lib/dnd/tasks-dnd-context.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   DndContext,
   DragOverlay,
-  PointerSensor,
+  MouseSensor,
   TouchSensor,
   KeyboardSensor,
   useSensor,
@@ -57,12 +57,14 @@ export function TasksDndProvider({ children }: TasksDndProviderProps) {
   const reorderTasks = useReorderTasks();
 
   // Drag and drop sensors with keyboard support for accessibility
-  // Using delay + distance to ensure clicks register before drag starts
+  // Mouse: distance-based so a drag starts the instant the pointer moves a
+  // few px — no hold delay — while a plain click (no movement) still opens
+  // the task. Touch: a short press-and-hold so vertical swipes still scroll
+  // the board on mobile instead of grabbing a card.
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: {
-        delay: 100,
-        tolerance: 5,
+        distance: 4,
       },
     }),
     useSensor(TouchSensor, {

--- a/apps/web/src/lib/dnd/tasks-dnd-context.tsx
+++ b/apps/web/src/lib/dnd/tasks-dnd-context.tsx
@@ -11,7 +11,6 @@ import {
   type DragStartEvent,
   type DragOverEvent,
   type DragEndEvent,
-  closestCenter,
 } from "@dnd-kit/core";
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
@@ -157,6 +156,33 @@ export function TasksDndProvider({ children }: TasksDndProviderProps) {
 
       const overId = String(over.id);
 
+      // Read a column's tasks from the cache regardless of which `limit` /
+      // filter the query was made with. Day columns cache under
+      // { scheduledDate, limit: 200 } and the backlog under
+      // { backlog: true, limit: 500 }, so a bare { scheduledDate } /
+      // { backlog } lookup missed — which silently broke reordering within a
+      // column (the dropped task's order never updated).
+      const getColumnTasks = (column: string): Task[] => {
+        const isBacklogCol = column === "backlog";
+        const entries = queryClient.getQueriesData<Task[]>({
+          queryKey: taskKeys.lists(),
+        });
+        const byId = new Map<string, Task>();
+        for (const [key, data] of entries) {
+          if (!data) continue;
+          const filters = (key as unknown[])[2] as
+            | { scheduledDate?: string | null; backlog?: boolean }
+            | undefined;
+          if (!filters) continue;
+          const match = isBacklogCol
+            ? filters.backlog === true
+            : filters.scheduledDate === column;
+          if (!match) continue;
+          for (const t of data) if (!byId.has(t.id)) byId.set(t.id, t);
+        }
+        return [...byId.values()];
+      };
+
       // Get source column from drag data
       // The columnId must be set in useSortable data for both task cards and backlog tasks
       const sourceColumn = String(
@@ -196,13 +222,8 @@ export function TasksDndProvider({ children }: TasksDndProviderProps) {
         const targetDate =
           destinationColumn === "backlog" ? "backlog" : destinationColumn;
 
-        // Get the destination column's tasks
-        const isDestBacklog = destinationColumn === "backlog";
-        const destQueryKey = isDestBacklog
-          ? taskKeys.list({ backlog: true })
-          : taskKeys.list({ scheduledDate: destinationColumn });
-
-        const destTasks = queryClient.getQueryData<Task[]>(destQueryKey);
+        // Get the destination column's tasks (cache-key-agnostic)
+        const destTasks = getColumnTasks(destinationColumn);
 
         // Build the new task order for the destination column
         // Filter to only pending tasks (not completed) and exclude the moving task
@@ -245,17 +266,11 @@ export function TasksDndProvider({ children }: TasksDndProviderProps) {
 
       // Same column but different position - reorder within column
       if (!columnChanged && overTask && !isSameTask) {
-        // Get all tasks in this column from the cache
+        // Get all tasks in this column from the cache (cache-key-agnostic)
         const isBacklog = sourceColumn === "backlog";
-        const queryKey = isBacklog
-          ? taskKeys.list({ backlog: true })
-          : taskKeys.list({
-              scheduledDate: sourceColumn,
-            });
+        const columnTasks = getColumnTasks(sourceColumn);
 
-        const columnTasks = queryClient.getQueryData<Task[]>(queryKey);
-
-        if (columnTasks) {
+        if (columnTasks.length) {
           // Sort by position to get current order
           const sortedTasks = [...columnTasks].sort(
             (a, b) => (a.position ?? 0) - (b.position ?? 0)

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -78,16 +78,22 @@ export function stripHtmlTags(html: string): string {
  * Avatar URLs are stored as relative paths (/uploads/...) which need the API base URL prepended
  */
 export function getAvatarUrl(avatarUrl: string | null | undefined): string | undefined {
-  if (!avatarUrl) return undefined;
+  return resolveUploadUrl(avatarUrl) ?? undefined;
+}
 
-  // If already a full URL, return as-is
-  if (avatarUrl.startsWith("http://") || avatarUrl.startsWith("https://")) {
-    return avatarUrl;
-  }
-
-  // Prepend API base URL for relative paths
+/**
+ * Resolve an upload URL for display. Uploads are stored as relative proxy
+ * paths (`/uploads/...`) served by the API, so relative paths need the API
+ * base URL prepended; absolute URLs and data URIs pass through unchanged.
+ */
+export function resolveUploadUrl(
+  url: string | null | undefined
+): string | null {
+  if (!url) return null;
+  if (/^(https?:|data:|blob:)/.test(url)) return url;
   const apiBaseUrl = import.meta.env.VITE_API_URL || "http://localhost:3001";
-  return `${apiBaseUrl}${avatarUrl}`;
+  if (url.startsWith("/uploads/")) return `${apiBaseUrl}${url}`;
+  return url;
 }
 
 // ============================================================================

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -12,6 +12,7 @@ import {
   useShortcutsModal,
 } from "@/hooks/useKeyboardShortcuts";
 import { SearchProvider, useSearch } from "@/hooks/useSearch";
+import { UndoRedoProvider } from "@/hooks/useUndoRedo";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import {
   ShortcutsModal,
@@ -89,7 +90,9 @@ export default function AppLayout() {
     <HoveredTaskProvider>
       <ShortcutsProvider>
         <SearchProvider>
-          <AppLayoutInner />
+          <UndoRedoProvider>
+            <AppLayoutInner />
+          </UndoRedoProvider>
         </SearchProvider>
       </ShortcutsProvider>
     </HoveredTaskProvider>


### PR DESCRIPTION
A batch of fixes on top of the Ideas feature (already merged via #62–#67).

### Editor
- **Image insert was broken in both task & idea editors** ("Failed to load image"). Uploads are stored as relative `/uploads/...` proxy paths served by the API; the editor inserted them as raw `<img src>` resolving against the frontend origin. Now resolved to the API base in the image/video/file node views and in `HtmlContent`.

### Board (kanban) drag & drop
- **Today-column reorder silently failed** — drag-end read the column's tasks with a query key missing `limit`, so `getQueryData` returned `undefined`. Now reads cache-key-agnostically.
- **Instant drag** — replaced the `delay`-based `PointerSensor` (forced a hold; quick flicks were cancelled) with `MouseSensor` (distance) + `TouchSensor` (delay for mobile scroll).
- **Stale hovered card after shortcuts** — after `C`/`D`/etc. the card under a stationary cursor changed but no `mouseenter` fired, so the next shortcut no-op'd. The hover target is now recomputed via `data-task-id` + `elementFromPoint` whenever task lists change.

### Undo / redo (was a stub)
- `Cmd+Z` / `Cmd+Shift+Z` now work, recorded inside the core task mutation hooks (create/update/complete/delete/reorder/move) so keyboard, menu, modal, and drag are all undoable.
- **Cross-day moves** restore the previous order of *every* affected bucket (source + destination), so undo actually returns the task to its day.

### Ideas board DnD polish (match the task card)
- Crisp **drop-indicator line** on the hovered card instead of a persistent gap; dragged original dimmed.
- `dropAnimation={null}` so the card no longer reverts-then-snaps on release.
- Column grip reveals on hover; column `DragOverlay` previews the **whole column** (static card clones, to avoid duplicate sortable ids).

These DnD lessons were also folded back into the `kanban-dnd` skill.

✅ Full-repo typecheck (13/13) · web build · lint clean. Frontend-only — no schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)