### PR TITLE
fix(board): drag UX polish (auto-scroll, ghost-drag, empty-column)

### DIFF
--- a/apps/web/src/components/ideas/idea-column.tsx
+++ b/apps/web/src/components/ideas/idea-column.tsx
@@ -25,6 +25,8 @@ interface IdeaColumnProps {
   ideas: Idea[];
   allColumns: IdeaColumnType[];
   canDelete: boolean;
+  /** True while a card is being dragged anywhere on the board. */
+  isDragActive: boolean;
 }
 
 export function IdeaColumnView({
@@ -33,6 +35,7 @@ export function IdeaColumnView({
   ideas,
   allColumns,
   canDelete,
+  isDragActive,
 }: IdeaColumnProps) {
   const [addOpen, setAddOpen] = React.useState(false);
   const [renaming, setRenaming] = React.useState(false);
@@ -163,11 +166,11 @@ export function IdeaColumnView({
           ))}
         </SortableContext>
 
-        {ideas.length === 0 && (
+        {/* Drop placeholder only appears during a drag — an idle empty column
+            takes up no space (just its "Add idea" button below). */}
+        {ideas.length === 0 && isDragActive && (
           <div className="rounded-lg border border-dashed border-border/60 px-2.5 py-4 text-center text-xs leading-relaxed text-muted-foreground">
-            Drag cards here,
-            <br />
-            or add a new one
+            Drop here
           </div>
         )}
       </div>

--- a/apps/web/src/components/ideas/ideas-board-view.tsx
+++ b/apps/web/src/components/ideas/ideas-board-view.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import {
   DndContext,
   DragOverlay,
-  PointerSensor,
-  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   closestCorners,
@@ -13,7 +13,6 @@ import {
 import {
   SortableContext,
   horizontalListSortingStrategy,
-  sortableKeyboardCoordinates,
   arrayMove,
 } from "@dnd-kit/sortable";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
@@ -53,12 +52,15 @@ export function IdeasBoardView({ boardId }: IdeasBoardViewProps) {
   const [addingColumn, setAddingColumn] = React.useState(false);
   const [columnDraft, setColumnDraft] = React.useState("");
 
+  // Mouse: instant distance-based drag; Touch: press-and-hold so swipes scroll.
+  // No KeyboardSensor — Space/Enter on a focused card would start an accidental
+  // keyboard drag (cards keep focus after a mouse drag).
   const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 5 },
+    useSensor(MouseSensor, {
+      activationConstraint: { distance: 4 },
     }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 8 },
     })
   );
 

--- a/apps/web/src/components/ideas/ideas-board-view.tsx
+++ b/apps/web/src/components/ideas/ideas-board-view.tsx
@@ -196,6 +196,7 @@ export function IdeasBoardView({ boardId }: IdeasBoardViewProps) {
               ideas={ideasByColumn.get(column.id) ?? []}
               allColumns={sortedColumns}
               canDelete={sortedColumns.length > 1}
+              isDragActive={!!activeIdea}
             />
           ))}
         </SortableContext>

--- a/apps/web/src/lib/dnd/tasks-dnd-context.tsx
+++ b/apps/web/src/lib/dnd/tasks-dnd-context.tsx
@@ -323,6 +323,11 @@ export function TasksDndProvider({ children }: TasksDndProviderProps) {
       <DndContext
         sensors={sensors}
         collisionDetection={taskPriorityCollision}
+        // Disable horizontal auto-scroll (threshold x:0) so reordering within a
+        // column never yanks the board sideways — the default ~20% edge zone is
+        // wide enough to cover the leftmost (Today) column. Keep vertical
+        // auto-scroll for dragging to the bottom of a long column.
+        autoScroll={{ threshold: { x: 0, y: 0.2 } }}
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}

--- a/apps/web/src/lib/dnd/tasks-dnd-context.tsx
+++ b/apps/web/src/lib/dnd/tasks-dnd-context.tsx
@@ -5,14 +5,13 @@ import {
   DragOverlay,
   MouseSensor,
   TouchSensor,
-  KeyboardSensor,
   useSensor,
   useSensors,
   type DragStartEvent,
   type DragOverEvent,
   type DragEndEvent,
 } from "@dnd-kit/core";
-import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { arrayMove } from "@dnd-kit/sortable";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
 import type { Task } from "@open-sunsama/types";
 import { useMoveTask, useReorderTasks, taskKeys } from "@/hooks/useTasks";
@@ -72,10 +71,12 @@ export function TasksDndProvider({ children }: TasksDndProviderProps) {
         delay: 200,
         tolerance: 8,
       },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
     })
+    // No KeyboardSensor on purpose: cards keep DOM focus after a mouse drag,
+    // and the KeyboardSensor treats Space/Enter on a focused card as "start
+    // dragging" — so pressing Enter (for another action) accidentally re-grabbed
+    // the card into a dragged state. Keyboard reordering is handled by the task
+    // shortcuts (move to top/bottom, defer, …) instead.
   );
 
   // Find target column from over ID


### PR DESCRIPTION
Three board drag-and-drop fixes:

1. **No horizontal auto-scroll within a column** — dnd-kit's default ~20% edge zone covered the leftmost (Today) column, so vertical reorders yanked the board sideways. Disabled horizontal auto-scroll (`threshold.x = 0`), kept vertical.
2. **Removed `KeyboardSensor`** — after a mouse drag the card keeps DOM focus, and the sensor treated Space/Enter as "start dragging", so pressing Enter for another action ghost-dragged the card. Keyboard reordering stays via the task shortcuts.
3. **Empty-column drop placeholder only during a drag** — the "Drag cards here" box no longer permanently reserves space on idle boards; empty columns collapse to just their "Add idea" button and show "Drop here" only while dragging.

✅ typecheck · lint · web build. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)