### PR TITLE
fix: move images in editor (not copy) + mobile column snap-scroll

### DIFF
--- a/apps/web/src/components/ideas/idea-column.tsx
+++ b/apps/web/src/components/ideas/idea-column.tsx
@@ -81,7 +81,7 @@ export function IdeaColumnView({
       ref={setNodeRef}
       style={style}
       className={cn(
-        "group/col flex w-[272px] shrink-0 flex-col gap-2 rounded-xl border border-border/60 bg-muted/40 p-2.5 transition-colors",
+        "group/col flex w-[272px] shrink-0 snap-start snap-always flex-col gap-2 rounded-xl border border-border/60 bg-muted/40 p-2.5 transition-colors",
         isOver && "border-primary/40 bg-primary/5"
       )}
     >

--- a/apps/web/src/components/ideas/ideas-board-view.tsx
+++ b/apps/web/src/components/ideas/ideas-board-view.tsx
@@ -183,7 +183,9 @@ export function IdeasBoardView({ boardId }: IdeasBoardViewProps) {
         setActiveColumn(null);
       }}
     >
-      <div className="flex flex-1 items-start gap-3.5 overflow-x-auto p-4">
+      {/* On mobile, snap each column into view while scrolling (Trello/Notion
+          style); free horizontal scroll from sm up. Matches the kanban board. */}
+      <div className="flex flex-1 items-start gap-3.5 overflow-x-auto p-4 snap-x snap-mandatory scroll-pl-4 sm:snap-none">
         <SortableContext
           items={columnIds}
           strategy={horizontalListSortingStrategy}
@@ -203,7 +205,7 @@ export function IdeasBoardView({ boardId }: IdeasBoardViewProps) {
 
         {/* Add column */}
         {addingColumn ? (
-          <div className="w-[272px] shrink-0 rounded-xl border border-border/60 bg-muted/40 p-2.5">
+          <div className="w-[272px] shrink-0 snap-start rounded-xl border border-border/60 bg-muted/40 p-2.5">
             <Input
               autoFocus
               value={columnDraft}
@@ -225,7 +227,7 @@ export function IdeasBoardView({ boardId }: IdeasBoardViewProps) {
           <button
             onClick={() => setAddingColumn(true)}
             className={cn(
-              "flex w-[272px] shrink-0 items-center gap-2 rounded-xl border border-dashed border-border/60 bg-transparent p-3 text-[13px] text-muted-foreground transition-colors",
+              "flex w-[272px] shrink-0 snap-start items-center gap-2 rounded-xl border border-dashed border-border/60 bg-transparent p-3 text-[13px] text-muted-foreground transition-colors",
               "hover:border-muted-foreground/50 hover:bg-muted/50 hover:text-foreground"
             )}
           >

--- a/apps/web/src/components/ui/file-upload-node.tsx
+++ b/apps/web/src/components/ui/file-upload-node.tsx
@@ -16,7 +16,10 @@ export function ImageNodeView({ node, deleteNode, selected }: NodeViewProps) {
   const [hasError, setHasError] = React.useState(false);
 
   return (
-    <NodeViewWrapper className="tiptap-image-wrapper relative group">
+    <NodeViewWrapper
+      className="tiptap-image-wrapper relative group"
+      data-drag-handle
+    >
       <div
         className={cn(
           "relative inline-block max-w-full rounded-lg overflow-hidden transition-all",
@@ -37,6 +40,9 @@ export function ImageNodeView({ node, deleteNode, selected }: NodeViewProps) {
             src={resolveUploadUrl(src) ?? src}
             alt={alt || ""}
             title={title || ""}
+            // Disable the browser's native image drag so ProseMirror's node
+            // drag (move) takes over instead of dropping a copy.
+            draggable={false}
             className="max-w-full h-auto rounded-lg"
             onLoad={() => setIsLoading(false)}
             onError={() => {

--- a/apps/web/src/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/components/ui/rich-text-editor.tsx
@@ -116,6 +116,10 @@ const FileAttachmentNode = Node.create({
  * Custom Image Extension with React NodeView
  */
 const CustomImage = Image.extend({
+  // Make the node draggable so ProseMirror MOVES it within the doc. Without
+  // this, dragging the inner <img> falls back to the browser's native image
+  // drag, which drops a *copy* instead of moving the node.
+  draggable: true,
   addNodeView() {
     return ReactNodeViewRenderer(ImageNodeView);
   },


### PR DESCRIPTION
- **Editor image drag = move, not copy.** Dragging an image within the rich-text editor inserted a duplicate, because the image node wasn't ProseMirror-draggable so the browser's native image drag dropped a copy. Made `CustomImage` `draggable: true`, marked the node-view wrapper as the drag handle (`data-drag-handle`), and set `draggable={false}` on the `<img>` so ProseMirror moves the node.
- **Mobile board column snap.** Ideas board columns now snap into view while scrolling on phones (`snap-x snap-mandatory`, off at `sm`), like Trello/Notion — matching the kanban board's existing convention. (The tasks board already snaps; on real mobile it renders a list.)

✅ typecheck · lint · build. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)