### PR TITLE
fix(editor): markdown headings (## → H2) + render in read views

### DIFF
--- a/apps/web/src/components/ui/html-content.tsx
+++ b/apps/web/src/components/ui/html-content.tsx
@@ -16,6 +16,7 @@ export function HtmlContent({ html, className }: HtmlContentProps) {
       ALLOWED_TAGS: [
         "p", "br", "strong", "b", "em", "i", "u", "s", "a",
         "ul", "ol", "li", "blockquote", "pre", "code", "span", "div", "img",
+        "h1", "h2", "h3", "h4", "h5", "h6", "hr",
       ],
       ALLOWED_ATTR: ["href", "target", "rel", "class", "src", "alt", "title"],
       ADD_ATTR: ["target"],
@@ -47,6 +48,7 @@ export function HtmlContent({ html, className }: HtmlContentProps) {
         "text-[13px] leading-relaxed",
         "prose-p:my-0.5 prose-ul:my-0.5 prose-ol:my-0.5 prose-li:my-0",
         "[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5",
+        "prose-headings:font-semibold prose-headings:my-1 prose-h1:text-base prose-h2:text-sm prose-h3:text-[13px]",
         "prose-a:underline prose-a:underline-offset-2",
         className
       )}

--- a/apps/web/src/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/components/ui/rich-text-editor.tsx
@@ -353,7 +353,8 @@ export function RichTextEditor({
   const extensions = React.useMemo((): AnyExtension[] => {
     const baseExtensions: AnyExtension[] = [
       StarterKit.configure({
-        heading: false,
+        // Enable headings so the `#`, `##`, `###` markdown shortcuts work.
+        heading: { levels: [1, 2, 3] },
       }),
       Placeholder.configure({
         placeholder,
@@ -398,6 +399,8 @@ export function RichTextEditor({
           "text-[13px] leading-relaxed",
           "prose-p:my-0.5 prose-ul:my-0.5 prose-ol:my-0.5 prose-li:my-0",
           "[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5",
+          // Compact, distinct headings (the base font is 13px)
+          "prose-headings:font-semibold prose-headings:my-1 prose-h1:text-base prose-h2:text-sm prose-h3:text-[13px]",
           // Image styles
           "[&_.tiptap-image]:max-w-full [&_.tiptap-image]:h-auto [&_.tiptap-image]:rounded-md",
           // Video styles


### PR DESCRIPTION
The rich-text editor had `StarterKit.configure({ heading: false })`, so typing `##` (and `#`/`###`) never converted to a heading.

- **Enable headings** (levels 1–3) so the `#`/`##`/`###` markdown input rules fire, with compact styling to fit the 13px notes editor.
- **Render them in read views** — `HtmlContent` (card previews, detail views) didn't allow `<h1>`–`<h6>`/`<hr>`, so saved headings/rules were stripped. Added them (+ matching heading styles).

Other StarterKit shortcuts (`**bold**`, `*italic*`, `~~strike~~`, `` `code` ``, ```` ``` ````, `- `/`1. ` lists, `> ` quote, `---`) were already enabled and now also survive the read-view sanitizer.

✅ typecheck · lint · build. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)