### PR TITLE
feat(editor): click image/file to open large modal preview

### DIFF
--- a/apps/web/src/components/ui/file-upload-node.tsx
+++ b/apps/web/src/components/ui/file-upload-node.tsx
@@ -2,9 +2,10 @@
 
 import * as React from "react";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
-import { Download, X, FileText, Play, Loader2 } from "lucide-react";
+import { Download, X, FileText, Play, Loader2, Maximize2 } from "lucide-react";
 import { cn, resolveUploadUrl } from "@/lib/utils";
 import { formatFileSize, getFileIcon } from "@/hooks/useUploadAttachment";
+import { useLightbox } from "./lightbox";
 
 /**
  * Image Node View Component
@@ -14,6 +15,14 @@ export function ImageNodeView({ node, deleteNode, selected }: NodeViewProps) {
   const { src, alt, title } = node.attrs;
   const [isLoading, setIsLoading] = React.useState(true);
   const [hasError, setHasError] = React.useState(false);
+  const lightbox = useLightbox();
+
+  const openPreview = () => {
+    if (hasError) return;
+    lightbox.open([
+      { url: src, filename: alt || title || "Image", contentType: "image/*" },
+    ]);
+  };
 
   return (
     <NodeViewWrapper
@@ -43,7 +52,8 @@ export function ImageNodeView({ node, deleteNode, selected }: NodeViewProps) {
             // Disable the browser's native image drag so ProseMirror's node
             // drag (move) takes over instead of dropping a copy.
             draggable={false}
-            className="max-w-full h-auto rounded-lg"
+            onClick={openPreview}
+            className="max-w-full h-auto rounded-lg cursor-zoom-in"
             onLoad={() => setIsLoading(false)}
             onError={() => {
               setIsLoading(false);
@@ -51,6 +61,20 @@ export function ImageNodeView({ node, deleteNode, selected }: NodeViewProps) {
             }}
             style={{ maxHeight: "400px" }}
           />
+        )}
+        {/* Expand-to-preview on hover */}
+        {!hasError && (
+          <button
+            onClick={openPreview}
+            className={cn(
+              "absolute top-2 left-2 p-1.5 rounded-full bg-black/60 text-white",
+              "opacity-0 group-hover:opacity-100 transition-opacity",
+              "hover:bg-black/80 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-white"
+            )}
+            aria-label="Preview image"
+          >
+            <Maximize2 className="h-4 w-4" />
+          </button>
         )}
         {/* Delete button on hover */}
         <button
@@ -138,10 +162,17 @@ export function VideoNodeView({ node, deleteNode, selected }: NodeViewProps) {
 export function FileAttachmentNodeView({ node, deleteNode, selected }: NodeViewProps) {
   const { src, filename, contentType, size } = node.attrs;
   const icon = getFileIcon(contentType);
+  const lightbox = useLightbox();
 
   const handleDownload = () => {
     // Open in new tab / trigger download
     window.open(resolveUploadUrl(src) ?? src, "_blank");
+  };
+
+  const openPreview = () => {
+    lightbox.open([
+      { url: src, filename: filename || "File", contentType: contentType || "" },
+    ]);
   };
 
   return (
@@ -154,19 +185,26 @@ export function FileAttachmentNodeView({ node, deleteNode, selected }: NodeViewP
           selected && "ring-2 ring-primary ring-offset-2"
         )}
       >
-        {/* File Icon */}
-        <div className="flex-shrink-0 text-2xl">{icon}</div>
-
-        {/* File Info */}
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium truncate" title={filename}>
-            {filename}
-          </p>
-          <p className="text-xs text-muted-foreground">{formatFileSize(size)}</p>
-        </div>
+        {/* File Icon + Info — click to preview in a modal */}
+        <button
+          type="button"
+          onClick={openPreview}
+          className="flex flex-1 items-center gap-3 min-w-0 text-left cursor-pointer focus:outline-none"
+          aria-label={`Preview ${filename}`}
+        >
+          <div className="flex-shrink-0 text-2xl">{icon}</div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate" title={filename}>
+              {filename}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {formatFileSize(size)}
+            </p>
+          </div>
+        </button>
 
         {/* Action Buttons */}
-        <div className="flex items-center gap-1">
+        <div className="flex flex-shrink-0 items-center gap-1">
           <button
             onClick={handleDownload}
             className={cn(

--- a/apps/web/src/components/ui/html-content.tsx
+++ b/apps/web/src/components/ui/html-content.tsx
@@ -3,6 +3,7 @@
 import DOMPurify from "dompurify";
 import { useMemo } from "react";
 import { cn, resolveUploadUrl } from "@/lib/utils";
+import { useLightbox } from "./lightbox";
 
 interface HtmlContentProps {
   html: string;
@@ -10,6 +11,7 @@ interface HtmlContentProps {
 }
 
 export function HtmlContent({ html, className }: HtmlContentProps) {
+  const lightbox = useLightbox();
   const sanitizedHtml = useMemo(() => {
     if (!html) return null;
     const clean = DOMPurify.sanitize(html, {
@@ -42,6 +44,20 @@ export function HtmlContent({ html, className }: HtmlContentProps) {
 
   return (
     <div
+      onClick={(e) => {
+        // Click an inline image to preview it in the lightbox.
+        const target = e.target as HTMLElement;
+        if (target.tagName === "IMG") {
+          const img = target as HTMLImageElement;
+          lightbox.open([
+            {
+              url: img.currentSrc || img.src,
+              filename: img.alt || "Image",
+              contentType: "image/*",
+            },
+          ]);
+        }
+      }}
       className={cn(
         // Compact text like Linear - smaller font, tighter spacing
         "prose dark:prose-invert max-w-none",
@@ -50,6 +66,7 @@ export function HtmlContent({ html, className }: HtmlContentProps) {
         "[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5",
         "prose-headings:font-semibold prose-headings:my-1 prose-h1:text-base prose-h2:text-sm prose-h3:text-[13px]",
         "prose-a:underline prose-a:underline-offset-2",
+        "[&_img]:cursor-zoom-in",
         className
       )}
       dangerouslySetInnerHTML={{ __html: sanitizedHtml }}

--- a/apps/web/src/components/ui/lightbox.tsx
+++ b/apps/web/src/components/ui/lightbox.tsx
@@ -1,9 +1,18 @@
 import * as React from "react";
-import { X, ChevronLeft, ChevronRight, Download, ZoomIn, ZoomOut } from "lucide-react";
-import { cn } from "@/lib/utils";
+import {
+  X,
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  ZoomIn,
+  ZoomOut,
+  FileText,
+  ExternalLink,
+} from "lucide-react";
+import { cn, resolveUploadUrl } from "@/lib/utils";
 import { Button } from "./button";
 
-interface LightboxItem {
+export interface LightboxItem {
   url: string;
   filename: string;
   contentType: string;
@@ -111,6 +120,8 @@ export function Lightbox({ items, initialIndex = 0, open, onClose }: LightboxPro
 
   const isImage = currentItem.contentType.startsWith("image/");
   const isVideo = currentItem.contentType.startsWith("video/");
+  const isPdf = currentItem.contentType === "application/pdf";
+  const isPreviewable = isImage || isVideo || isPdf;
 
   const handleDownload = () => {
     const link = document.createElement("a");
@@ -306,6 +317,48 @@ export function Lightbox({ items, initialIndex = 0, open, onClose }: LightboxPro
             Your browser does not support the video tag.
           </video>
         )}
+
+        {isPdf && (
+          <iframe
+            src={currentItem.url}
+            title={currentItem.filename}
+            className="h-full w-full bg-white"
+          />
+        )}
+
+        {/* Non-previewable files (docs, zips, etc.) — browsers can't render
+            them inline, so show a card with download / open actions. */}
+        {!isPreviewable && (
+          <div className="flex flex-col items-center gap-5 px-6 text-center text-white">
+            <div className="flex h-24 w-24 items-center justify-center rounded-2xl bg-white/10">
+              <FileText className="h-12 w-12 text-white/80" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-base font-medium">{currentItem.filename}</p>
+              <p className="text-sm text-white/50">
+                Preview isn’t available for this file type.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                onClick={handleDownload}
+                className="gap-2"
+              >
+                <Download className="h-4 w-4" />
+                Download
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => window.open(currentItem.url, "_blank")}
+                className="gap-2 border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white"
+              >
+                <ExternalLink className="h-4 w-4" />
+                Open in new tab
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Navigation arrows */}
@@ -365,4 +418,62 @@ export function Lightbox({ items, initialIndex = 0, open, onClose }: LightboxPro
       )}
     </div>
   );
+}
+
+interface LightboxContextValue {
+  /**
+   * Open the lightbox with one or more items. Relative `/uploads/...` urls are
+   * resolved to the API origin automatically, so callers can pass raw node
+   * `src` values.
+   */
+  open: (items: LightboxItem[], initialIndex?: number) => void;
+}
+
+const LightboxContext = React.createContext<LightboxContextValue>({
+  // No-op fallback so components used outside the provider don't crash.
+  open: () => {},
+});
+
+/**
+ * App-wide lightbox. Mount once near the root; any descendant can call
+ * `useLightbox().open(items)` to preview images, video, PDFs, or files in a
+ * full-screen overlay.
+ */
+export function LightboxProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = React.useState<{
+    items: LightboxItem[];
+    index: number;
+  } | null>(null);
+
+  const open = React.useCallback(
+    (items: LightboxItem[], initialIndex = 0) => {
+      const resolved = items
+        .map((item) => ({
+          ...item,
+          url: resolveUploadUrl(item.url) ?? item.url,
+        }))
+        .filter((item) => item.url);
+      if (resolved.length === 0) return;
+      setState({ items: resolved, index: initialIndex });
+    },
+    []
+  );
+
+  const value = React.useMemo(() => ({ open }), [open]);
+
+  return (
+    <LightboxContext.Provider value={value}>
+      {children}
+      <Lightbox
+        items={state?.items ?? []}
+        initialIndex={state?.index ?? 0}
+        open={state !== null}
+        onClose={() => setState(null)}
+      />
+    </LightboxContext.Provider>
+  );
+}
+
+export function useLightbox() {
+  return React.useContext(LightboxContext);
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,6 +11,7 @@ import { HelmetProvider } from "react-helmet-async";
 import { AuthProvider } from "@/hooks/useAuth";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { TooltipProvider } from "@/components/ui";
+import { LightboxProvider } from "@/components/ui/lightbox";
 import { useTimezoneSync } from "@/hooks/useTimezoneSync";
 import { persister, shouldPersistQueryFn } from "@/lib/query-persister";
 import { installChunkErrorRecovery } from "@/lib/chunk-error-recovery";
@@ -121,9 +122,11 @@ function App() {
             delayDuration={0}) can still nest their own; Radix
             allows nesting and inner overrides outer. */}
         <TooltipProvider delayDuration={300}>
-          <TimezoneSync>
-            <RouterProvider router={router} />
-          </TimezoneSync>
+          <LightboxProvider>
+            <TimezoneSync>
+              <RouterProvider router={router} />
+            </TimezoneSync>
+          </LightboxProvider>
         </TooltipProvider>
       </ThemeProvider>
     </AuthProvider>


### PR DESCRIPTION
## What

Click an inline image or file attachment to open it in a large full-screen modal preview. Works in the rich-text editor **and** read-only note views.

This wires up the previously-unused `Lightbox` component (zoom, pan, keyboard nav, swipe) behind a small app-wide provider, and extends it to handle every attachment type.

## Changes

- **`LightboxProvider` / `useLightbox`** — mounted once at the app root (`main.tsx`). Any component calls `useLightbox().open(items)`; relative `/uploads/...` paths are resolved to the API origin automatically.
- **Lightbox content types** — added **PDF** (inline `<iframe>`) and **generic/non-previewable files** (icon + filename + Download / Open-in-new-tab card) on top of the existing image + video handling.
- **Inline images** (`ImageNodeView`) — `cursor-zoom-in` + click opens the preview; a hover **expand** button gives an explicit affordance. Doesn't interfere with the existing drag-to-move or delete button.
- **File attachments** (`FileAttachmentNodeView`) — the file card is now clickable to preview/open; Download + delete buttons unchanged.
- **Read views** (`HtmlContent`) — images are click-to-preview via event delegation (covers idea cards, kanban descriptions, calendar event details).

## Test on dev

1. Open a task/idea note, insert an image → click it (or the hover ⤢ button) → large modal with zoom/pan/keyboard arrows.
2. Attach a PDF → click the card → inline PDF preview. Attach a `.docx` → click → download/open card.
3. Open a card preview (read-only) and click an image → same lightbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)