### PR TITLE
fix(nav): client-side routing for app tabs to stop page flicker

### DIFF
--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -14,6 +14,7 @@ import {
   Download,
   BookOpen,
 } from "lucide-react";
+import { Link, useRouterState } from "@tanstack/react-router";
 import { useAuth } from "@/hooks/useAuth";
 import { useSearch } from "@/hooks/useSearch";
 import { useTheme } from "@/hooks/useTheme";
@@ -68,7 +69,7 @@ export function Header({ className }: HeaderProps) {
       <div className="flex h-11 w-full items-center px-3 sm:px-4">
         {/* Logo */}
         <div className="mr-3 flex">
-          <a href="/app" className="mr-4 flex items-center space-x-2">
+          <Link to="/app" className="mr-4 flex items-center space-x-2">
             <img
               src="/open-sunsama-logo.png"
               alt="Open Sunsama"
@@ -77,7 +78,7 @@ export function Header({ className }: HeaderProps) {
             <span className="hidden text-[13px] font-semibold sm:inline-block">
               Open Sunsama
             </span>
-          </a>
+          </Link>
         </div>
 
         {/* Navigation - Hidden on mobile (using bottom nav instead) */}
@@ -203,16 +204,16 @@ export function Header({ className }: HeaderProps) {
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuItem asChild className="text-[13px] py-1.5">
-                <a href="/app/settings" className="w-full cursor-pointer">
+                <Link to="/app/settings" className="w-full cursor-pointer">
                   <User className="mr-2 h-3.5 w-3.5" />
                   Profile
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild className="text-[13px] py-1.5">
-                <a href="/app/settings" className="w-full cursor-pointer">
+                <Link to="/app/settings" className="w-full cursor-pointer">
                   <Settings className="mr-2 h-3.5 w-3.5" />
                   Settings
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild className="text-[13px] py-1.5">
                 <a
@@ -250,23 +251,23 @@ export function Header({ className }: HeaderProps) {
 }
 
 interface NavLinkProps {
-  href: string;
+  href: "/app/board" | "/app/tasks" | "/app/calendar" | "/app/ideas";
   icon?: React.ReactNode;
   children: React.ReactNode;
 }
 
 function NavLink({ href, icon, children }: NavLinkProps) {
-  // Check if current path matches for active state
+  // Reactive active state via the router — a plain <a> would hard-reload the
+  // whole SPA on every tab switch (the flicker), so use a client-side <Link>.
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isActive =
-    typeof window !== "undefined" &&
-    ((href === "/app/board" &&
-      (window.location.pathname === "/app/board" ||
-        window.location.pathname === "/app")) ||
-      (href !== "/app/board" && window.location.pathname.startsWith(href)));
+    href === "/app/board"
+      ? pathname === "/app/board" || pathname === "/app"
+      : pathname.startsWith(href);
 
   return (
-    <a
-      href={href}
+    <Link
+      to={href}
       className={cn(
         "inline-flex items-center gap-1.5 rounded px-2 py-1 text-[13px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground",
         isActive && "bg-accent text-accent-foreground"
@@ -274,6 +275,6 @@ function NavLink({ href, icon, children }: NavLinkProps) {
     >
       {icon}
       <span className="hidden sm:inline">{children}</span>
-    </a>
+    </Link>
   );
 }

--- a/apps/web/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/web/src/components/layout/mobile-bottom-nav.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { ListTodo, Calendar, Lightbulb, MoreHorizontal } from "lucide-react";
-import { useRouterState } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
-  href: string;
+  href: "/app" | "/app/calendar" | "/app/ideas" | "/app/more";
   icon: React.ReactNode;
   label: string;
   matchExact?: boolean;
@@ -59,9 +59,9 @@ export function MobileBottomNav() {
             : currentPath.startsWith(item.href);
 
           return (
-            <a
+            <Link
               key={item.href}
-              href={item.href}
+              to={item.href}
               className={cn(
                 "flex flex-col items-center justify-center gap-1 py-2 px-3",
                 "min-h-[56px] min-w-[64px]", // Touch-friendly size (> 44px)
@@ -82,7 +82,7 @@ export function MobileBottomNav() {
                 {item.icon}
               </div>
               <span className="text-xs font-medium">{item.label}</span>
-            </a>
+            </Link>
           );
         })}
       </div>


### PR DESCRIPTION
## Problem

Switching between **Board → Tasks → Ideas** (and Calendar) flickered every time — the page visibly reloaded.

## Cause

The desktop header nav (`NavLink`) and the mobile bottom nav linked with plain `<a href="/app/...">` anchors. A plain anchor does a **full document navigation**, so each tab switch tore down and rebooted the entire SPA: React unmounts, the app shell re-mounts, auth re-runs, and queries refetch. That full reboot is the flicker.

## Fix

Use TanStack Router `<Link>` for all in-app navigation, so tab switches are instant client-side transitions with the React Query cache intact (no reboot, no flash):

- Header nav tabs (Board / Tasks / Calendar / Ideas), the logo, and the Profile/Settings dropdown items.
- Mobile bottom nav items.
- Active-tab state now derives reactively from the router (`useRouterState`) instead of a one-shot `window.location.pathname` read.

`/download` (a public marketing page outside the app shell) is intentionally left as a normal anchor.

Typecheck, lint, and build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)