### PR TITLE
fix(undo): undoable completion toggles + let `c` uncomplete a completed task

### DIFF
--- a/apps/web/src/components/task-shortcuts-handler.tsx
+++ b/apps/web/src/components/task-shortcuts-handler.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   SHORTCUTS,
   matchesShortcut,
@@ -16,6 +17,7 @@ import {
 } from "@/hooks/useTasks";
 import { useSubtasks, useUpdateSubtask } from "@/hooks/useSubtasks";
 import { useAutoSchedule } from "@/hooks";
+import { taskKeys } from "@/lib/query-keys";
 import { toast } from "@/hooks/use-toast";
 import { addDays, startOfWeek, startOfDay, format, parseISO } from "date-fns";
 import type { Task } from "@open-sunsama/types";
@@ -41,7 +43,43 @@ export function TaskShortcutsHandler({
   onSelect,
 }: TaskShortcutsHandlerProps) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { hoveredTask, hoveredSubtaskId } = useHoveredTask();
+
+  // The hovered task is a snapshot captured at mouse-enter time, so its
+  // `completedAt` can be stale (e.g. right after completing it without moving
+  // the cursor). Resolve the freshest copy from the caches so toggling always
+  // flips the *current* state — letting `c` uncomplete a just-completed task.
+  const getFreshTask = React.useCallback(
+    (task: Task): Task => {
+      const detail = queryClient.getQueryData<Task>(taskKeys.detail(task.id));
+      if (detail) return detail;
+
+      const lists = queryClient.getQueriesData<Task[]>({
+        queryKey: taskKeys.lists(),
+      });
+      for (const [, data] of lists) {
+        const found = data?.find((t) => t.id === task.id);
+        if (found) return found;
+      }
+
+      // List view stores tasks in the infinite-search cache, not lists().
+      const infinite = queryClient.getQueriesData({
+        queryKey: ["tasks", "search", "infinite"],
+      });
+      for (const [, data] of infinite) {
+        if (!data || typeof data !== "object" || !("pages" in data)) continue;
+        const pages = (data as { pages: Array<{ data: Task[] }> }).pages;
+        for (const page of pages) {
+          const found = page.data?.find((t) => t.id === task.id);
+          if (found) return found;
+        }
+      }
+
+      return task;
+    },
+    [queryClient]
+  );
 
   const completeTask = useCompleteTask();
   const createTask = useCreateTask();
@@ -128,16 +166,17 @@ export function TaskShortcutsHandler({
           }
         }
 
-        // Complete the hovered task
+        // Complete the hovered task (toggle against its freshest state).
         if (hoveredTask) {
-          const isCompleted = !!hoveredTask.completedAt;
+          const current = getFreshTask(hoveredTask);
+          const isCompleted = !!current.completedAt;
           completeTask.mutate({
-            id: hoveredTask.id,
+            id: current.id,
             completed: !isCompleted,
           });
           toast({
             title: isCompleted ? "Task uncompleted" : "Task completed",
-            description: `"${hoveredTask.title}"`,
+            description: `"${current.title}"`,
           });
         }
         return;
@@ -416,6 +455,7 @@ export function TaskShortcutsHandler({
     updateSubtask,
     reorderTasks,
     autoSchedule,
+    getFreshTask,
   ]);
 
   return null; // This component renders nothing

--- a/apps/web/src/hooks/useIdeaSubtasks.ts
+++ b/apps/web/src/hooks/useIdeaSubtasks.ts
@@ -9,6 +9,7 @@ import type {
   UpdateIdeaSubtaskInput,
 } from "@open-sunsama/types";
 import { getApi } from "@/lib/api";
+import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { ideaSubtaskKeys } from "@/lib/query-keys";
 
 export { ideaSubtaskKeys };
@@ -80,6 +81,7 @@ export function useCreateIdeaSubtask() {
 
 export function useUpdateIdeaSubtask() {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
   return useMutation({
     mutationFn: async ({
       ideaId,
@@ -97,12 +99,13 @@ export function useUpdateIdeaSubtask() {
       const key = ideaSubtaskKeys.list(ideaId);
       await queryClient.cancelQueries({ queryKey: key });
       const previous = queryClient.getQueryData<IdeaSubtask[]>(key);
+      const prevCompleted = previous?.find((s) => s.id === subtaskId)?.completed;
       queryClient.setQueryData<IdeaSubtask[]>(key, (old) =>
         (old ?? []).map((s) =>
           s.id === subtaskId ? { ...s, ...input } : s
         )
       );
-      return { previous };
+      return { previous, prevCompleted };
     },
     onError: (_e, { ideaId }, context) => {
       if (context?.previous) {
@@ -110,6 +113,41 @@ export function useUpdateIdeaSubtask() {
           ideaSubtaskKeys.list(ideaId),
           context.previous
         );
+      }
+    },
+    onSuccess: (_updated, { ideaId, subtaskId, input }, context) => {
+      // Make completion toggles undoable (title edits aren't recorded here).
+      if (
+        input.completed === undefined ||
+        context?.prevCompleted === undefined ||
+        context.prevCompleted === input.completed
+      ) {
+        return;
+      }
+      const prevCompleted = context.prevCompleted;
+      const nextCompleted = input.completed;
+      try {
+        record({
+          label: nextCompleted ? "Complete subtask" : "Uncomplete subtask",
+          undo: async () => {
+            await getApi().ideas.subtasks.update(ideaId, subtaskId, {
+              completed: prevCompleted,
+            });
+            queryClient.invalidateQueries({
+              queryKey: ideaSubtaskKeys.list(ideaId),
+            });
+          },
+          redo: async () => {
+            await getApi().ideas.subtasks.update(ideaId, subtaskId, {
+              completed: nextCompleted,
+            });
+            queryClient.invalidateQueries({
+              queryKey: ideaSubtaskKeys.list(ideaId),
+            });
+          },
+        });
+      } catch {
+        // history bookkeeping must never break the update
       }
     },
   });

--- a/apps/web/src/hooks/useIdeas.ts
+++ b/apps/web/src/hooks/useIdeas.ts
@@ -22,6 +22,7 @@ import type {
 import { getApi } from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
+import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { ideaBoardKeys, ideaKeys, taskKeys } from "@/lib/query-keys";
 
 export { ideaBoardKeys, ideaKeys };
@@ -391,6 +392,7 @@ export function useCreateIdea(boardId: string | undefined) {
 
 export function useUpdateIdea(boardId: string | undefined) {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
   return useMutation({
     mutationFn: async ({
       id,
@@ -407,6 +409,8 @@ export function useUpdateIdea(boardId: string | undefined) {
       const key = ideaKeys.byBoard(boardId);
       await queryClient.cancelQueries({ queryKey: key });
       const previous = queryClient.getQueryData<Idea[]>(key);
+      const prevCompletedAt =
+        previous?.find((i) => i.id === id)?.completedAt ?? null;
       queryClient.setQueryData<Idea[]>(key, (old) =>
         (old ?? []).map((i) =>
           i.id === id
@@ -421,7 +425,7 @@ export function useUpdateIdea(boardId: string | undefined) {
             : i
         )
       );
-      return { previous };
+      return { previous, prevCompletedAt };
     },
     onError: (error, _vars, context) => {
       if (boardId && context?.previous) {
@@ -432,6 +436,35 @@ export function useUpdateIdea(boardId: string | undefined) {
         title: "Failed to update idea",
         description: error instanceof Error ? error.message : "Unknown error",
       });
+    },
+    onSuccess: (_data, { id, input }, context) => {
+      // Make completion toggles undoable (other field edits aren't recorded).
+      if (input.completedAt === undefined) return;
+      const prevCompletedAt = context?.prevCompletedAt ?? null;
+      const nextCompletedAt = input.completedAt;
+      try {
+        record({
+          label: nextCompletedAt ? "Complete idea" : "Uncomplete idea",
+          undo: async () => {
+            await getApi().ideas.update(id, { completedAt: prevCompletedAt });
+            if (boardId) {
+              queryClient.invalidateQueries({
+                queryKey: ideaKeys.byBoard(boardId),
+              });
+            }
+          },
+          redo: async () => {
+            await getApi().ideas.update(id, { completedAt: nextCompletedAt });
+            if (boardId) {
+              queryClient.invalidateQueries({
+                queryKey: ideaKeys.byBoard(boardId),
+              });
+            }
+          },
+        });
+      } catch {
+        // history bookkeeping must never break the update
+      }
     },
     onSettled: () => {
       if (boardId) {

--- a/apps/web/src/hooks/useKeyboardShortcuts.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.tsx
@@ -309,6 +309,25 @@ export function HoveredTaskProvider({
         break;
       }
     }
+    // The list view keeps its tasks in the infinite-search cache rather than
+    // taskKeys.lists(), so search there too — otherwise the hovered card goes
+    // stale (or null) after a shortcut completes/uncompletes it.
+    if (!next) {
+      const infinite = queryClient.getQueriesData({
+        queryKey: ["tasks", "search", "infinite"],
+      });
+      outer: for (const [, data] of infinite) {
+        if (!data || typeof data !== "object" || !("pages" in data)) continue;
+        const pages = (data as { pages: Array<{ data: Task[] }> }).pages;
+        for (const page of pages) {
+          const found = page.data?.find((t) => t.id === id);
+          if (found) {
+            next = found;
+            break outer;
+          }
+        }
+      }
+    }
     setHoveredTask((prev) => (prev?.id === next?.id && prev === next ? prev : next));
     setHoveredSubtaskId(null);
   }, [queryClient]);
@@ -319,7 +338,10 @@ export function HoveredTaskProvider({
     let raf = 0;
     const unsub = queryClient.getQueryCache().subscribe((event) => {
       const key = event?.query?.queryKey as unknown[] | undefined;
-      if (!key || key[0] !== "tasks" || key[1] !== "list") return;
+      // Board view uses ["tasks","list",...]; list view uses
+      // ["tasks","search","infinite",...]. Recompute on either.
+      if (!key || key[0] !== "tasks" || (key[1] !== "list" && key[1] !== "search"))
+        return;
       cancelAnimationFrame(raf);
       raf = requestAnimationFrame(recomputeHoveredFromCursor);
     });

--- a/apps/web/src/hooks/useSubtaskMutations.ts
+++ b/apps/web/src/hooks/useSubtaskMutations.ts
@@ -6,6 +6,7 @@ import type {
 } from "@open-sunsama/types";
 import { getApi } from "@/lib/api";
 import { toast } from "@/hooks/use-toast";
+import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { subtaskKeys } from "@/lib/query-keys";
 
 /**
@@ -89,6 +90,7 @@ export function useCreateSubtask() {
  */
 export function useUpdateSubtask() {
   const queryClient = useQueryClient();
+  const { record } = useUndoRedo();
 
   return useMutation({
     mutationFn: async ({
@@ -108,6 +110,9 @@ export function useUpdateSubtask() {
       const previous = queryClient.getQueryData<Subtask[]>(
         subtaskKeys.list(taskId)
       );
+      const prevCompleted = previous?.find(
+        (st) => st.id === subtaskId
+      )?.completed;
 
       queryClient.setQueryData<Subtask[]>(
         subtaskKeys.list(taskId),
@@ -119,7 +124,7 @@ export function useUpdateSubtask() {
           ) ?? []
       );
 
-      return { previous };
+      return { previous, prevCompleted };
     },
     onError: (error, { taskId }, context) => {
       if (context?.previous !== undefined) {
@@ -131,7 +136,7 @@ export function useUpdateSubtask() {
         description: error instanceof Error ? error.message : "Unknown error",
       });
     },
-    onSuccess: (updatedSubtask, { taskId }) => {
+    onSuccess: (updatedSubtask, { taskId, subtaskId, data }, context) => {
       queryClient.setQueryData<Subtask[]>(
         subtaskKeys.list(taskId),
         (old) =>
@@ -139,6 +144,39 @@ export function useUpdateSubtask() {
             st.id === updatedSubtask.id ? updatedSubtask : st
           ) ?? []
       );
+
+      // Make completion toggles undoable (title edits aren't recorded here).
+      if (
+        data.completed !== undefined &&
+        context?.prevCompleted !== undefined &&
+        context.prevCompleted !== data.completed
+      ) {
+        const prevCompleted = context.prevCompleted;
+        const nextCompleted = data.completed;
+        try {
+          record({
+            label: nextCompleted ? "Complete subtask" : "Uncomplete subtask",
+            undo: async () => {
+              await getApi().subtasks.update(taskId, subtaskId, {
+                completed: prevCompleted,
+              });
+              queryClient.invalidateQueries({
+                queryKey: subtaskKeys.list(taskId),
+              });
+            },
+            redo: async () => {
+              await getApi().subtasks.update(taskId, subtaskId, {
+                completed: nextCompleted,
+              });
+              queryClient.invalidateQueries({
+                queryKey: subtaskKeys.list(taskId),
+              });
+            },
+          });
+        } catch {
+          // history bookkeeping must never break the update
+        }
+      }
     },
   });
 }


### PR DESCRIPTION
## What

Two related fixes around completing/uncompleting tasks and subtasks.

### 1. Completion toggles are now undoable/redoable

Previously only top-level **task** completion (`useCompleteTask`) registered with the undo system. Subtask, idea-card, and idea-subtask completions went through generic update mutations that never recorded history, so Cmd+Z / Cmd+Shift+Z did nothing for them — in the board view, the tasks list, and the Ideas boards.

Added scoped undo/redo recording (completion changes only — title/other edits are left alone) to:
- `useUpdateSubtask` ([useSubtaskMutations.ts](apps/web/src/hooks/useSubtaskMutations.ts)) — covers subtask checkboxes in board, list, focus, and time-block views
- `useUpdateIdea` ([useIdeas.ts](apps/web/src/hooks/useIdeas.ts)) — idea card done/undone
- `useUpdateIdeaSubtask` ([useIdeaSubtasks.ts](apps/web/src/hooks/useIdeaSubtasks.ts)) — idea checklist items

Each follows the existing `useCompleteTask` convention: `undo`/`redo` call the API directly (so they don't re-enter the recording mutation), then invalidate the relevant cache. The previous value is captured in `onMutate` for an accurate restore, and recording is wrapped in try/catch so history bookkeeping can never break the mutation. Because every call site funnels through these hooks, all views are fixed at once.

### 2. Pressing `c` now uncompletes a completed task

`hoveredTask` is a snapshot captured at mouse-enter, so after completing a task without moving the cursor its `completedAt` was stale — pressing `c` again re-ran "complete" instead of "uncomplete". The hover auto-refresh also only searched the board's `taskKeys.lists()` cache, while the **list view stores tasks in the infinite-search cache**, so it was never refreshed there.

- [task-shortcuts-handler.tsx](apps/web/src/components/task-shortcuts-handler.tsx): the `c` handler resolves the freshest task state (detail → `taskKeys.lists()` → infinite-search cache) before toggling.
- [useKeyboardShortcuts.tsx](apps/web/src/hooks/useKeyboardShortcuts.tsx): `recomputeHoveredFromCursor` also searches the infinite-search cache, and its cache subscription now fires on `["tasks","search",…]` changes (not just `["tasks","list"]`).

## Why

Reported bug: completion/uncompletion of tasks and subtasks (board view, tasks list, and Ideas boards) could not be undone/redone; and `c` couldn't uncomplete an already-completed task.

## Notes for reviewers

- Undo recording is intentionally limited to completion changes; title/position edits via these hooks are unchanged.
- Top-level task completion (`useCompleteTask`) already worked and was not modified.
- `c` is hover-based — the cursor must be over the task. If completed tasks live in a collapsed section that can't be hovered, that's a separate UI concern.
- Verified with `tsc --noEmit` (exit 0).