### PR TITLE
feat(backlog): bulk clean-up of undated tasks by age

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -428,6 +428,68 @@ tasksRouter.patch(
   }
 );
 
+/**
+ * DELETE /tasks/batch?ids=a,b,c - Delete multiple tasks at once.
+ * Registered before "/:id" so Hono matches the static "/batch" path first.
+ */
+tasksRouter.delete(
+  "/batch",
+  requireScopes("tasks:write"),
+  zValidator(
+    "query",
+    z.object({
+      ids: z
+        .string()
+        .min(1)
+        .transform((s) =>
+          s
+            .split(",")
+            .map((x) => x.trim())
+            .filter(Boolean)
+        )
+        .pipe(z.array(uuidSchema).min(1).max(500)),
+    })
+  ),
+  async (c) => {
+    const userId = c.get("userId");
+    const { ids } = c.req.valid("query");
+    const db = getDb();
+
+    // Only delete tasks that actually belong to this user.
+    const existing = await db
+      .select({ id: tasks.id, scheduledDate: tasks.scheduledDate })
+      .from(tasks)
+      .where(and(inArray(tasks.id, ids), eq(tasks.userId, userId)));
+
+    if (existing.length > 0) {
+      await db.delete(tasks).where(
+        and(
+          inArray(
+            tasks.id,
+            existing.map((t) => t.id)
+          ),
+          eq(tasks.userId, userId)
+        )
+      );
+
+      // Publish a realtime event per task (fire and forget) so other
+      // devices/columns stay in sync, mirroring the single-delete route.
+      for (const t of existing) {
+        publishEvent(userId, "task:deleted", {
+          taskId: t.id,
+          scheduledDate: t.scheduledDate,
+        });
+      }
+    }
+
+    return c.json({
+      success: true,
+      data: { deleted: existing.length },
+      message: `Deleted ${existing.length} task${existing.length === 1 ? "" : "s"}`,
+    });
+  }
+);
+
 /** DELETE /tasks/:id - Delete a task */
 tasksRouter.delete(
   "/:id",

--- a/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
+++ b/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
@@ -73,17 +73,32 @@ interface CleanUpBacklogModalProps {
  * Clean up Backlog — groups the undated, pending backlog by age since created
  * and lets the user bulk hard-delete whole strata or hand-picked tasks.
  * Opened from the Backlog rail (desktop) and Backlog sheet (mobile).
+ *
+ * The body lives in a child component that Radix only mounts while the dialog
+ * is open, so the backlog query and all selection state are created fresh on
+ * each open and torn down on close (no fetching while closed).
  */
 export function CleanUpBacklogModal({
   open,
   onOpenChange,
 }: CleanUpBacklogModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-2xl flex-col gap-0 overflow-hidden p-0">
+        <CleanUpBacklogBody onClose={() => onOpenChange(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CleanUpBacklogBody({ onClose }: { onClose: () => void }) {
   const { data: tasks, isLoading } = useTasks({ backlog: true, limit: 500 });
   const batchDelete = useBatchDeleteTasks();
 
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
   const [confirmOpen, setConfirmOpen] = React.useState(false);
+  const collapseInitialized = React.useRef(false);
 
   // Pending (not completed) backlog tasks grouped into age buckets.
   const groups = React.useMemo(() => {
@@ -92,7 +107,8 @@ export function CleanUpBacklogModal({
     for (const task of pending) {
       const days = ageDays(task);
       // The last bucket has minDays 0, so a match is always found.
-      const bucketKey = (BUCKETS.find((b) => days >= b.minDays) ?? BUCKETS[4]!).key;
+      const bucketKey = (BUCKETS.find((b) => days >= b.minDays) ?? BUCKETS[4]!)
+        .key;
       const list = byBucket.get(bucketKey) ?? [];
       list.push(task);
       byBucket.set(bucketKey, list);
@@ -103,25 +119,26 @@ export function CleanUpBacklogModal({
     })).filter((g) => g.tasks.length > 0);
   }, [tasks]);
 
-  const total = React.useMemo(
-    () => groups.reduce((n, g) => n + g.tasks.length, 0),
+  const allTasks = React.useMemo(
+    () => groups.flatMap((g) => g.tasks),
     [groups]
   );
+  const total = allTasks.length;
 
-  // Collapse every bucket except the first (oldest) non-empty one on open.
+  // Collapse every bucket except the first (oldest) non-empty one — once, as
+  // soon as data has loaded. Guarded by a ref so user-toggled collapse state
+  // is never clobbered when the list later changes (e.g. after a delete).
   React.useEffect(() => {
-    if (!open) return;
-    setSelected(new Set());
-    setConfirmOpen(false);
+    if (collapseInitialized.current || groups.length === 0) return;
+    collapseInitialized.current = true;
     setCollapsed(new Set(groups.slice(1).map((g) => g.key)));
-    // Run only when the dialog opens — group identity is stable per open.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [groups]);
 
   const selecting = selected.size > 0;
-  const allIds = React.useMemo(
-    () => groups.flatMap((g) => g.tasks.map((t) => t.id)),
-    [groups]
+
+  const selectedTasks = React.useMemo(
+    () => allTasks.filter((t) => selected.has(t.id)),
+    [allTasks, selected]
   );
 
   const toggleTask = (id: string) => {
@@ -145,7 +162,9 @@ export function CleanUpBacklogModal({
   };
 
   const toggleMaster = () => {
-    setSelected((prev) => (prev.size > 0 ? new Set() : new Set(allIds)));
+    setSelected((prev) =>
+      prev.size > 0 ? new Set() : new Set(allTasks.map((t) => t.id))
+    );
   };
 
   const clearAll = () => setSelected(new Set());
@@ -167,208 +186,201 @@ export function CleanUpBacklogModal({
   };
 
   const masterState: CheckState =
-    selected.size === 0 ? "off" : selected.size === total ? "on" : "mixed";
+    selected.size === 0 ? "off" : selected.size >= total ? "on" : "mixed";
 
   const handleConfirmDelete = () => {
-    const ids = [...selected];
+    const ids = selectedTasks.map((t) => t.id);
     if (ids.length === 0) return;
     batchDelete.mutate(ids);
     setSelected(new Set());
     setConfirmOpen(false);
   };
 
-  const previewTasks = React.useMemo(() => {
-    const set = selected;
-    return allIds
-      .map((id) => groups.flatMap((g) => g.tasks).find((t) => t.id === id))
-      .filter((t): t is Task => !!t && set.has(t.id));
-  }, [selected, allIds, groups]);
-
   return (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-2xl flex-col gap-0 overflow-hidden p-0">
-          <DialogHeader className="space-y-0.5 px-5 py-4 text-left">
-            <DialogTitle className="text-base">Clean up Backlog</DialogTitle>
-            <DialogDescription className="text-xs">
-              {total} undated task{total === 1 ? "" : "s"} · oldest first
-            </DialogDescription>
-          </DialogHeader>
+      <DialogHeader className="space-y-0.5 px-5 py-4 text-left">
+        <DialogTitle className="text-base">Clean up Backlog</DialogTitle>
+        <DialogDescription className="text-xs">
+          {total} undated task{total === 1 ? "" : "s"} · oldest first
+        </DialogDescription>
+      </DialogHeader>
 
-          {/* Control bar */}
-          <div className="flex items-center gap-2.5 border-y px-5 py-2.5">
-            <button
-              type="button"
-              onClick={toggleMaster}
-              disabled={total === 0}
-              className="flex items-center gap-2.5 text-sm font-medium disabled:opacity-40"
-            >
-              <CheckBox state={masterState} />
-              <span>
-                {selected.size === 0 ? "Select all" : `${selected.size} selected`}
-              </span>
-            </button>
-            <div className="flex-1" />
-            {selecting && (
-              <button
-                type="button"
-                onClick={clearAll}
-                className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
-              >
-                Deselect all
-              </button>
-            )}
-          </div>
+      {/* Control bar */}
+      <div className="flex items-center gap-2.5 border-y px-5 py-2.5">
+        <button
+          type="button"
+          onClick={toggleMaster}
+          disabled={total === 0}
+          className="flex items-center gap-2.5 text-sm font-medium disabled:opacity-40"
+        >
+          <CheckBox state={masterState} />
+          <span>
+            {selected.size === 0 ? "Select all" : `${selected.size} selected`}
+          </span>
+        </button>
+        <div className="flex-1" />
+        {selecting && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            Deselect all
+          </button>
+        )}
+      </div>
 
-          {/* Body */}
-          <ScrollArea className="flex-1">
-            <div className="px-3 py-1">
-              {isLoading ? (
-                <div className="space-y-2 p-2">
-                  {Array.from({ length: 4 }).map((_, i) => (
-                    <Skeleton key={i} className="h-8 w-full rounded-md" />
-                  ))}
-                </div>
-              ) : total === 0 ? (
-                <div className="flex flex-col items-center justify-center px-6 py-14 text-center">
-                  <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-muted">
-                    <CheckCircle2 className="h-5 w-5 text-muted-foreground" />
-                  </div>
-                  <p className="text-sm font-medium">Backlog's clean</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    No unscheduled tasks to review.
-                  </p>
-                </div>
-              ) : (
-                groups.map((group, gi) => {
-                  const isCollapsed = collapsed.has(group.key);
-                  return (
-                    <div
-                      key={group.key}
-                      className={cn("group/sec", gi > 0 && "border-t border-border/60")}
+      {/* Body */}
+      <ScrollArea className="flex-1">
+        <div className="px-3 py-1">
+          {isLoading ? (
+            <div className="space-y-2 p-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-full rounded-md" />
+              ))}
+            </div>
+          ) : total === 0 ? (
+            <div className="flex flex-col items-center justify-center px-6 py-14 text-center">
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-muted">
+                <CheckCircle2 className="h-5 w-5 text-muted-foreground" />
+              </div>
+              <p className="text-sm font-medium">Backlog's clean</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                No unscheduled tasks to review.
+              </p>
+            </div>
+          ) : (
+            groups.map((group, gi) => {
+              const isCollapsed = collapsed.has(group.key);
+              return (
+                <div
+                  key={group.key}
+                  className={cn(
+                    "group/sec",
+                    gi > 0 && "border-t border-border/60"
+                  )}
+                >
+                  <div className="flex items-center gap-2.5 px-2 py-2.5">
+                    <button
+                      type="button"
+                      onClick={() => toggleCollapse(group.key)}
+                      className="shrink-0 text-muted-foreground"
+                      aria-label={isCollapsed ? "Expand" : "Collapse"}
                     >
-                      <div className="flex items-center gap-2.5 px-2 py-2.5">
-                        <button
-                          type="button"
-                          onClick={() => toggleCollapse(group.key)}
-                          className="shrink-0 text-muted-foreground"
-                          aria-label={isCollapsed ? "Expand" : "Collapse"}
-                        >
-                          <ChevronRight
-                            className={cn(
-                              "h-4 w-4 transition-transform",
-                              !isCollapsed && "rotate-90"
-                            )}
-                          />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => toggleBucket(group.key)}
-                          className={cn(
-                            "shrink-0 transition-opacity",
-                            selecting
-                              ? "opacity-100"
-                              : "opacity-0 group-hover/sec:opacity-100"
-                          )}
-                          aria-label={`Select ${group.label}`}
-                        >
-                          <CheckBox state={bucketState(group)} />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => toggleCollapse(group.key)}
-                          className="text-sm font-semibold"
-                        >
-                          {group.label}
-                        </button>
-                        <span className="text-xs text-muted-foreground">
-                          {group.tasks.length}
-                        </span>
-                      </div>
+                      <ChevronRight
+                        className={cn(
+                          "h-4 w-4 transition-transform",
+                          !isCollapsed && "rotate-90"
+                        )}
+                      />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => toggleBucket(group.key)}
+                      className={cn(
+                        "shrink-0 transition-opacity",
+                        selecting
+                          ? "opacity-100"
+                          : "opacity-0 group-hover/sec:opacity-100"
+                      )}
+                      aria-label={`Select ${group.label}`}
+                    >
+                      <CheckBox state={bucketState(group)} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => toggleCollapse(group.key)}
+                      className="text-sm font-semibold"
+                    >
+                      {group.label}
+                    </button>
+                    <span className="text-xs text-muted-foreground">
+                      {group.tasks.length}
+                    </span>
+                  </div>
 
-                      {!isCollapsed && (
-                        <div className="pb-2">
-                          {group.tasks.map((task) => {
-                            const isSel = selected.has(task.id);
-                            const days = ageDays(task);
-                            return (
-                              <button
-                                key={task.id}
-                                type="button"
-                                onClick={() => toggleTask(task.id)}
+                  {!isCollapsed && (
+                    <div className="pb-2">
+                      {group.tasks.map((task) => {
+                        const isSel = selected.has(task.id);
+                        const days = ageDays(task);
+                        return (
+                          <button
+                            key={task.id}
+                            type="button"
+                            onClick={() => toggleTask(task.id)}
+                            className={cn(
+                              "group/row flex w-full items-center gap-3 rounded-md py-1.5 pl-9 pr-2 text-left transition-colors",
+                              isSel ? "bg-primary/[0.07]" : "hover:bg-accent/60"
+                            )}
+                          >
+                            <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
+                              <span
                                 className={cn(
-                                  "group/row flex w-full items-center gap-3 rounded-md py-1.5 pl-9 pr-2 text-left transition-colors",
-                                  isSel ? "bg-primary/[0.07]" : "hover:bg-accent/60"
+                                  "absolute h-1.5 w-1.5 rounded-full",
+                                  PRIORITY_DOT[task.priority],
+                                  isSel || selecting
+                                    ? "opacity-0"
+                                    : "opacity-100 group-hover/row:opacity-0"
+                                )}
+                              />
+                              <span
+                                className={cn(
+                                  "absolute transition-opacity",
+                                  isSel || selecting
+                                    ? "opacity-100"
+                                    : "opacity-0 group-hover/row:opacity-100"
                                 )}
                               >
-                                <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
-                                  <span
-                                    className={cn(
-                                      "absolute h-1.5 w-1.5 rounded-full",
-                                      PRIORITY_DOT[task.priority],
-                                      isSel || selecting
-                                        ? "opacity-0"
-                                        : "opacity-100 group-hover/row:opacity-0"
-                                    )}
-                                  />
-                                  <span
-                                    className={cn(
-                                      "absolute transition-opacity",
-                                      isSel || selecting
-                                        ? "opacity-100"
-                                        : "opacity-0 group-hover/row:opacity-100"
-                                    )}
-                                  >
-                                    <CheckBox state={isSel ? "on" : "off"} />
-                                  </span>
-                                </span>
-                                <span className="flex-1 truncate text-sm">
-                                  {task.title}
-                                </span>
-                                <span className="shrink-0 text-xs text-muted-foreground">
-                                  {ageLabel(days)}
-                                </span>
-                              </button>
-                            );
-                          })}
-                        </div>
-                      )}
+                                <CheckBox state={isSel ? "on" : "off"} />
+                              </span>
+                            </span>
+                            <span className="flex-1 truncate text-sm">
+                              {task.title}
+                            </span>
+                            <span className="shrink-0 text-xs text-muted-foreground">
+                              {ageLabel(days)}
+                            </span>
+                          </button>
+                        );
+                      })}
                     </div>
-                  );
-                })
-              )}
-            </div>
-          </ScrollArea>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+      </ScrollArea>
 
-          {/* Footer */}
-          <DialogFooter className="flex-row items-center gap-2 border-t px-5 py-3 sm:justify-end">
-            <div className="flex-1" />
-            <Button variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={selected.size === 0}
-              onClick={() => setConfirmOpen(true)}
-            >
-              <Trash2 className="mr-1.5 h-4 w-4" />
-              {selected.size === 0 ? "Delete" : `Delete ${selected.size}`}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {/* Footer */}
+      <DialogFooter className="flex-row items-center gap-2 border-t px-5 py-3 sm:justify-end">
+        <div className="flex-1" />
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="destructive"
+          disabled={selected.size === 0}
+          onClick={() => setConfirmOpen(true)}
+        >
+          <Trash2 className="mr-1.5 h-4 w-4" />
+          {selected.size === 0 ? "Delete" : `Delete ${selected.size}`}
+        </Button>
+      </DialogFooter>
 
       {/* Confirm — hard delete */}
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent className="max-w-sm">
           <DialogHeader className="text-left">
             <DialogTitle className="text-base">
-              Delete {selected.size} task{selected.size === 1 ? "" : "s"} permanently?
+              Delete {selectedTasks.length} task
+              {selectedTasks.length === 1 ? "" : "s"} permanently?
             </DialogTitle>
             <DialogDescription>This can't be undone.</DialogDescription>
           </DialogHeader>
           <div className="max-h-40 divide-y overflow-auto rounded-md border">
-            {previewTasks.slice(0, 4).map((task) => (
+            {selectedTasks.slice(0, 4).map((task) => (
               <div
                 key={task.id}
                 className="flex items-center gap-2.5 px-3 py-2 text-xs"
@@ -385,9 +397,9 @@ export function CleanUpBacklogModal({
                 </span>
               </div>
             ))}
-            {selected.size > 4 && (
+            {selectedTasks.length > 4 && (
               <div className="bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-                + {selected.size - 4} more
+                + {selectedTasks.length - 4} more
               </div>
             )}
           </div>
@@ -396,7 +408,7 @@ export function CleanUpBacklogModal({
               Cancel
             </Button>
             <Button variant="destructive" onClick={handleConfirmDelete}>
-              Delete {selected.size}
+              Delete {selectedTasks.length}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
+++ b/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
@@ -1,0 +1,406 @@
+import * as React from "react";
+import { ChevronRight, Check, Minus, Trash2, CheckCircle2 } from "lucide-react";
+import type { Task, TaskPriority } from "@open-sunsama/types";
+import { useTasks, useBatchDeleteTasks } from "@/hooks/useTasks";
+import { cn } from "@/lib/utils";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+  Skeleton,
+} from "@/components/ui";
+
+const PRIORITY_DOT: Record<TaskPriority, string> = {
+  P0: "bg-red-500",
+  P1: "bg-orange-500",
+  P2: "bg-blue-400",
+  P3: "bg-slate-300 dark:bg-slate-600",
+};
+
+/** Age buckets, ordered oldest-first so the stalest pile surfaces at the top. */
+const BUCKETS: Array<{ key: string; label: string; minDays: number }> = [
+  { key: "6mo", label: "6 months +", minDays: 180 },
+  { key: "3-6mo", label: "3–6 months", minDays: 90 },
+  { key: "1-3mo", label: "1–3 months", minDays: 30 },
+  { key: "8-30d", label: "8–30 days", minDays: 7 },
+  { key: "0-7d", label: "Last 7 days", minDays: 0 },
+];
+
+function ageDays(task: Task): number {
+  const created = new Date(task.createdAt as unknown as string).getTime();
+  if (Number.isNaN(created)) return 0;
+  return Math.max(0, Math.floor((Date.now() - created) / 86_400_000));
+}
+
+function ageLabel(days: number): string {
+  if (days <= 0) return "today";
+  if (days < 14) return `${days} day${days === 1 ? "" : "s"}`;
+  if (days < 60) return `${Math.round(days / 7)} weeks`;
+  if (days < 365) return `${Math.round(days / 30)} months`;
+  const years = Math.floor(days / 365);
+  return `${years} year${years === 1 ? "" : "s"}`;
+}
+
+type CheckState = "off" | "on" | "mixed";
+
+function CheckBox({ state }: { state: CheckState }) {
+  return (
+    <span
+      className={cn(
+        "flex h-4 w-4 shrink-0 items-center justify-center rounded-[5px] border transition-colors",
+        state === "off"
+          ? "border-muted-foreground/40 bg-background"
+          : "border-primary bg-primary text-primary-foreground"
+      )}
+    >
+      {state === "on" && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
+      {state === "mixed" && <Minus className="h-2.5 w-2.5" strokeWidth={3} />}
+    </span>
+  );
+}
+
+interface CleanUpBacklogModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Clean up Backlog — groups the undated, pending backlog by age since created
+ * and lets the user bulk hard-delete whole strata or hand-picked tasks.
+ * Opened from the Backlog rail (desktop) and Backlog sheet (mobile).
+ */
+export function CleanUpBacklogModal({
+  open,
+  onOpenChange,
+}: CleanUpBacklogModalProps) {
+  const { data: tasks, isLoading } = useTasks({ backlog: true, limit: 500 });
+  const batchDelete = useBatchDeleteTasks();
+
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
+  const [confirmOpen, setConfirmOpen] = React.useState(false);
+
+  // Pending (not completed) backlog tasks grouped into age buckets.
+  const groups = React.useMemo(() => {
+    const pending = (tasks ?? []).filter((t) => !t.completedAt);
+    const byBucket = new Map<string, Task[]>();
+    for (const task of pending) {
+      const days = ageDays(task);
+      // The last bucket has minDays 0, so a match is always found.
+      const bucketKey = (BUCKETS.find((b) => days >= b.minDays) ?? BUCKETS[4]!).key;
+      const list = byBucket.get(bucketKey) ?? [];
+      list.push(task);
+      byBucket.set(bucketKey, list);
+    }
+    return BUCKETS.map((b) => ({
+      ...b,
+      tasks: (byBucket.get(b.key) ?? []).sort((a, c) => ageDays(c) - ageDays(a)),
+    })).filter((g) => g.tasks.length > 0);
+  }, [tasks]);
+
+  const total = React.useMemo(
+    () => groups.reduce((n, g) => n + g.tasks.length, 0),
+    [groups]
+  );
+
+  // Collapse every bucket except the first (oldest) non-empty one on open.
+  React.useEffect(() => {
+    if (!open) return;
+    setSelected(new Set());
+    setConfirmOpen(false);
+    setCollapsed(new Set(groups.slice(1).map((g) => g.key)));
+    // Run only when the dialog opens — group identity is stable per open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const selecting = selected.size > 0;
+  const allIds = React.useMemo(
+    () => groups.flatMap((g) => g.tasks.map((t) => t.id)),
+    [groups]
+  );
+
+  const toggleTask = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleBucket = (bucketKey: string) => {
+    const group = groups.find((g) => g.key === bucketKey);
+    if (!group) return;
+    setSelected((prev) => {
+      const next = new Set(prev);
+      const allOn = group.tasks.every((t) => next.has(t.id));
+      group.tasks.forEach((t) => (allOn ? next.delete(t.id) : next.add(t.id)));
+      return next;
+    });
+  };
+
+  const toggleMaster = () => {
+    setSelected((prev) => (prev.size > 0 ? new Set() : new Set(allIds)));
+  };
+
+  const clearAll = () => setSelected(new Set());
+
+  const toggleCollapse = (bucketKey: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(bucketKey)) next.delete(bucketKey);
+      else next.add(bucketKey);
+      return next;
+    });
+  };
+
+  const bucketState = (group: (typeof groups)[number]): CheckState => {
+    const count = group.tasks.filter((t) => selected.has(t.id)).length;
+    if (count === 0) return "off";
+    if (count === group.tasks.length) return "on";
+    return "mixed";
+  };
+
+  const masterState: CheckState =
+    selected.size === 0 ? "off" : selected.size === total ? "on" : "mixed";
+
+  const handleConfirmDelete = () => {
+    const ids = [...selected];
+    if (ids.length === 0) return;
+    batchDelete.mutate(ids);
+    setSelected(new Set());
+    setConfirmOpen(false);
+  };
+
+  const previewTasks = React.useMemo(() => {
+    const set = selected;
+    return allIds
+      .map((id) => groups.flatMap((g) => g.tasks).find((t) => t.id === id))
+      .filter((t): t is Task => !!t && set.has(t.id));
+  }, [selected, allIds, groups]);
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-2xl flex-col gap-0 overflow-hidden p-0">
+          <DialogHeader className="space-y-0.5 px-5 py-4 text-left">
+            <DialogTitle className="text-base">Clean up Backlog</DialogTitle>
+            <DialogDescription className="text-xs">
+              {total} undated task{total === 1 ? "" : "s"} · oldest first
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Control bar */}
+          <div className="flex items-center gap-2.5 border-y px-5 py-2.5">
+            <button
+              type="button"
+              onClick={toggleMaster}
+              disabled={total === 0}
+              className="flex items-center gap-2.5 text-sm font-medium disabled:opacity-40"
+            >
+              <CheckBox state={masterState} />
+              <span>
+                {selected.size === 0 ? "Select all" : `${selected.size} selected`}
+              </span>
+            </button>
+            <div className="flex-1" />
+            {selecting && (
+              <button
+                type="button"
+                onClick={clearAll}
+                className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                Deselect all
+              </button>
+            )}
+          </div>
+
+          {/* Body */}
+          <ScrollArea className="flex-1">
+            <div className="px-3 py-1">
+              {isLoading ? (
+                <div className="space-y-2 p-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-8 w-full rounded-md" />
+                  ))}
+                </div>
+              ) : total === 0 ? (
+                <div className="flex flex-col items-center justify-center px-6 py-14 text-center">
+                  <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-muted">
+                    <CheckCircle2 className="h-5 w-5 text-muted-foreground" />
+                  </div>
+                  <p className="text-sm font-medium">Backlog's clean</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    No unscheduled tasks to review.
+                  </p>
+                </div>
+              ) : (
+                groups.map((group, gi) => {
+                  const isCollapsed = collapsed.has(group.key);
+                  return (
+                    <div
+                      key={group.key}
+                      className={cn("group/sec", gi > 0 && "border-t border-border/60")}
+                    >
+                      <div className="flex items-center gap-2.5 px-2 py-2.5">
+                        <button
+                          type="button"
+                          onClick={() => toggleCollapse(group.key)}
+                          className="shrink-0 text-muted-foreground"
+                          aria-label={isCollapsed ? "Expand" : "Collapse"}
+                        >
+                          <ChevronRight
+                            className={cn(
+                              "h-4 w-4 transition-transform",
+                              !isCollapsed && "rotate-90"
+                            )}
+                          />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => toggleBucket(group.key)}
+                          className={cn(
+                            "shrink-0 transition-opacity",
+                            selecting
+                              ? "opacity-100"
+                              : "opacity-0 group-hover/sec:opacity-100"
+                          )}
+                          aria-label={`Select ${group.label}`}
+                        >
+                          <CheckBox state={bucketState(group)} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => toggleCollapse(group.key)}
+                          className="text-sm font-semibold"
+                        >
+                          {group.label}
+                        </button>
+                        <span className="text-xs text-muted-foreground">
+                          {group.tasks.length}
+                        </span>
+                      </div>
+
+                      {!isCollapsed && (
+                        <div className="pb-2">
+                          {group.tasks.map((task) => {
+                            const isSel = selected.has(task.id);
+                            const days = ageDays(task);
+                            return (
+                              <button
+                                key={task.id}
+                                type="button"
+                                onClick={() => toggleTask(task.id)}
+                                className={cn(
+                                  "group/row flex w-full items-center gap-3 rounded-md py-1.5 pl-9 pr-2 text-left transition-colors",
+                                  isSel ? "bg-primary/[0.07]" : "hover:bg-accent/60"
+                                )}
+                              >
+                                <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
+                                  <span
+                                    className={cn(
+                                      "absolute h-1.5 w-1.5 rounded-full",
+                                      PRIORITY_DOT[task.priority],
+                                      isSel || selecting
+                                        ? "opacity-0"
+                                        : "opacity-100 group-hover/row:opacity-0"
+                                    )}
+                                  />
+                                  <span
+                                    className={cn(
+                                      "absolute transition-opacity",
+                                      isSel || selecting
+                                        ? "opacity-100"
+                                        : "opacity-0 group-hover/row:opacity-100"
+                                    )}
+                                  >
+                                    <CheckBox state={isSel ? "on" : "off"} />
+                                  </span>
+                                </span>
+                                <span className="flex-1 truncate text-sm">
+                                  {task.title}
+                                </span>
+                                <span className="shrink-0 text-xs text-muted-foreground">
+                                  {ageLabel(days)}
+                                </span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </ScrollArea>
+
+          {/* Footer */}
+          <DialogFooter className="flex-row items-center gap-2 border-t px-5 py-3 sm:justify-end">
+            <div className="flex-1" />
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={selected.size === 0}
+              onClick={() => setConfirmOpen(true)}
+            >
+              <Trash2 className="mr-1.5 h-4 w-4" />
+              {selected.size === 0 ? "Delete" : `Delete ${selected.size}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Confirm — hard delete */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader className="text-left">
+            <DialogTitle className="text-base">
+              Delete {selected.size} task{selected.size === 1 ? "" : "s"} permanently?
+            </DialogTitle>
+            <DialogDescription>This can't be undone.</DialogDescription>
+          </DialogHeader>
+          <div className="max-h-40 divide-y overflow-auto rounded-md border">
+            {previewTasks.slice(0, 4).map((task) => (
+              <div
+                key={task.id}
+                className="flex items-center gap-2.5 px-3 py-2 text-xs"
+              >
+                <span
+                  className={cn(
+                    "h-1.5 w-1.5 shrink-0 rounded-full",
+                    PRIORITY_DOT[task.priority]
+                  )}
+                />
+                <span className="flex-1 truncate">{task.title}</span>
+                <span className="shrink-0 text-muted-foreground">
+                  {ageLabel(ageDays(task))}
+                </span>
+              </div>
+            ))}
+            {selected.size > 4 && (
+              <div className="bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                + {selected.size - 4} more
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDelete}>
+              Delete {selected.size}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/layout/mobile-backlog-sheet.tsx
+++ b/apps/web/src/components/layout/mobile-backlog-sheet.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Plus, Check, InboxIcon } from "lucide-react";
+import { Plus, Check, InboxIcon, Eraser } from "lucide-react";
 import type { Task } from "@open-sunsama/types";
 import { useTasks, useCreateTask, useCompleteTask } from "@/hooks/useTasks";
 import { cn } from "@/lib/utils";
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui";
 import { TaskCardContent } from "@/components/kanban/task-card-content";
 import { TaskContextMenu } from "@/components/kanban/task-context-menu";
+import { CleanUpBacklogModal } from "@/components/backlog/clean-up-backlog-modal";
 
 interface MobileBacklogSheetProps {
   /** Custom trigger element. If not provided, uses default FAB button */
@@ -30,6 +31,7 @@ interface MobileBacklogSheetProps {
  */
 export function MobileBacklogSheet({ trigger, onTaskClick }: MobileBacklogSheetProps) {
   const [open, setOpen] = React.useState(false);
+  const [isCleanupOpen, setIsCleanupOpen] = React.useState(false);
   const [newTaskTitle, setNewTaskTitle] = React.useState("");
   const [isAddingTask, setIsAddingTask] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -97,6 +99,7 @@ export function MobileBacklogSheet({ trigger, onTaskClick }: MobileBacklogSheetP
   );
 
   return (
+    <>
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>{trigger || defaultTrigger}</SheetTrigger>
       <SheetContent side="left" className="w-full max-w-sm p-0 flex flex-col">
@@ -109,15 +112,31 @@ export function MobileBacklogSheet({ trigger, onTaskClick }: MobileBacklogSheetP
                 {backlogTasks.length} task{backlogTasks.length !== 1 ? "s" : ""}
               </p>
             </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-10 w-10" // Touch-friendly
-              onClick={() => setIsAddingTask(true)}
-            >
-              <Plus className="h-5 w-5" />
-              <span className="sr-only">Add task</span>
-            </Button>
+            <div className="flex items-center gap-1">
+              {backlogTasks.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-10 w-10 text-primary hover:text-primary"
+                  onClick={() => {
+                    setOpen(false);
+                    setIsCleanupOpen(true);
+                  }}
+                >
+                  <Eraser className="h-5 w-5" />
+                  <span className="sr-only">Clean up backlog</span>
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10" // Touch-friendly
+                onClick={() => setIsAddingTask(true)}
+              >
+                <Plus className="h-5 w-5" />
+                <span className="sr-only">Add task</span>
+              </Button>
+            </div>
           </div>
         </SheetHeader>
 
@@ -201,6 +220,9 @@ export function MobileBacklogSheet({ trigger, onTaskClick }: MobileBacklogSheetP
         )}
       </SheetContent>
     </Sheet>
+
+    <CleanUpBacklogModal open={isCleanupOpen} onOpenChange={setIsCleanupOpen} />
+    </>
   );
 }
 

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Plus, Inbox, ChevronLeft, ChevronRight } from "lucide-react";
+import { Plus, Inbox, ChevronLeft, ChevronRight, Eraser } from "lucide-react";
 import { useDroppable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import {
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { Button, ScrollArea, Skeleton } from "@/components/ui";
 import { AddTaskModal } from "@/components/kanban/add-task-modal.lazy";
 import { TaskModal } from "@/components/kanban/task-modal.lazy";
+import { CleanUpBacklogModal } from "@/components/backlog/clean-up-backlog-modal";
 
 const SIDEBAR_COLLAPSED_KEY = "open-sunsama-sidebar-collapsed";
 
@@ -29,6 +30,7 @@ interface SidebarProps {
  */
 export function Sidebar({ className }: SidebarProps) {
   const [isAddModalOpen, setIsAddModalOpen] = React.useState(false);
+  const [isCleanupOpen, setIsCleanupOpen] = React.useState(false);
   const [selectedTask, setSelectedTask] = React.useState<Task | null>(null);
   const [isCollapsed, setIsCollapsed] = React.useState(() => {
     if (typeof window === "undefined") return false;
@@ -139,6 +141,17 @@ export function Sidebar({ className }: SidebarProps) {
           )}
         </div>
         <div className="flex items-center gap-0.5">
+          {backlogTasks.length > 0 && (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="h-6 w-6 text-primary hover:text-primary"
+              onClick={() => setIsCleanupOpen(true)}
+              title="Clean up backlog"
+            >
+              <Eraser className="h-3.5 w-3.5" />
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="icon-xs"
@@ -240,6 +253,12 @@ export function Sidebar({ className }: SidebarProps) {
         open={isAddModalOpen}
         onOpenChange={setIsAddModalOpen}
         scheduledDate={null}
+      />
+
+      {/* Clean up Backlog Modal */}
+      <CleanUpBacklogModal
+        open={isCleanupOpen}
+        onOpenChange={setIsCleanupOpen}
       />
 
       {/* Task Detail Modal */}

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -619,6 +619,87 @@ export function useDeleteTask() {
 }
 
 /**
+ * Permanently delete many tasks at once (backlog cleanup).
+ *
+ * Optimistically removes every id from the list + infinite-search caches and
+ * rolls them all back on error. Shows a single count toast. No undo for v1 —
+ * the Clean up Backlog dialog gates this behind an explicit confirm.
+ */
+export function useBatchDeleteTasks() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (ids: string[]): Promise<string[]> => {
+      const api = getApi();
+      await api.tasks.batchDelete(ids);
+      return ids;
+    },
+    onMutate: async (ids) => {
+      const idSet = new Set(ids);
+      await queryClient.cancelQueries({ queryKey: taskKeys.lists() });
+      await queryClient.cancelQueries({
+        queryKey: ["tasks", "search", "infinite"],
+      });
+
+      const previousQueries = queryClient.getQueriesData<Task[]>({
+        queryKey: taskKeys.lists(),
+      });
+      const previousInfinite = queryClient.getQueriesData({
+        queryKey: ["tasks", "search", "infinite"],
+      });
+
+      queryClient.setQueriesData<Task[]>(
+        { queryKey: taskKeys.lists() },
+        (old) => (old ? old.filter((t) => !idSet.has(t.id)) : old)
+      );
+      queryClient.setQueriesData(
+        { queryKey: ["tasks", "search", "infinite"] },
+        (old: unknown) => {
+          if (!old || typeof old !== "object" || !("pages" in old)) return old;
+          const current = old as {
+            pages: Array<{ data: Task[]; meta?: unknown }>;
+            pageParams: unknown[];
+          };
+          return {
+            ...current,
+            pages: current.pages.map((page) => ({
+              ...page,
+              data: page.data.filter((t) => !idSet.has(t.id)),
+            })),
+          };
+        }
+      );
+      ids.forEach((id) =>
+        queryClient.removeQueries({ queryKey: taskKeys.detail(id) })
+      );
+
+      return { previousQueries, previousInfinite };
+    },
+    onError: (error, _ids, context) => {
+      context?.previousQueries?.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+      context?.previousInfinite?.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+      toast({
+        variant: "destructive",
+        title: "Failed to delete tasks",
+        description: error instanceof Error ? error.message : "Unknown error",
+      });
+    },
+    onSuccess: (ids) => {
+      // Calendar time blocks may reference deleted tasks.
+      queryClient.invalidateQueries({ queryKey: timeBlockKeys.lists() });
+      toast({
+        title: `Deleted ${ids.length} task${ids.length === 1 ? "" : "s"}`,
+        description: "They've been permanently removed.",
+      });
+    },
+  });
+}
+
+/**
  * Complete a task
  * When completing, automatically stops any running timer and saves actualMins
  */


### PR DESCRIPTION
## What & why
Backlogs pile up. This adds a focused **Clean up Backlog** flow so users can quickly bucket their undated tasks by age and bulk-delete the stale pile — instead of removing them one by one.

## How it works
- **Entry point:** an eraser button in the Backlog rail header (desktop, `sidebar.tsx`) and the Backlog sheet header (mobile, `mobile-backlog-sheet.tsx`). Shown only when the backlog is non-empty.
- **Dialog:** groups undated, pending tasks by **age since created** — `Last 7 days`, `8–30 days`, `1–3 months`, `3–6 months`, `6 months +` — oldest first, each row showing a relative age ("6 weeks", "4 months").
- **Selection (calm at rest):** rows show just a priority dot until you hover or enter selection mode, then checkboxes appear. Master + per-section tri-state checkboxes; one-click **Deselect all**.
- **Delete:** hard delete behind a confirm dialog with a task preview. Optimistic removal across list + infinite-search caches with rollback; a single count toast.

## Backend
- New `DELETE /tasks/batch?ids=a,b,c` route in `apps/api/src/routes/tasks.ts` (registered before `/:id`), scoped to the authenticated user, emitting a `task:deleted` realtime event per task. This wires up the existing-but-previously-unrouted `api.tasks.batchDelete` client method.

## Verification
- `turbo typecheck` (web + api) ✅
- `turbo build` (web, vite production) ✅
- lint clean on changed files (pre-existing `workers/rollover/*` lint debt is unrelated)

## Notes / follow-ups
- Buckets are fixed (7/30/90/180d) for v1.
- Hard delete is confirm-only (no undo) for v1; a 5s undo toast is a natural fast-follow since there's no archive.
- Pending tasks only (completed backlog tasks are excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)