### PR TITLE
fix(mobile): cleaner task modal + focus header on small screens

### DIFF
--- a/apps/web/src/components/focus/focus-subtasks.tsx
+++ b/apps/web/src/components/focus/focus-subtasks.tsx
@@ -143,9 +143,9 @@ export function FocusSubtasks({ taskId }: FocusSubtasksProps) {
       )}
 
       {/* Add subtask input */}
-      <div className="flex items-center gap-2 py-2 px-2 -mx-2 rounded-md hover:bg-muted/30 transition-colors">
-        <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-muted-foreground/20">
-          <Plus className="h-3 w-3 text-muted-foreground/40" />
+      <div className="flex items-center gap-2 py-1 px-2 -mx-2 rounded-md hover:bg-muted/30 transition-colors">
+        <div className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-[1.5px] border-dashed border-muted-foreground/20">
+          <Plus className="h-2.5 w-2.5 text-muted-foreground/40" />
         </div>
         <Input
           value={newSubtaskTitle}
@@ -157,7 +157,7 @@ export function FocusSubtasks({ taskId }: FocusSubtasksProps) {
             }
           }}
           placeholder="Add a subtask..."
-          className="border-none p-0 h-auto text-sm shadow-none focus-visible:ring-0 bg-transparent placeholder:text-muted-foreground/40"
+          className="border-none p-0 h-auto text-[13px] shadow-none focus-visible:ring-0 bg-transparent placeholder:text-muted-foreground/40"
           disabled={createSubtask.isPending}
         />
       </div>

--- a/apps/web/src/components/kanban/sortable-subtask-item.tsx
+++ b/apps/web/src/components/kanban/sortable-subtask-item.tsx
@@ -90,17 +90,18 @@ export function SortableSubtaskItem({
       ref={setNodeRef}
       style={style}
       className={cn(
-        "group flex items-center gap-3 py-2.5 px-1 -mx-1 rounded-md hover:bg-muted/30 transition-colors",
+        "group flex items-center gap-2.5 py-1.5 px-1 -mx-1 rounded-md hover:bg-muted/30 transition-colors",
         isDragging && "opacity-50 bg-muted/30"
       )}
       onMouseEnter={() => setHoveredSubtaskId(subtask.id)}
       onMouseLeave={() => setHoveredSubtaskId(null)}
     >
-      {/* Drag handle */}
+      {/* Drag handle — hidden on touch (no hover to reveal it, and it would
+          otherwise reserve dead space on the left of every row). */}
       <div
         {...attributes}
         {...listeners}
-        className="touch-none cursor-grab active:cursor-grabbing"
+        className="hidden sm:block touch-none cursor-grab active:cursor-grabbing"
       >
         <GripVertical className="h-4 w-4 text-muted-foreground/40 opacity-0 group-hover:opacity-100 transition-opacity" />
       </div>

--- a/apps/web/src/components/kanban/sortable-subtask-item.tsx
+++ b/apps/web/src/components/kanban/sortable-subtask-item.tsx
@@ -90,7 +90,7 @@ export function SortableSubtaskItem({
       ref={setNodeRef}
       style={style}
       className={cn(
-        "group flex items-center gap-2.5 py-1.5 px-1 -mx-1 rounded-md hover:bg-muted/30 transition-colors",
+        "group flex items-center gap-2 py-1 px-1 -mx-1 rounded-md hover:bg-muted/30 transition-colors",
         isDragging && "opacity-50 bg-muted/30"
       )}
       onMouseEnter={() => setHoveredSubtaskId(subtask.id)}
@@ -110,14 +110,14 @@ export function SortableSubtaskItem({
       <button
         onClick={onToggle}
         className={cn(
-          "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all",
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-[1.5px] transition-all",
           "cursor-pointer",
           subtask.completed
             ? "border-primary bg-primary text-primary-foreground"
             : "border-muted-foreground/30 hover:border-primary"
         )}
       >
-        {subtask.completed && <Check className="h-3 w-3" strokeWidth={3} />}
+        {subtask.completed && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
       </button>
 
       {/* Title - click to edit */}
@@ -130,7 +130,7 @@ export function SortableSubtaskItem({
           onBlur={handleSave}
           onKeyDown={handleKeyDown}
           className={cn(
-            "flex-1 text-sm bg-transparent border-none outline-none",
+            "flex-1 text-[13px] bg-transparent border-none outline-none",
             "focus:ring-0 p-0"
           )}
         />
@@ -138,7 +138,7 @@ export function SortableSubtaskItem({
         <span
           onClick={handleTitleClick}
           className={cn(
-            "flex-1 text-sm cursor-text",
+            "flex-1 text-[13px] cursor-text",
             subtask.completed && "line-through text-muted-foreground"
           )}
         >

--- a/apps/web/src/components/kanban/task-modal.tsx
+++ b/apps/web/src/components/kanban/task-modal.tsx
@@ -947,7 +947,7 @@ export function TaskModal({ task, open, onOpenChange }: TaskModalProps) {
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent className="max-w-2xl p-0 gap-0 overflow-hidden [&>button]:hidden">
           {/* Title row with inline actions */}
-          <div className="flex items-start gap-3 px-6 pt-5 pb-3">
+          <div className="flex items-start gap-2.5 px-4 pt-4 pb-2.5 sm:gap-3 sm:px-6 sm:pt-5 sm:pb-3">
             {/* Checkbox */}
             <button
               type="button"
@@ -969,7 +969,7 @@ export function TaskModal({ task, open, onOpenChange }: TaskModalProps) {
               onBlur={() => title !== renderTask.title && handleSave()}
               rows={1}
               className={cn(
-                "flex-1 min-w-0 resize-none border-none p-0 text-lg font-semibold shadow-none focus:outline-none focus:ring-0 bg-transparent leading-snug",
+                "flex-1 min-w-0 resize-none border-none p-0 text-base sm:text-lg font-semibold shadow-none focus:outline-none focus:ring-0 bg-transparent leading-snug",
                 isCompleted && "line-through text-muted-foreground"
               )}
               placeholder="Task title"
@@ -1031,8 +1031,11 @@ export function TaskModal({ task, open, onOpenChange }: TaskModalProps) {
             </div>
           </div>
 
-          {/* Property bar — priority · date · time */}
-          <div className="flex items-center gap-1 px-6 pb-4">
+          {/* Property bar — priority · date · time. On mobile the actions
+              group wraps to its own line so the metadata keeps full width. */}
+          <div className="flex flex-wrap items-center gap-x-1 gap-y-2 px-4 pb-3 sm:px-6 sm:pb-4">
+            {/* Properties group — stays together as one unit */}
+            <div className="flex items-center gap-1">
             <InlinePrioritySelector
               priority={renderTask.priority}
               onChange={handlePriorityChange}
@@ -1101,7 +1104,10 @@ export function TaskModal({ task, open, onOpenChange }: TaskModalProps) {
                 </>
               )}
             </div>
-            <div className="flex-1" />
+            </div>
+            {/* Actions group — pinned right on desktop, wraps to its own
+                full line on mobile (keeps tap targets uncramped) */}
+            <div className="ml-auto flex items-center gap-1.5">
             <button
               type="button"
               onClick={() => setIsAddingSubtask(true)}
@@ -1131,10 +1137,11 @@ export function TaskModal({ task, open, onOpenChange }: TaskModalProps) {
                 </>
               )}
             </button>
+            </div>
           </div>
 
           {/* Main Content */}
-          <div className="border-t border-border/40 px-6 py-4 space-y-4 max-h-[55vh] overflow-y-auto">
+          <div className="border-t border-border/40 px-4 py-3 sm:px-6 sm:py-4 space-y-4 max-h-[55vh] overflow-y-auto">
             {/* Series Banner */}
             {renderTask.seriesId && <TaskSeriesBanner task={renderTask} />}
 

--- a/apps/web/src/routes/app/focus.$taskId.tsx
+++ b/apps/web/src/routes/app/focus.$taskId.tsx
@@ -349,8 +349,9 @@ export default function FocusPage() {
         </div>
       </div>
 
-      {/* Main content - centered with generous top padding */}
-      <div className="mx-auto max-w-3xl px-4 pt-14 pb-10 sm:px-6 sm:pt-16 sm:pb-12">
+      {/* Main content. The top bar is sticky (in-flow), so only a little
+          breathing room is needed below it — not a big empty gap. */}
+      <div className="mx-auto max-w-3xl px-4 pt-5 pb-10 sm:px-6 sm:pt-10 sm:pb-12">
         {/* Task header — title gets a full row on mobile; the timer drops
             below it instead of squeezing the title on the same line. */}
         <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
@@ -420,7 +421,7 @@ export default function FocusPage() {
         </div>
 
         {/* Metadata — priority · date */}
-        <div className="flex items-center gap-1 mb-10">
+        <div className="flex items-center gap-1 mb-6">
           <InlinePrioritySelector
             priority={task.priority}
             onChange={handlePriorityChange}

--- a/apps/web/src/routes/app/focus.$taskId.tsx
+++ b/apps/web/src/routes/app/focus.$taskId.tsx
@@ -310,7 +310,7 @@ export default function FocusPage() {
     <div className="fixed inset-0 z-50 bg-background overflow-auto">
       {/* Top bar - minimal */}
       <div className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border/50">
-        <div className="mx-auto max-w-3xl px-6 h-12 flex items-center justify-between">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 h-12 flex items-center justify-between">
           <button
             onClick={handleClose}
             className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
@@ -350,9 +350,12 @@ export default function FocusPage() {
       </div>
 
       {/* Main content - centered with generous top padding */}
-      <div className="mx-auto max-w-3xl px-6 pt-16 pb-12">
-        {/* Task header — checkbox + title + timer */}
-        <div className="flex items-center gap-4 mb-3">
+      <div className="mx-auto max-w-3xl px-4 pt-14 pb-10 sm:px-6 sm:pt-16 sm:pb-12">
+        {/* Task header — title gets a full row on mobile; the timer drops
+            below it instead of squeezing the title on the same line. */}
+        <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          {/* Checkbox + title */}
+          <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center sm:gap-4">
           {/* Checkbox */}
           <button
             onClick={handleToggleComplete}
@@ -383,7 +386,7 @@ export default function FocusPage() {
               }}
               autoFocus
               className={cn(
-                "flex-1 text-2xl font-semibold bg-transparent border-none outline-none tracking-tight",
+                "flex-1 text-xl sm:text-2xl font-semibold bg-transparent border-none outline-none tracking-tight",
                 "focus:ring-0 placeholder:text-muted-foreground/50",
                 isCompleted && "line-through text-muted-foreground"
               )}
@@ -393,7 +396,7 @@ export default function FocusPage() {
             <h1
               onClick={() => !isCompleted && setEditingTitle(true)}
               className={cn(
-                "flex-1 text-2xl font-semibold leading-tight cursor-text tracking-tight",
+                "flex-1 text-xl sm:text-2xl font-semibold leading-tight cursor-text tracking-tight",
                 isCompleted && "line-through text-muted-foreground"
               )}
             >
@@ -401,7 +404,9 @@ export default function FocusPage() {
             </h1>
           )}
 
-          {/* Timer — inline with title */}
+          </div>
+          {/* Timer — beside the title on desktop, on its own row on mobile */}
+          <div className="shrink-0">
           <FocusTimer
             taskId={task.id}
             plannedMins={task.estimatedMins}
@@ -411,6 +416,7 @@ export default function FocusPage() {
             timerRef={timerRef}
             compact
           />
+          </div>
         </div>
 
         {/* Metadata — priority · date */}


### PR DESCRIPTION
Redesigns two mobile detail surfaces for better use of space — no longer oversized/cramped.

## Task modal
- Title was `text-lg` and oversized on phones → `text-base sm:text-lg`.
- Tightened the generous `px-6` / vertical paddings to `px-4` on mobile (`sm:` restores desktop).
- **The cramped property row** (priority · date · time **and** Add-subtask · Start all jammed into one line) is now two groups: a **properties group** (priority · date · time) and an **actions group** (Add subtask · Start) that **wraps to its own line** on narrow screens via `flex-wrap`. The metadata gets full width instead of being squeezed; desktop still renders one row.

## Focus header
- The title shared a row with the timer and got crowded. Now the header is `flex-col` on mobile → `sm:flex-row`, so the **title takes a full-width row** and the **timer drops below it**; title is `text-xl` on mobile, `text-2xl` from `sm` up.

## Verification (mobile preview, 375×812)
- Task modal: properties (`P0 · Jun 30 · 0:00/0:00`) on one full-width row, actions (`+ Add subtask` · `▶ Start`) wrapped to the row below.
- Focus: title on its own row, timer (`0:00 / 0:00 ▶ Start`) and metadata (`P2 · Tue, Jun 30`) stacked beneath.

Typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)