### PR TITLE
fix(backlog): Clean up Backlog follow-ups (scroll, selection, Codex P2s)

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -455,37 +455,26 @@ tasksRouter.delete(
     const { ids } = c.req.valid("query");
     const db = getDb();
 
-    // Only delete tasks that actually belong to this user.
-    const existing = await db
-      .select({ id: tasks.id, scheduledDate: tasks.scheduledDate })
-      .from(tasks)
-      .where(and(inArray(tasks.id, ids), eq(tasks.userId, userId)));
+    // Delete only the caller's own tasks and get the deleted rows back in a
+    // single round-trip (the userId clause makes this safe against IDOR).
+    const deleted = await db
+      .delete(tasks)
+      .where(and(inArray(tasks.id, ids), eq(tasks.userId, userId)))
+      .returning({ id: tasks.id, scheduledDate: tasks.scheduledDate });
 
-    if (existing.length > 0) {
-      await db.delete(tasks).where(
-        and(
-          inArray(
-            tasks.id,
-            existing.map((t) => t.id)
-          ),
-          eq(tasks.userId, userId)
-        )
-      );
-
-      // Publish a realtime event per task (fire and forget) so other
-      // devices/columns stay in sync, mirroring the single-delete route.
-      for (const t of existing) {
-        publishEvent(userId, "task:deleted", {
-          taskId: t.id,
-          scheduledDate: t.scheduledDate,
-        });
-      }
+    // Publish a realtime event per task (fire and forget) so other
+    // devices/columns stay in sync, mirroring the single-delete route.
+    for (const t of deleted) {
+      publishEvent(userId, "task:deleted", {
+        taskId: t.id,
+        scheduledDate: t.scheduledDate,
+      });
     }
 
     return c.json({
       success: true,
-      data: { deleted: existing.length },
-      message: `Deleted ${existing.length} task${existing.length === 1 ? "" : "s"}`,
+      data: { deleted: deleted.length },
+      message: `Deleted ${deleted.length} task${deleted.length === 1 ? "" : "s"}`,
     });
   }
 );

--- a/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
+++ b/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
@@ -27,7 +27,7 @@ const BUCKETS: Array<{ key: string; label: string; minDays: number }> = [
   { key: "6mo", label: "6 months +", minDays: 180 },
   { key: "3-6mo", label: "3–6 months", minDays: 90 },
   { key: "1-3mo", label: "1–3 months", minDays: 30 },
-  { key: "8-30d", label: "8–30 days", minDays: 7 },
+  { key: "8-30d", label: "8–30 days", minDays: 8 },
   { key: "0-7d", label: "Last 7 days", minDays: 0 },
 ];
 
@@ -37,11 +37,19 @@ function ageDays(task: Task): number {
   return Math.max(0, Math.floor((Date.now() - created) / 86_400_000));
 }
 
+// Label thresholds mirror the bucket boundaries (days < 30 → days/weeks,
+// 30+ → months) so a row's age reads coherently within its section.
 function ageLabel(days: number): string {
   if (days <= 0) return "today";
-  if (days < 14) return `${days} day${days === 1 ? "" : "s"}`;
-  if (days < 60) return `${Math.round(days / 7)} weeks`;
-  if (days < 365) return `${Math.round(days / 30)} months`;
+  if (days < 7) return `${days} day${days === 1 ? "" : "s"}`;
+  if (days < 30) {
+    const weeks = Math.round(days / 7);
+    return `${weeks} week${weeks === 1 ? "" : "s"}`;
+  }
+  if (days < 365) {
+    const months = Math.round(days / 30);
+    return `${months} month${months === 1 ? "" : "s"}`;
+  }
   const years = Math.floor(days / 365);
   return `${years} year${years === 1 ? "" : "s"}`;
 }
@@ -96,9 +104,9 @@ function CleanUpBacklogBody({ onClose }: { onClose: () => void }) {
   const batchDelete = useBatchDeleteTasks();
 
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  // All buckets start expanded; users can collapse any of them manually.
   const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
   const [confirmOpen, setConfirmOpen] = React.useState(false);
-  const collapseInitialized = React.useRef(false);
 
   // Pending (not completed) backlog tasks grouped into age buckets.
   const groups = React.useMemo(() => {
@@ -125,14 +133,22 @@ function CleanUpBacklogBody({ onClose }: { onClose: () => void }) {
   );
   const total = allTasks.length;
 
-  // Collapse every bucket except the first (oldest) non-empty one — once, as
-  // soon as data has loaded. Guarded by a ref so user-toggled collapse state
-  // is never clobbered when the list later changes (e.g. after a delete).
+  // Keep the selection in sync with the live list: if a selected task
+  // disappears (background refetch, delete settle), drop its id so every
+  // count and the master checkbox reflect exactly what will be deleted.
   React.useEffect(() => {
-    if (collapseInitialized.current || groups.length === 0) return;
-    collapseInitialized.current = true;
-    setCollapsed(new Set(groups.slice(1).map((g) => g.key)));
-  }, [groups]);
+    setSelected((prev) => {
+      if (prev.size === 0) return prev;
+      const live = new Set(allTasks.map((t) => t.id));
+      let changed = false;
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (live.has(id)) next.add(id);
+        else changed = true;
+      });
+      return changed ? next : prev;
+    });
+  }, [allTasks]);
 
   const selecting = selected.size > 0;
 
@@ -162,8 +178,10 @@ function CleanUpBacklogBody({ onClose }: { onClose: () => void }) {
   };
 
   const toggleMaster = () => {
+    // Tri-state: everything selected → clear; otherwise (none or mixed) →
+    // select all. (Pruning keeps prev.size ≤ total.)
     setSelected((prev) =>
-      prev.size > 0 ? new Set() : new Set(allTasks.map((t) => t.id))
+      prev.size >= total ? new Set() : new Set(allTasks.map((t) => t.id))
     );
   };
 
@@ -231,7 +249,7 @@ function CleanUpBacklogBody({ onClose }: { onClose: () => void }) {
       </div>
 
       {/* Body */}
-      <ScrollArea className="flex-1">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="px-3 py-1">
           {isLoading ? (
             <div className="space-y-2 p-2">

--- a/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
+++ b/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
@@ -100,7 +100,14 @@ export function CleanUpBacklogModal({
 }
 
 function CleanUpBacklogBody({ onClose }: { onClose: () => void }) {
-  const { data: tasks, isLoading } = useTasks({ backlog: true, limit: 500 });
+  // Filter to pending server-side so the `limit` paginates the tasks this
+  // modal actually manages — otherwise completed undated tasks could fill the
+  // first page and hide/undercount the pending backlog.
+  const { data: tasks, isLoading } = useTasks({
+    backlog: true,
+    completed: false,
+    limit: 500,
+  });
   const batchDelete = useBatchDeleteTasks();
 
   const [selected, setSelected] = React.useState<Set<string>>(new Set());

--- a/apps/web/src/components/layout/mobile-backlog-sheet.tsx
+++ b/apps/web/src/components/layout/mobile-backlog-sheet.tsx
@@ -117,7 +117,7 @@ export function MobileBacklogSheet({ trigger, onTaskClick }: MobileBacklogSheetP
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-10 w-10 text-primary hover:text-primary"
+                  className="h-10 w-10"
                   onClick={() => {
                     setOpen(false);
                     setIsCleanupOpen(true);

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -145,7 +145,7 @@ export function Sidebar({ className }: SidebarProps) {
             <Button
               variant="ghost"
               size="icon-xs"
-              className="h-6 w-6 text-primary hover:text-primary"
+              className="h-6 w-6"
               onClick={() => setIsCleanupOpen(true)}
               title="Clean up backlog"
             >

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -691,6 +691,13 @@ export function useBatchDeleteTasks() {
       context?.previousDetails?.forEach(([id, detail]) => {
         if (detail) queryClient.setQueryData(taskKeys.detail(id), detail);
       });
+      // The delete is chunked, so a mid-batch failure may have already
+      // removed some tasks server-side. Refetch to converge on server truth
+      // instead of trusting the rolled-back optimistic snapshot.
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
+      queryClient.invalidateQueries({
+        queryKey: ["tasks", "search", "infinite"],
+      });
       toast({
         variant: "destructive",
         title: "Failed to delete tasks",

--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -647,6 +647,12 @@ export function useBatchDeleteTasks() {
       const previousInfinite = queryClient.getQueriesData({
         queryKey: ["tasks", "search", "infinite"],
       });
+      // Snapshot the per-task detail caches before removing them so a failed
+      // batch can fully restore them (parity with useDeleteTask).
+      const previousDetails = ids.map(
+        (id) =>
+          [id, queryClient.getQueryData<Task>(taskKeys.detail(id))] as const
+      );
 
       queryClient.setQueriesData<Task[]>(
         { queryKey: taskKeys.lists() },
@@ -673,7 +679,7 @@ export function useBatchDeleteTasks() {
         queryClient.removeQueries({ queryKey: taskKeys.detail(id) })
       );
 
-      return { previousQueries, previousInfinite };
+      return { previousQueries, previousInfinite, previousDetails };
     },
     onError: (error, _ids, context) => {
       context?.previousQueries?.forEach(([key, data]) => {
@@ -681,6 +687,9 @@ export function useBatchDeleteTasks() {
       });
       context?.previousInfinite?.forEach(([key, data]) => {
         queryClient.setQueryData(key, data);
+      });
+      context?.previousDetails?.forEach(([id, detail]) => {
+        if (detail) queryClient.setQueryData(taskKeys.detail(id), detail);
       });
       toast({
         variant: "destructive",

--- a/packages/api-client/src/tasks.ts
+++ b/packages/api-client/src/tasks.ts
@@ -306,10 +306,16 @@ export function createTasksApi(client: OpenSunsamaClient): TasksApi {
     },
 
     async batchDelete(ids: string[], options?: RequestOptions): Promise<void> {
-      await client.delete<ApiResponseWrapper<void>>("tasks/batch", {
-        ...options,
-        searchParams: { ...options?.searchParams, ids: ids.join(",") },
-      });
+      // Chunk so the `ids` query string stays well under reverse-proxy
+      // request-line limits (e.g. Nginx's default 8KB). ~100 UUIDs ≈ 3.7KB.
+      const CHUNK_SIZE = 100;
+      for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+        const chunk = ids.slice(i, i + CHUNK_SIZE);
+        await client.delete<ApiResponseWrapper<void>>("tasks/batch", {
+          ...options,
+          searchParams: { ...options?.searchParams, ids: chunk.join(",") },
+        });
+      }
     },
 
     async timerActive(options?: RequestOptions): Promise<Task | null> {


### PR DESCRIPTION
Follow-up fixes for the **Clean up Backlog** feature merged in #77. These commits were not part of that merge.

## User-reported breakage
- **Modal couldn't scroll vertically** (footer clipped, users stuck): the `ScrollArea` was `flex-1` without `min-h-0`, so the flex item grew to content height and never bounded the Radix viewport. Added `min-h-0`. Verified the body scrolls with a pinned footer.
- **Eraser entry button rendered orange** (`text-primary`) by default → made neutral, matching the sibling rail/sheet buttons.
- **Buckets opened with one arbitrary section expanded** → now all expanded by default (predictable); per-bucket collapse still works.

## Code-review findings (3 parallel verifiers)
- `toggleMaster` cleared on a *mixed* selection instead of selecting all (correct tri-state).
- Selection set was never reconciled with the live list, so header/footer counts could disagree with what deletes → prune stale ids when the list changes.
- `useBatchDeleteTasks` removed per-task detail caches without snapshotting them → incomplete rollback; now restores them (parity with `useDeleteTask`).
- Age bucket off-by-one (7-day task fell in "8–30 days") + row labels now mirror bucket boundaries.
- Backend batch delete collapsed into a single `DELETE … RETURNING` round-trip.

## Codex automated-review P2s (from #77)
- **Pending filtered client-side after pagination:** the modal fetched `limit:500` then dropped completed tasks in JS, so accounts with many completed undated tasks could fill page 1 with completed items and hide/undercount the pending backlog. Now fetches `completed:false` **server-side** (`isNull(completedAt)`).
- **500 UUIDs in the URL (~18KB)** exceeded default reverse-proxy request-line limits. `batchDelete` now **chunks** into ~100-id requests (~3.7KB); the hook reconciles via list invalidation on error so a mid-batch failure converges on server truth.

## Verification
- `turbo typecheck` (web, api, api-client) ✅
- `turbo build` (web, vite production) ✅
- ESLint clean on changed files
- Scroll fix confirmed via a static flex repro (scrollable body, pinned footer); backend route re-verified (no IDOR, Hono `/batch` precedence, comma round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)