### PR TITLE
fix(tasks): keep detail cache fresh on complete undo/redo

### DIFF
--- a/apps/web/src/hooks/useTasks.ts
+++ b/apps/web/src/hooks/useTasks.ts
@@ -18,6 +18,38 @@ import { useAuth } from "@/hooks/useAuth";
 import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { taskKeys, timeBlockKeys } from "@/lib/query-keys";
 
+/**
+ * Write an authoritative task into every cache that can hold it: the detail
+ * entry plus all list and infinite-search caches. Used after a mutation (or an
+ * undo/redo) resolves so synchronous cache readers — e.g. the `c` shortcut's
+ * `getFreshTask` — never observe a stale copy. Invalidation alone is not
+ * enough: it leaves the old value in cache until a refetch lands, and the
+ * detail cache isn't even refetched unless it's actively observed.
+ */
+function writeTaskToCaches(qc: QueryClient, task: Task) {
+  qc.setQueryData<Task>(taskKeys.detail(task.id), task);
+  qc.setQueriesData<Task[]>({ queryKey: taskKeys.lists() }, (old) =>
+    old ? old.map((t) => (t.id === task.id ? task : t)) : old
+  );
+  qc.setQueriesData(
+    { queryKey: ["tasks", "search", "infinite"] },
+    (old: unknown) => {
+      if (!old || typeof old !== "object" || !("pages" in old)) return old;
+      const current = old as {
+        pages: Array<{ data: Task[]; meta?: unknown }>;
+        pageParams: unknown[];
+      };
+      return {
+        ...current,
+        pages: current.pages.map((page) => ({
+          ...page,
+          data: page.data.map((t) => (t.id === task.id ? task : t)),
+        })),
+      };
+    }
+  );
+}
+
 /** Refetch the task-related caches after an undo/redo applies a raw change. */
 function invalidateTaskCaches(qc: QueryClient) {
   qc.invalidateQueries({ queryKey: taskKeys.lists() });
@@ -859,36 +891,7 @@ export function useCompleteTask() {
       });
     },
     onSuccess: (updatedTask, variables, context) => {
-      queryClient.setQueryData(taskKeys.detail(updatedTask.id), updatedTask);
-      queryClient.setQueriesData<Task[]>(
-        { queryKey: taskKeys.lists() },
-        (old) => {
-          if (!old) return old;
-          return old.map((task) =>
-            task.id === updatedTask.id ? updatedTask : task
-          );
-        }
-      );
-      queryClient.setQueriesData(
-        { queryKey: ["tasks", "search", "infinite"] },
-        (old: unknown) => {
-          if (!old || typeof old !== "object" || !("pages" in old)) return old;
-          const current = old as {
-            pages: Array<{ data: Task[]; meta?: unknown }>;
-            pageParams: unknown[];
-          };
-
-          return {
-            ...current,
-            pages: current.pages.map((page) => ({
-              ...page,
-              data: page.data.map((task) =>
-                task.id === updatedTask.id ? updatedTask : task
-              ),
-            })),
-          };
-        }
-      );
+      writeTaskToCaches(queryClient, updatedTask);
 
       // Undo toggles completion back. When completing also moved the task to
       // today (movedFromDate set), undo restores its original planned day.
@@ -899,26 +902,32 @@ export function useCompleteTask() {
           label: completed ? "Complete task" : "Uncomplete task",
           undo: async () => {
             const api = getApi();
+            let task: Task;
             if (completed) {
-              await api.tasks.uncomplete(id);
+              task = await api.tasks.uncomplete(id);
               if (movedFromDate)
-                await api.tasks.update(id, { scheduledDate: movedFromDate });
+                task = await api.tasks.update(id, {
+                  scheduledDate: movedFromDate,
+                });
             } else {
-              await api.tasks.complete(id);
+              task = await api.tasks.complete(id);
             }
+            writeTaskToCaches(queryClient, task);
             invalidateTaskCaches(queryClient);
           },
           redo: async () => {
             const api = getApi();
+            let task: Task;
             if (completed) {
-              await api.tasks.complete(id);
+              task = await api.tasks.complete(id);
               if (movedFromDate)
-                await api.tasks.update(id, {
+                task = await api.tasks.update(id, {
                   scheduledDate: format(new Date(), "yyyy-MM-dd"),
                 });
             } else {
-              await api.tasks.uncomplete(id);
+              task = await api.tasks.uncomplete(id);
             }
+            writeTaskToCaches(queryClient, task);
             invalidateTaskCaches(queryClient);
           },
         });


### PR DESCRIPTION
## Problem

Complete a task → click **Undo** → the task is restored and shown as active. But then pressing the **`C`** keyboard shortcut on it shows the wrong toast "Task uncompleted" (and fires a no-op API call), as if the task were still completed.

## Root cause

Completing a task writes the completed task (with `completedAt` set) into the **detail cache** (`taskKeys.detail(id)`) in `onSuccess`. The `undo`/`redo` handlers only called `invalidateTaskCaches`, which invalidates **lists / search-infinite / timeblocks** but **never** `taskKeys.detail(id)`.

So after undo: the list views refetch and show the task as active (looks correct), but the detail cache still holds `completedAt`. The `C` shortcut's `getFreshTask` reads the **detail cache first** → sees the stale `completedAt` → concludes "still completed" → wrong toast + no-op `uncomplete`.

## Fix

- Add a shared `writeTaskToCaches(qc, task)` helper that writes the authoritative API-returned task into **every** cache that can hold it (detail + lists + infinite-search).
- Call it from `undo`/`redo` (capturing the task each API call returns) so the detail cache can't go stale. Also fixes the symmetric undo-an-uncomplete case and keeps redo consistent.
- Refactor `onSuccess` to reuse the same helper, dropping a duplicated ~30-line cache-writing block.

## Verification

- `tsc --noEmit` ✅ clean
- `eslint` ✅ clean
- Traced the full call stack (`C` shortcut → `getFreshTask` → mutation → `onSuccess`/`record` → `useUndoRedo.run` → undo/redo). Error-handling and history-recursion guards confirmed intact — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)