### PR TITLE
fix(backlog): make Clean up Backlog list actually scroll

### DIFF
--- a/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
+++ b/apps/web/src/components/backlog/clean-up-backlog-modal.tsx
@@ -11,7 +11,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  ScrollArea,
   Skeleton,
 } from "@/components/ui";
 
@@ -255,9 +254,11 @@ function CleanUpBacklogBody({ onClose }: { onClose: () => void }) {
         )}
       </div>
 
-      {/* Body */}
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="px-3 py-1">
+      {/* Body — native overflow scroll. Radix ScrollArea's nested h-full
+          viewport doesn't resolve its height through this flex/max-h dialog
+          chain, so the list wouldn't scroll; a plain overflow-y-auto flex
+          child does. */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-1">
           {isLoading ? (
             <div className="space-y-2 p-2">
               {Array.from({ length: 4 }).map((_, i) => (
@@ -375,8 +376,7 @@ function CleanUpBacklogBody({ onClose }: { onClose: () => void }) {
               );
             })
           )}
-        </div>
-      </ScrollArea>
+      </div>
 
       {/* Footer */}
       <DialogFooter className="flex-row items-center gap-2 border-t px-5 py-3 sm:justify-end">


### PR DESCRIPTION
## Problem
With 30+ undated tasks the **Clean up Backlog** dialog list could not be scrolled — it grew past the dialog and the footer was clipped, leaving users stuck.

## Root cause
The dialog body used Radix `<ScrollArea>`. Its scrolling element is a nested viewport with `height: 100%` (`h-full`), which does **not** resolve through the dialog's `flex` + `max-h-[85vh]` chain. So the viewport expanded to full content height and never overflowed. The previous `min-h-0` fix didn't help because the element that failed to bound was Radix's inner viewport, not the flex item.

## Fix
Replace Radix `ScrollArea` with a plain `overflow-y-auto` flex child (`min-h-0 flex-1`) — the element that actually scrolls. The list now scrolls reliably inside the bounded dialog while the header and "Select all" bar and footer stay pinned.

One-line change in the real component `apps/web/src/components/backlog/clean-up-backlog-modal.tsx` (+ drop the now-unused `ScrollArea` import).

## Verification
- `turbo typecheck` + `turbo build` (web) ✅
- ESLint clean
- Confirmed the exact final DOM (flex-col `max-h-[85vh]` > header + bar + `overflow-y-auto` body + footer) scrolls: body scrollHeight 1306 > clientHeight 472, scrolls to bottom, footer stays pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)