### PR TITLE
feat(board): primary "Add task" button in board toolbar

### DIFF
--- a/apps/web/src/components/kanban/kanban-board-toolbar.tsx
+++ b/apps/web/src/components/kanban/kanban-board-toolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChevronLeft, ChevronRight, CalendarDays, ArrowUpDown, Check } from "lucide-react";
+import { ChevronLeft, ChevronRight, CalendarDays, ArrowUpDown, Check, Plus } from "lucide-react";
 import type { TaskSortBy } from "@open-sunsama/types";
 import {
   Button,
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
   ShortcutHint,
 } from "@/components/ui";
+import { prefetchAddTaskModal } from "./add-task-modal.lazy";
 
 // Extended sort option that includes direction
 export type SortOption = "position" | "priority-desc" | "priority-asc" | "createdAt-desc" | "createdAt-asc";
@@ -45,6 +46,7 @@ interface KanbanBoardToolbarProps {
   onNavigatePrevious: () => void;
   onNavigateNext: () => void;
   onNavigateToday: () => void;
+  onAddTask: () => void;
   sortBy: SortOption;
   onSortChange: (sort: SortOption) => void;
 }
@@ -76,14 +78,15 @@ export function KanbanBoardToolbar({
   onNavigatePrevious,
   onNavigateNext,
   onNavigateToday,
+  onAddTask,
   sortBy,
   onSortChange,
 }: KanbanBoardToolbarProps) {
   const currentSortLabel = SORT_OPTIONS.find((o) => o.value === sortBy)?.label ?? "Manual";
 
   return (
-    <div className="flex items-center justify-between border-b px-3 sm:px-4 py-2 sm:py-3">
-      <div className="flex items-center gap-2 sm:gap-4">
+    <div className="flex h-14 flex-shrink-0 items-center justify-between border-b px-3 sm:px-4">
+      <div className="flex items-center gap-2 sm:gap-3">
         {/* Navigation Arrows */}
         <div className="flex items-center gap-0.5 sm:gap-1">
           <Button
@@ -91,14 +94,14 @@ export function KanbanBoardToolbar({
             size="icon"
             onClick={onNavigatePrevious}
             title="Previous day"
-            className="h-9 w-9 sm:h-10 sm:w-10"
+            className="h-8 w-8"
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <Button 
-            variant="outline" 
-            onClick={onNavigateToday} 
-            className="group h-9 sm:h-10 px-2 sm:px-3"
+          <Button
+            variant="outline"
+            onClick={onNavigateToday}
+            className="group h-8 px-2.5"
           >
             <CalendarDays className="h-4 w-4 sm:mr-2" />
             <span className="hidden sm:inline">Today</span>
@@ -109,7 +112,7 @@ export function KanbanBoardToolbar({
             size="icon"
             onClick={onNavigateNext}
             title="Next day"
-            className="h-9 w-9 sm:h-10 sm:w-10"
+            className="h-8 w-8"
           >
             <ChevronRight className="h-4 w-4" />
           </Button>
@@ -117,11 +120,31 @@ export function KanbanBoardToolbar({
 
       </div>
 
-      {/* Sort Dropdown */}
+      {/* Right-side actions */}
       <div className="flex items-center gap-2">
+        {/* Primary Add Task action */}
+        <Button
+          onClick={onAddTask}
+          onMouseEnter={() => {
+            void prefetchAddTaskModal();
+          }}
+          onFocus={() => {
+            void prefetchAddTaskModal();
+          }}
+          size="sm"
+          className="gap-1.5 h-8 pl-2.5 pr-1.5"
+        >
+          <Plus className="h-4 w-4" />
+          <span className="hidden sm:inline">Add task</span>
+          <kbd className="hidden sm:inline-flex h-4 min-w-[16px] items-center justify-center rounded border border-primary-foreground/25 bg-primary-foreground/15 px-1 text-[9px] font-semibold leading-none">
+            A
+          </kbd>
+        </Button>
+
+        {/* Sort Dropdown */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="gap-1 sm:gap-2 h-9 sm:h-10 px-2 sm:px-3">
+            <Button variant="outline" size="sm" className="gap-1.5 h-8 px-2.5">
               <ArrowUpDown className="h-4 w-4" />
               <span className="hidden sm:inline">Sort:</span>
               <span className="text-xs sm:text-sm">{currentSortLabel}</span>

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
+import { format } from "date-fns";
 import type { Task } from "@open-sunsama/types";
 import { useKanbanDates } from "@/hooks/useKanbanDates";
 import { useKanbanRangePrefetch } from "@/hooks/useKanbanRangePrefetch";
 import { useTasksDnd } from "@/lib/dnd/tasks-dnd-context";
 import { DayColumn } from "./day-column";
 import { TaskModal } from "./task-modal.lazy";
+import { AddTaskModal } from "./add-task-modal.lazy";
 import { KanbanBoardToolbar, useSortPreference } from "./kanban-board-toolbar";
 import { KanbanNavigationProvider } from "./kanban-navigation-context";
 
@@ -31,6 +33,7 @@ interface KanbanBoardProps {
 export function KanbanBoard({ children, onFirstVisibleDateChange }: KanbanBoardProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [selectedTask, setSelectedTask] = React.useState<Task | null>(null);
+  const [isAddTaskOpen, setIsAddTaskOpen] = React.useState(false);
   const [sortBy, onSortChange] = useSortPreference();
   const { isDragging } = useTasksDnd();
 
@@ -92,6 +95,7 @@ export function KanbanBoard({ children, onFirstVisibleDateChange }: KanbanBoardP
           onNavigatePrevious={navigatePrevious}
           onNavigateNext={navigateNext}
           onNavigateToday={navigateToToday}
+          onAddTask={() => setIsAddTaskOpen(true)}
           sortBy={sortBy}
           onSortChange={onSortChange}
         />
@@ -141,6 +145,13 @@ export function KanbanBoard({ children, onFirstVisibleDateChange }: KanbanBoardP
           onOpenChange={(open) => {
             if (!open) setSelectedTask(null);
           }}
+        />
+
+        {/* Add Task Modal — scoped to the day currently in view */}
+        <AddTaskModal
+          open={isAddTaskOpen}
+          onOpenChange={setIsAddTaskOpen}
+          scheduledDate={format(firstVisibleDate ?? new Date(), "yyyy-MM-dd")}
         />
       </div>
 

--- a/apps/web/src/components/kanban/kanban-calendar-panel.tsx
+++ b/apps/web/src/components/kanban/kanban-calendar-panel.tsx
@@ -362,12 +362,13 @@ export function KanbanCalendarPanel({
         className
       )}
     >
-      {/* Header */}
-      <div className="flex-shrink-0 px-3 py-2 border-b">
-        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+      {/* Header — height matched to the board toolbar (h-14) so the two
+          top rows line up as one uniform band. */}
+      <div className="flex h-14 flex-shrink-0 flex-col justify-center border-b px-3 leading-tight">
+        <div className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
           {format(date, "EEE")}
         </div>
-        <div className="text-lg font-semibold">{format(date, "MMM d")}</div>
+        <div className="text-base font-semibold">{format(date, "MMM d")}</div>
       </div>
 
       {/* All-day banner — only renders when there's at least one all-day


### PR DESCRIPTION
## What & why

The board had no visible **Add task** CTA — only muted per-column buttons and an undiscoverable global `A` shortcut. This adds a primary **Add task** button to the **board toolbar, next to Sort**, with the `A` shortcut shown as a badge.

Placed in the board toolbar (not the global header) so it doesn't bleed into Tasks (which already has its own "New" button), Calendar, or Ideas.

## Changes
- **kanban-board-toolbar.tsx** — Primary `Add task` button next to Sort with `[A]` badge; prefetches the modal on hover/focus.
- **kanban-board.tsx** — Owns the add-task modal, scoped to the day currently in view (falls back to today).
- **kanban-calendar-panel.tsx** — Slimmed the toolbar row to `h-14` and matched the calendar panel's header to the same height, so the two top rows form one uniform 56px band.

Global `A` shortcut and per-column add buttons are unchanged.

## Verified
- Button renders next to Sort (light + dark); opens the modal; `A` shortcut still works.
- Tasks page keeps its own "New" button (no global-header bleed).
- Both top rows measure exactly 56px with the same top edge.
- Typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)