### PR TITLE
feat(desktop): add manual Check for updates with version display

### DIFF
--- a/apps/web/src/components/desktop-update-menu-item.tsx
+++ b/apps/web/src/components/desktop-update-menu-item.tsx
@@ -1,0 +1,116 @@
+/**
+ * "Check for updates" menu item for the desktop app.
+ *
+ * Renders the current app version plus a manual update check that always gives
+ * feedback via toast — "you're on the latest" when current, an actionable
+ * "update now" when behind. Complements the passive auto-check banner, which is
+ * invisible when there's nothing to install. Renders nothing on web.
+ */
+
+import * as React from "react";
+import { RefreshCw } from "lucide-react";
+import { isDesktop } from "@/lib/desktop";
+import {
+  getAppVersion,
+  checkForUpdate,
+  downloadAndInstallUpdate,
+} from "@/lib/updater";
+import { toast } from "@/hooks/use-toast";
+import { DropdownMenuItem, ToastAction } from "@/components/ui";
+
+export function DesktopUpdateMenuItem() {
+  const [version, setVersion] = React.useState<string | null>(null);
+  const [checking, setChecking] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isDesktop()) return;
+    void getAppVersion().then(setVersion);
+  }, []);
+
+  if (!isDesktop()) return null;
+
+  const handleCheck = async (event: Event) => {
+    // Keep the dropdown from closing so the spinner stays visible.
+    event.preventDefault();
+    if (checking) return;
+    setChecking(true);
+
+    try {
+      const update = await checkForUpdate();
+
+      if (update) {
+        toast({
+          title: `Version ${update.version} available`,
+          description: "A new version of Open Sunsama is ready to install.",
+          action: (
+            <ToastAction
+              altText="Update now"
+              onClick={() => {
+                void handleInstall(update.version);
+              }}
+            >
+              Update now
+            </ToastAction>
+          ),
+        });
+      } else {
+        toast({
+          title: "You're up to date",
+          description: version
+            ? `Open Sunsama ${version} is the latest version.`
+            : "You're on the latest version.",
+        });
+      }
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Couldn't check for updates",
+        description:
+          err instanceof Error ? err.message : "Please try again later.",
+      });
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleInstall = async (nextVersion: string) => {
+    const { id, update, dismiss } = toast({
+      title: `Installing ${nextVersion}…`,
+      description: "Downloading update. The app will restart when ready.",
+      duration: Infinity,
+    });
+
+    try {
+      await downloadAndInstallUpdate();
+      // Normally the app relaunches before reaching here.
+      dismiss();
+    } catch (err) {
+      update({
+        id,
+        variant: "destructive",
+        title: "Update failed",
+        description:
+          err instanceof Error ? err.message : "Please try again later.",
+      });
+    }
+  };
+
+  return (
+    <DropdownMenuItem
+      className="text-[13px] py-1.5 cursor-pointer"
+      onSelect={(e) => {
+        void handleCheck(e);
+      }}
+    >
+      <RefreshCw
+        className={`mr-2 h-3.5 w-3.5 ${checking ? "animate-spin" : ""}`}
+      />
+      <span className="flex-1">Check for updates</span>
+      {version && (
+        <span className="ml-2 text-[11px] text-muted-foreground tabular-nums">
+          {version}
+        </span>
+      )}
+    </DropdownMenuItem>
+  );
+}

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useSearch } from "@/hooks/useSearch";
 import { useTheme } from "@/hooks/useTheme";
 import { prefetchCommandPalette } from "@/components/command-palette/command-palette.lazy";
+import { DesktopUpdateMenuItem } from "@/components/desktop-update-menu-item";
 import { cn, getAvatarUrl } from "@/lib/utils";
 import {
   Button,
@@ -234,6 +235,7 @@ export function Header({ className }: HeaderProps) {
                   </a>
                 </DropdownMenuItem>
               )}
+              <DesktopUpdateMenuItem />
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="cursor-pointer text-destructive focus:text-destructive text-[13px] py-1.5"

--- a/apps/web/src/hooks/useAppUpdate.ts
+++ b/apps/web/src/hooks/useAppUpdate.ts
@@ -40,13 +40,18 @@ export function useAppUpdate(): AppUpdateState {
     setStatus('checking');
     setError(null);
 
-    const result = await checkForUpdate();
-    if (result) {
-      setUpdate(result);
-      setStatus('available');
-      setDismissed(false);
-    } else {
-      setStatus('idle');
+    try {
+      const result = await checkForUpdate();
+      if (result) {
+        setUpdate(result);
+        setStatus('available');
+        setDismissed(false);
+      } else {
+        setStatus('idle');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to check for updates');
+      setStatus('error');
     }
   }, []);
 
@@ -55,12 +60,18 @@ export function useAppUpdate(): AppUpdateState {
 
     setStatus('downloading');
     setProgress(null);
+    setError(null);
 
-    await downloadAndInstallUpdate((p) => {
-      setProgress(p);
-    });
-    // If we get here, relaunch didn't happen (shouldn't normally reach this)
-    setStatus('installing');
+    try {
+      await downloadAndInstallUpdate((p) => {
+        setProgress(p);
+      });
+      // If we get here, relaunch didn't happen (shouldn't normally reach this)
+      setStatus('installing');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to install update');
+      setStatus('error');
+    }
   }, []);
 
   const dismiss = useCallback(() => {

--- a/apps/web/src/lib/updater.ts
+++ b/apps/web/src/lib/updater.ts
@@ -20,6 +20,17 @@ export interface UpdateProgress {
 }
 
 /**
+ * Get the running app's version (from the Tauri bundle).
+ * Returns null when not running in the desktop app.
+ */
+export async function getAppVersion(): Promise<string | null> {
+  if (!isDesktop()) return null;
+
+  const { getVersion } = await import('@tauri-apps/api/app');
+  return getVersion();
+}
+
+/**
  * Check for available updates
  * Returns update info if available, null otherwise
  */


### PR DESCRIPTION
## What

Adds a desktop-only **Check for updates** item to the avatar menu, showing the running app version inline (e.g. `1.0.11`).

## Why

The auto-update banner only appears when a newer version exists. When the app is current it shows *nothing* — no version, no affordance — which reads as the update feature being missing/broken. This adds always-on feedback.

## Behavior (desktop only; renders nothing on web)

- **Up to date** → toast: "You're up to date — Open Sunsama X is the latest version."
- **Update available** → toast with **Update now** action → downloads signed `.app.tar.gz`, hot-swaps, relaunches.
- **Error** → destructive toast (previously a silent unhandled rejection).

Also fixes the swallowed-error gap in `useAppUpdate` so the launch-time banner path reports `'error'` instead of throwing.

## Files

- `desktop-update-menu-item.tsx` (new)
- `header.tsx` — wired into dropdown
- `updater.ts` — added `getAppVersion()`
- `useAppUpdate.ts` — error handling

## Verification

- `tsc --noEmit` passes clean.
- Not browser-observable (gated on `isDesktop()`); needs a desktop build to exercise live — will be testable when shipped in 1.0.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)