### PR TITLE
fix(ideas): board search trigger lives in the rail header, field only when active

### DIFF
--- a/apps/web/src/components/ideas/board-rail-content.tsx
+++ b/apps/web/src/components/ideas/board-rail-content.tsx
@@ -35,6 +35,15 @@ interface BoardRailContentProps {
   onNewBoard: () => void;
   /** Icon-only mode (desktop collapsed rail). */
   collapsed?: boolean;
+  /**
+   * Search is controlled by the parent so its trigger can live in the rail's
+   * header row beside the +/collapse buttons — the field itself only takes a
+   * row of its own while it's actually open.
+   */
+  searchOpen?: boolean;
+  query?: string;
+  onQueryChange?: (query: string) => void;
+  onCloseSearch?: () => void;
 }
 
 interface BoardRowProps {
@@ -127,10 +136,12 @@ export function BoardRailContent({
   onSelect,
   onNewBoard,
   collapsed,
+  searchOpen = false,
+  query = "",
+  onQueryChange,
+  onCloseSearch,
 }: BoardRailContentProps) {
   const [editing, setEditing] = React.useState<IdeaBoard | null>(null);
-  const [searchOpen, setSearchOpen] = React.useState(false);
-  const [query, setQuery] = React.useState("");
   const searchRef = React.useRef<HTMLInputElement>(null);
   const deleteBoard = useDeleteIdeaBoard();
   const reorderBoards = useReorderIdeaBoards();
@@ -159,16 +170,10 @@ export function BoardRailContent({
   // shown, so it's only enabled on the full list.
   const canReorder = !trimmedQuery && boards.length > 1;
 
-  const openSearch = () => {
-    setSearchOpen(true);
-    // Wait for the input to mount before focusing it.
-    setTimeout(() => searchRef.current?.focus(), 0);
-  };
-
-  const closeSearch = () => {
-    setSearchOpen(false);
-    setQuery("");
-  };
+  // Focus the field as soon as the parent opens it.
+  React.useEffect(() => {
+    if (searchOpen) searchRef.current?.focus();
+  }, [searchOpen]);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -188,49 +193,34 @@ export function BoardRailContent({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* Search — an icon button that expands into a filter input. Hidden in
-          the collapsed icon-only rail, where there's no room for it. */}
-      {!collapsed && (
-        <div className="mb-1.5 px-0.5">
-          {searchOpen ? (
-            <div className="flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1">
-              <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <input
-                ref={searchRef}
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") closeSearch();
-                  if (e.key === "Enter" && visibleBoards[0]) {
-                    onSelect(visibleBoards[0].id);
-                  }
-                }}
-                onBlur={() => {
-                  if (!query) setSearchOpen(false);
-                }}
-                placeholder="Search boards…"
-                className="min-w-0 flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
-              />
-              <button
-                onClick={closeSearch}
-                aria-label="Clear board search"
-                className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          ) : (
-            // Idle state is icon-only — the field only takes rail width while
-            // it's actually being used.
-            <button
-              onClick={openSearch}
-              aria-label="Search boards"
-              title="Search boards"
-              className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            >
-              <Search className="h-[15px] w-[15px]" />
-            </button>
-          )}
+      {/* The active search field — a row of its own, only while open. The
+          trigger that opens it lives in the rail header. */}
+      {!collapsed && searchOpen && (
+        <div className="mb-1.5 flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1">
+          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <input
+            ref={searchRef}
+            value={query}
+            onChange={(e) => onQueryChange?.(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") onCloseSearch?.();
+              if (e.key === "Enter" && visibleBoards[0]) {
+                onSelect(visibleBoards[0].id);
+              }
+            }}
+            onBlur={() => {
+              if (!query) onCloseSearch?.();
+            }}
+            placeholder="Search boards…"
+            className="min-w-0 flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
+          />
+          <button
+            onClick={onCloseSearch}
+            aria-label="Clear board search"
+            className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
       )}
 

--- a/apps/web/src/components/ideas/board-rail.tsx
+++ b/apps/web/src/components/ideas/board-rail.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
+import { Plus, ChevronLeft, ChevronRight, Search } from "lucide-react";
 import type { IdeaBoard } from "@open-sunsama/types";
 import { cn } from "@/lib/utils";
 import { BoardRailContent } from "./board-rail-content";
@@ -24,6 +24,16 @@ export function BoardRail({
     if (typeof window === "undefined") return false;
     return localStorage.getItem(COLLAPSED_KEY) === "true";
   });
+
+  // Search lives here so its trigger can sit in the header row; the field
+  // itself is rendered by BoardRailContent, and only while open.
+  const [searchOpen, setSearchOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+
+  const closeSearch = React.useCallback(() => {
+    setSearchOpen(false);
+    setQuery("");
+  }, []);
 
   const toggle = React.useCallback(() => {
     setCollapsed((prev) => {
@@ -55,6 +65,17 @@ export function BoardRail({
           </span>
           <div className="flex items-center gap-0.5">
             <button
+              onClick={() => (searchOpen ? closeSearch() : setSearchOpen(true))}
+              title="Search boards"
+              aria-label="Search boards"
+              className={cn(
+                "flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground",
+                searchOpen && "bg-muted text-foreground"
+              )}
+            >
+              <Search className="h-3.5 w-3.5" />
+            </button>
+            <button
               onClick={onNewBoard}
               title="New board"
               className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -78,6 +99,10 @@ export function BoardRail({
         onSelect={onSelect}
         onNewBoard={onNewBoard}
         collapsed={collapsed}
+        searchOpen={searchOpen && !collapsed}
+        query={query}
+        onQueryChange={setQuery}
+        onCloseSearch={closeSearch}
       />
     </aside>
   );

--- a/apps/web/src/routes/app/ideas.tsx
+++ b/apps/web/src/routes/app/ideas.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   Plus,
   ChevronDown,
+  Search,
 } from "lucide-react";
 import {
   Button,
@@ -21,6 +22,7 @@ import {
   matchesShortcut,
   shouldIgnoreShortcut,
 } from "@/hooks/useKeyboardShortcuts";
+import { cn } from "@/lib/utils";
 import { useIdeaBoards, useIdeaColumns } from "@/hooks/useIdeas";
 import { BoardRail } from "@/components/ideas/board-rail";
 import { BoardRailContent } from "@/components/ideas/board-rail-content";
@@ -47,6 +49,10 @@ export default function IdeasPage() {
   }) as { board?: string; idea?: string };
   const [newBoardOpen, setNewBoardOpen] = React.useState(false);
   const [mobileSheetOpen, setMobileSheetOpen] = React.useState(false);
+  // Board search inside the mobile sheet — trigger in its header row, field
+  // only while open (same shape as the desktop rail).
+  const [boardSearchOpen, setBoardSearchOpen] = React.useState(false);
+  const [boardQuery, setBoardQuery] = React.useState("");
   const [quickAddOpen, setQuickAddOpen] = React.useState(false);
 
   React.useEffect(() => {
@@ -174,16 +180,43 @@ export default function IdeasPage() {
               </button>
             </SheetTrigger>
             <SheetContent side="left" className="flex w-72 flex-col p-3">
-              <SheetHeader className="mb-3">
+              <SheetHeader className="mb-3 flex-row items-center justify-between space-y-0">
                 <SheetTitle className="text-left">Boards</SheetTitle>
+                <button
+                  onClick={() => {
+                    if (boardSearchOpen) {
+                      setBoardSearchOpen(false);
+                      setBoardQuery("");
+                    } else {
+                      setBoardSearchOpen(true);
+                    }
+                  }}
+                  aria-label="Search boards"
+                  className={cn(
+                    "mr-6 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground",
+                    boardSearchOpen && "bg-muted text-foreground"
+                  )}
+                >
+                  <Search className="h-4 w-4" />
+                </button>
               </SheetHeader>
               <BoardRailContent
                 boards={boards}
                 activeBoardId={activeBoardId}
-                onSelect={selectBoard}
+                onSelect={(id) => {
+                  selectBoard(id);
+                  setMobileSheetOpen(false);
+                }}
                 onNewBoard={() => {
                   setMobileSheetOpen(false);
                   setNewBoardOpen(true);
+                }}
+                searchOpen={boardSearchOpen}
+                query={boardQuery}
+                onQueryChange={setBoardQuery}
+                onCloseSearch={() => {
+                  setBoardSearchOpen(false);
+                  setBoardQuery("");
                 }}
               />
             </SheetContent>


### PR DESCRIPTION
The board search sat in its own permanent row above the list, costing rail height even when unused.

- The trigger is now an icon in the rail header row, next to **+** (new board) and the collapse chevron.
- Only the **active** field takes a row of its own; it disappears when cleared or dismissed (Escape, or blur while empty).
- Same treatment in the mobile board sheet — the icon sits in the "Boards" header next to the close button.
- Picking a board in the mobile sheet now closes the sheet.

Search state moved up to `BoardRail` (and to the ideas page for the sheet) so the trigger and the field can live in different places; `BoardRailContent` renders the field and focuses it when the parent opens it.

Verified: desktop rail header reads `BOARDS  ⌕ + ‹`, opening the field adds one row and filtering "start" narrows to Startup Ideas; the mobile sheet header shows the trigger beside the close button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)