### PR TITLE
feat(mobile): Tasks list/board + sort, multi-day calendar views, calendar sync recovery

### DIFF
--- a/apps/api/src/workers/calendar-sync/sync-check.ts
+++ b/apps/api/src/workers/calendar-sync/sync-check.ts
@@ -18,6 +18,22 @@ export interface CalendarSyncCheckPayload {
 const SYNC_INTERVAL_MINUTES = 15;
 
 /**
+ * How long an account may sit in `syncing` before we assume the job died and
+ * queue it again. Without this an interrupted worker (deploy, crash, lost
+ * pg-boss job) leaves the account marked `syncing` forever, and the check —
+ * which only looked at `idle`/null — skipped it for good: "connected but never
+ * syncs".
+ */
+const STUCK_SYNCING_MINUTES = 30;
+
+/**
+ * How long to wait before retrying an account whose last sync errored. Errors
+ * are usually transient (expired token, provider 5xx, network), but a status
+ * of `error` used to be terminal for the same reason as above.
+ */
+const ERROR_RETRY_MINUTES = 30;
+
+/**
  * Main job handler that finds accounts needing sync and queues sync jobs
  * Runs every 5 minutes
  */
@@ -28,11 +44,15 @@ export async function processCalendarSyncCheck(
   const boss = await getPgBoss();
   const now = new Date();
 
-  // Find accounts that need syncing:
-  // 1. Active accounts
-  // 2. Not currently syncing
-  // 3. Last synced more than 15 minutes ago OR never synced
+  // Find active accounts that need syncing. An account qualifies when it is:
+  //  - idle (or has no status yet) and hasn't synced within the interval,
+  //  - stuck in `syncing` past STUCK_SYNCING_MINUTES (dead job — self-heal),
+  //  - or in `error` and untouched for ERROR_RETRY_MINUTES (transient failure).
+  // The last two used to be excluded entirely, which is why an account could
+  // read as connected while silently never syncing again.
   const syncThreshold = subMinutes(now, SYNC_INTERVAL_MINUTES);
+  const stuckThreshold = subMinutes(now, STUCK_SYNCING_MINUTES);
+  const errorRetryThreshold = subMinutes(now, ERROR_RETRY_MINUTES);
 
   const accountsNeedingSync = await db
     .select({
@@ -40,18 +60,34 @@ export async function processCalendarSyncCheck(
       userId: calendarAccounts.userId,
       provider: calendarAccounts.provider,
       email: calendarAccounts.email,
+      syncStatus: calendarAccounts.syncStatus,
     })
     .from(calendarAccounts)
     .where(
       and(
         eq(calendarAccounts.isActive, true),
         or(
-          eq(calendarAccounts.syncStatus, 'idle'),
-          isNull(calendarAccounts.syncStatus)
-        ),
-        or(
-          lt(calendarAccounts.lastSyncedAt, syncThreshold),
-          isNull(calendarAccounts.lastSyncedAt)
+          // Normal path: idle / never-synced, due for a refresh.
+          and(
+            or(
+              eq(calendarAccounts.syncStatus, 'idle'),
+              isNull(calendarAccounts.syncStatus)
+            ),
+            or(
+              lt(calendarAccounts.lastSyncedAt, syncThreshold),
+              isNull(calendarAccounts.lastSyncedAt)
+            )
+          ),
+          // Recovery: a sync that never reported back.
+          and(
+            eq(calendarAccounts.syncStatus, 'syncing'),
+            lt(calendarAccounts.updatedAt, stuckThreshold)
+          ),
+          // Retry: a sync that failed a while ago.
+          and(
+            eq(calendarAccounts.syncStatus, 'error'),
+            lt(calendarAccounts.updatedAt, errorRetryThreshold)
+          )
         )
       )
     );
@@ -60,7 +96,13 @@ export async function processCalendarSyncCheck(
     return;
   }
 
-  console.log(`[Calendar Sync Check] Found ${accountsNeedingSync.length} accounts needing sync`);
+  const recovered = accountsNeedingSync.filter(
+    (a) => a.syncStatus === 'syncing' || a.syncStatus === 'error'
+  ).length;
+  console.log(
+    `[Calendar Sync Check] Found ${accountsNeedingSync.length} accounts needing sync` +
+      (recovered > 0 ? ` (${recovered} recovered from stuck/errored state)` : '')
+  );
 
   // Queue sync jobs for each account
   let jobsQueued = 0;

--- a/apps/web/src/components/app/board-page-content.tsx
+++ b/apps/web/src/components/app/board-page-content.tsx
@@ -4,7 +4,7 @@ import { KanbanBoard, useKanbanNavigation } from "@/components/kanban";
 import { KanbanCalendarPanel } from "@/components/kanban/kanban-calendar-panel";
 import { Sidebar } from "@/components/layout/sidebar";
 import { MobileBacklogSheet } from "@/components/layout/mobile-backlog-sheet";
-import { MobileTaskListView } from "@/components/mobile";
+import { MobileTasksView } from "@/components/mobile";
 import { TasksDndProvider } from "@/lib/dnd/tasks-dnd-context";
 import { TaskShortcutsHandler } from "@/components/task-shortcuts-handler";
 import { TaskModal } from "@/components/kanban/task-modal.lazy";
@@ -49,7 +49,7 @@ export function BoardPageContent() {
   }, [fetchedTask, selectedTaskId]);
 
   if (isMobile) {
-    return <MobileTaskListView />;
+    return <MobileTasksView />;
   }
 
   const handleViewTask = (taskId: string) => {

--- a/apps/web/src/components/mobile/index.ts
+++ b/apps/web/src/components/mobile/index.ts
@@ -1,5 +1,11 @@
 export { MobileCalendarView } from "./mobile-calendar-view";
 export { MobileMoreMenu } from "./mobile-more-menu";
 export { MobileTaskListView } from "./task-list-view";
+export { MobileTasksView } from "./mobile-tasks-view";
+export { MobileBoardView } from "./mobile-board-view";
+export {
+  MobileViewControls,
+  type MobileTasksViewMode,
+} from "./mobile-view-controls";
 export { MobileTaskCard, MobileTaskCardWithActualTime } from "./mobile-task-card";
 export { SortableMobileTaskCard } from "./sortable-mobile-task-card";

--- a/apps/web/src/components/mobile/mobile-board-view.tsx
+++ b/apps/web/src/components/mobile/mobile-board-view.tsx
@@ -1,0 +1,147 @@
+import * as React from "react";
+import { addDays, format, startOfDay } from "date-fns";
+import { ChevronLeft, ChevronRight, CalendarDays } from "lucide-react";
+import type { Task } from "@open-sunsama/types";
+import { cn } from "@/lib/utils";
+import { ViewSearch } from "@/components/ui";
+import { DayColumn } from "@/components/kanban/day-column";
+import { TaskModal } from "@/components/kanban/task-modal.lazy";
+import { TasksDndProvider } from "@/lib/dnd/tasks-dnd-context";
+import type { SortOption } from "@/components/kanban/kanban-board-toolbar";
+import {
+  MobileViewControls,
+  type MobileTasksViewMode,
+} from "./mobile-view-controls";
+
+/** How many days the mobile board holds at once. */
+const VISIBLE_DAYS = 7;
+
+interface MobileBoardViewProps {
+  viewMode: MobileTasksViewMode;
+  onViewModeChange: (mode: MobileTasksViewMode) => void;
+  sortBy: SortOption;
+  onSortChange: (sort: SortOption) => void;
+  className?: string;
+}
+
+/**
+ * Board (day-column) view for the mobile Tasks tab.
+ *
+ * Same shape as the Ideas board: a horizontal snap-scroller with one column
+ * per screen, so a swipe moves exactly one day. The columns are the desktop
+ * `DayColumn` — it already sizes itself to the viewport below `sm`, so cards,
+ * inline add, drag-to-reorder and cross-day drops behave identically to the
+ * desktop board rather than being reimplemented.
+ */
+export function MobileBoardView({
+  viewMode,
+  onViewModeChange,
+  sortBy,
+  onSortChange,
+  className,
+}: MobileBoardViewProps) {
+  const [anchorDate, setAnchorDate] = React.useState(() => startOfDay(new Date()));
+  const [selectedTask, setSelectedTask] = React.useState<Task | null>(null);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const scrollerRef = React.useRef<HTMLDivElement>(null);
+
+  const days = React.useMemo(
+    () =>
+      Array.from({ length: VISIBLE_DAYS }, (_, i) => {
+        const date = addDays(anchorDate, i);
+        return { date, dateString: format(date, "yyyy-MM-dd") };
+      }),
+    [anchorDate]
+  );
+
+  const scrollToStart = React.useCallback(() => {
+    scrollerRef.current?.scrollTo({ left: 0, behavior: "smooth" });
+  }, []);
+
+  const goToToday = () => {
+    setAnchorDate(startOfDay(new Date()));
+    scrollToStart();
+  };
+
+  const shiftDays = (delta: number) => {
+    setAnchorDate((prev) => startOfDay(addDays(prev, delta)));
+    scrollToStart();
+  };
+
+  return (
+    <TasksDndProvider>
+      <div className={cn("flex h-full flex-col bg-background", className)}>
+        {/* Header: week nav on the left, view controls on the right */}
+        <header className="sticky top-0 z-40 border-b border-border/40 bg-background">
+          <div className="flex items-center justify-between gap-2 px-3 py-2.5">
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => shiftDays(-VISIBLE_DAYS)}
+                aria-label="Previous week"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground active:bg-muted"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <button
+                onClick={goToToday}
+                className="flex h-8 items-center gap-1.5 rounded-lg px-2 text-sm font-medium active:bg-muted"
+              >
+                <CalendarDays className="h-4 w-4 text-muted-foreground" />
+                Today
+              </button>
+              <button
+                onClick={() => shiftDays(VISIBLE_DAYS)}
+                aria-label="Next week"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground active:bg-muted"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="flex items-center gap-1.5">
+              <ViewSearch
+                value={searchQuery}
+                onChange={setSearchQuery}
+                placeholder="Search tasks…"
+              />
+              {!searchQuery && (
+                <MobileViewControls
+                  viewMode={viewMode}
+                  onViewModeChange={onViewModeChange}
+                  sortBy={sortBy}
+                  onSortChange={onSortChange}
+                />
+              )}
+            </div>
+          </div>
+        </header>
+
+        {/* One day per screen; swiping snaps between them. */}
+        <div
+          ref={scrollerRef}
+          className="flex flex-1 snap-x snap-mandatory overflow-x-auto overflow-y-hidden pb-20"
+        >
+          {days.map(({ date, dateString }) => (
+            <div key={dateString} className="h-full shrink-0 snap-start">
+              <DayColumn
+                date={date}
+                dateString={dateString}
+                onSelectTask={setSelectedTask}
+                sortBy={sortBy}
+                searchQuery={searchQuery}
+              />
+            </div>
+          ))}
+        </div>
+
+        <TaskModal
+          task={selectedTask}
+          open={selectedTask !== null}
+          onOpenChange={(open) => {
+            if (!open) setSelectedTask(null);
+          }}
+        />
+      </div>
+    </TasksDndProvider>
+  );
+}

--- a/apps/web/src/components/mobile/mobile-calendar-view.tsx
+++ b/apps/web/src/components/mobile/mobile-calendar-view.tsx
@@ -9,6 +9,7 @@ import {
   endOfDay,
   addDays,
   subDays,
+  startOfWeek,
 } from "date-fns";
 import {
   Menu,
@@ -55,6 +56,7 @@ import {
   layoutOverlappingItems,
   type LayoutResult,
 } from "@/components/calendar/event-layout";
+import { MobileMultiDayView } from "./mobile-multi-day-view";
 import { UnscheduledTasksDrawer } from "./mobile-unscheduled-drawer";
 
 const DEFAULT_LAYOUT: LayoutResult = { lane: 0, columnCount: 1 };
@@ -75,6 +77,15 @@ interface MobileCalendarViewProps {
   /** Custom className */
   className?: string;
 }
+
+/** Day spans offered by the mobile calendar. */
+type CalendarDayCount = 1 | 3 | 7;
+const DAY_COUNT_KEY = "open-sunsama-mobile-calendar-days";
+const DAY_COUNT_OPTIONS: { value: CalendarDayCount; label: string }[] = [
+  { value: 1, label: "Day" },
+  { value: 3, label: "3 days" },
+  { value: 7, label: "Week" },
+];
 
 function generateHours(): number[] {
   return Array.from(
@@ -106,6 +117,18 @@ export function MobileCalendarView({
     startOfDay(initialDate)
   );
   const [drawerOpen, setDrawerOpen] = React.useState(false);
+  // 1 / 3 / 7-day modes, the standard phone-calendar set. Persisted so the
+  // chosen span survives navigation.
+  const [dayCount, setDayCount] = React.useState<CalendarDayCount>(() => {
+    if (typeof window === "undefined") return 1;
+    const stored = Number(localStorage.getItem(DAY_COUNT_KEY));
+    return stored === 3 || stored === 7 ? (stored as CalendarDayCount) : 1;
+  });
+
+  const changeDayCount = React.useCallback((next: CalendarDayCount) => {
+    setDayCount(next);
+    localStorage.setItem(DAY_COUNT_KEY, String(next));
+  }, []);
   const scrollAreaRef = React.useRef<HTMLDivElement>(null);
   const timelineRef = React.useRef<HTMLDivElement>(null);
 
@@ -135,6 +158,17 @@ export function MobileCalendarView({
       setSelectedDate(todayStart);
     }
   }, [now, selectedDate]);
+
+  // The days on screen. A week view snaps to the Monday of the selected
+  // week; 3-day rolls forward from the selected day, like Google Calendar.
+  const visibleDays = React.useMemo(() => {
+    if (dayCount === 1) return [selectedDate];
+    const first =
+      dayCount === 7
+        ? startOfWeek(selectedDate, { weekStartsOn: 1 })
+        : selectedDate;
+    return Array.from({ length: dayCount }, (_, i) => addDays(first, i));
+  }, [dayCount, selectedDate]);
 
   // Format date for API calls
   const dateString = format(selectedDate, "yyyy-MM-dd");
@@ -317,8 +351,8 @@ export function MobileCalendarView({
     []
   );
 
-  const goToPrevDay = () => setSelectedDate((d) => subDays(d, 1));
-  const goToNextDay = () => setSelectedDate((d) => addDays(d, 1));
+  const goToPrevDay = () => setSelectedDate((d) => subDays(d, dayCount));
+  const goToNextDay = () => setSelectedDate((d) => addDays(d, dayCount));
   const goToToday = () => setSelectedDate(startOfDay(new Date()));
 
   return (
@@ -362,10 +396,17 @@ export function MobileCalendarView({
 
           <div className="min-w-0 flex-1">
             <h1 className="truncate text-lg font-semibold leading-tight">
-              {format(selectedDate, "EEEE")}
+              {dayCount === 1
+                ? format(selectedDate, "EEEE")
+                : `${format(visibleDays[0]!, "MMM d")} – ${format(
+                    visibleDays[visibleDays.length - 1]!,
+                    "MMM d"
+                  )}`}
             </h1>
-            <p className="text-xs text-muted-foreground leading-tight">
-              {format(selectedDate, "MMMM d, yyyy")}
+            <p className="text-xs leading-tight text-muted-foreground">
+              {dayCount === 1
+                ? format(selectedDate, "MMMM d, yyyy")
+                : format(visibleDays[0]!, "yyyy")}
             </p>
           </div>
 
@@ -390,15 +431,54 @@ export function MobileCalendarView({
               variant="ghost"
               size="icon"
               onClick={goToNextDay}
-              aria-label="Next day"
+              aria-label={dayCount === 1 ? "Next day" : "Next period"}
               className="h-9 w-9"
             >
               <ChevronRight className="h-4 w-4" />
             </Button>
           </div>
         </div>
+
+        {/* Day / 3 days / Week — the span switch every phone calendar has. */}
+        <div className="flex items-center rounded-lg bg-muted/60 p-0.5">
+          {DAY_COUNT_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => changeDayCount(option.value)}
+              aria-pressed={dayCount === option.value}
+              className={cn(
+                "h-7 flex-1 rounded-md text-xs font-medium transition-colors",
+                dayCount === option.value
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground"
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
       </header>
 
+      {/* 3-day / week: compact multi-column overview. Tapping a day header
+          drops back into this same view at 1 day, where the editing gestures
+          (drag to reschedule, tap an empty slot) live. */}
+      {dayCount > 1 && (
+        <MobileMultiDayView
+          days={visibleDays}
+          onSelectDate={(day) => {
+            setSelectedDate(startOfDay(day));
+            changeDayCount(1);
+          }}
+          onEventClick={handleExternalEventClick}
+          onBlockClick={(block) => {
+            onBlockClick?.(block);
+          }}
+        />
+      )}
+
+      {dayCount === 1 && (
+      <>
       {/* All-day banner — shown only when there's at least one all-day
           event for this day. Compact chips matching the desktop. */}
       {allDayEvents.length > 0 && (
@@ -588,8 +668,12 @@ export function MobileCalendarView({
           </div>
         </div>
       </ScrollArea>
+      </>
+      )}
 
-      {/* FAB for creating time blocks */}
+      {/* FAB for creating time blocks — 1-day only; the multi-day overview
+          has no slot to anchor a new block to. */}
+      {dayCount === 1 && (
       <button
         onClick={() => {
           // Default-time logic: when viewing today, anchor at the
@@ -621,6 +705,7 @@ export function MobileCalendarView({
       >
         <Plus className="h-6 w-6" />
       </button>
+      )}
 
       {/* External event detail sheet — read + edit + delete on tap. */}
       <CalendarEventDetailSheet

--- a/apps/web/src/components/mobile/mobile-multi-day-view.tsx
+++ b/apps/web/src/components/mobile/mobile-multi-day-view.tsx
@@ -1,0 +1,222 @@
+import * as React from "react";
+import {
+  endOfDay,
+  format,
+  isSameDay,
+  isToday,
+  startOfDay,
+} from "date-fns";
+import type { CalendarEvent, TimeBlock } from "@open-sunsama/types";
+import { cn } from "@/lib/utils";
+import { ScrollArea } from "@/components/ui";
+import {
+  HOUR_HEIGHT,
+  TIMELINE_START_HOUR,
+  TIMELINE_END_HOUR,
+} from "@/hooks/calendar-dnd-utils";
+import { useCalendarEvents } from "@/hooks/useCalendars";
+import { useTimeBlocksForDateRange } from "@/hooks/useTimeBlocks";
+
+interface MobileMultiDayViewProps {
+  /** Days to show side by side (3 for the 3-day view, 7 for the week). */
+  days: Date[];
+  /** Tap a column header to drop into the single-day timeline for that date. */
+  onSelectDate: (date: Date) => void;
+  onEventClick: (event: CalendarEvent) => void;
+  onBlockClick: (block: TimeBlock) => void;
+  className?: string;
+}
+
+/** Minutes from the top of the timeline for a given instant on `day`. */
+function minutesFromTop(day: Date, time: Date) {
+  const start = startOfDay(day);
+  const mins = (time.getTime() - start.getTime()) / 60000;
+  return mins - TIMELINE_START_HOUR * 60;
+}
+
+/** Chip geometry: clamped to the visible window, with a readable minimum. */
+function chipStyle(day: Date, start: Date, end: Date) {
+  const topMins = Math.max(minutesFromTop(day, start), 0);
+  const endMins = Math.min(
+    minutesFromTop(day, end),
+    (TIMELINE_END_HOUR + 1 - TIMELINE_START_HOUR) * 60
+  );
+  const height = Math.max(((endMins - topMins) / 60) * HOUR_HEIGHT, 16);
+  return { top: (topMins / 60) * HOUR_HEIGHT, height };
+}
+
+/**
+ * The 3-day and week modes of the mobile calendar.
+ *
+ * Standard phone-calendar treatment: one shared hour gutter, a narrow column
+ * per day, and compact chips you tap to open. Editing gestures (drag to
+ * reschedule, tap-empty-slot to create) stay in the 1-day timeline where
+ * there's room for them — tapping a day header jumps there.
+ */
+export function MobileMultiDayView({
+  days,
+  onSelectDate,
+  onEventClick,
+  onBlockClick,
+  className,
+}: MobileMultiDayViewProps) {
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const hours = React.useMemo(
+    () =>
+      Array.from(
+        { length: TIMELINE_END_HOUR - TIMELINE_START_HOUR + 1 },
+        (_, i) => i + TIMELINE_START_HOUR
+      ),
+    []
+  );
+
+  const rangeStart = days[0] ?? new Date();
+  const rangeEnd = days[days.length - 1] ?? rangeStart;
+
+  const { data: events = [] } = useCalendarEvents(
+    startOfDay(rangeStart).toISOString(),
+    endOfDay(rangeEnd).toISOString()
+  );
+  const { data: blocks = [] } = useTimeBlocksForDateRange(
+    startOfDay(rangeStart),
+    endOfDay(rangeEnd)
+  );
+
+  // Scroll to the working day (08:00) on mount, like the day view does.
+  React.useEffect(() => {
+    const viewport = scrollRef.current?.querySelector(
+      "[data-radix-scroll-area-viewport]"
+    );
+    if (viewport) {
+      viewport.scrollTop = Math.max((8 - TIMELINE_START_HOUR) * HOUR_HEIGHT, 0);
+    }
+  }, []);
+
+  return (
+    <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
+      {/* Day headers — tap one to open that day full-width */}
+      <div className="flex flex-shrink-0 border-b bg-background">
+        <div className="w-10 flex-shrink-0 border-r bg-muted/30" />
+        {days.map((day) => (
+          <button
+            key={day.toISOString()}
+            onClick={() => onSelectDate(day)}
+            className={cn(
+              "flex-1 border-r border-border/40 py-1.5 text-center last:border-r-0 active:bg-muted",
+              isToday(day) && "bg-primary/5"
+            )}
+          >
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              {format(day, "EEE")}
+            </div>
+            <div
+              className={cn(
+                "mx-auto mt-0.5 grid h-6 w-6 place-items-center rounded-full text-[13px] font-semibold tabular-nums",
+                isToday(day) && "bg-primary text-primary-foreground"
+              )}
+            >
+              {format(day, "d")}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <ScrollArea className="flex-1" ref={scrollRef}>
+        <div className="flex" style={{ minHeight: hours.length * HOUR_HEIGHT }}>
+          {/* Hour gutter */}
+          <div className="w-10 flex-shrink-0 border-r bg-muted/30">
+            {hours.map((hour) => (
+              <div
+                key={hour}
+                className="relative border-b border-border/50"
+                style={{ height: HOUR_HEIGHT }}
+              >
+                <span className="absolute -top-1.5 right-1 text-[9px] font-medium tabular-nums text-muted-foreground">
+                  {format(new Date(2000, 0, 1, hour), "ha").toLowerCase()}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {/* One column per day */}
+          {days.map((day) => {
+            const dayEvents = events.filter(
+              (event) =>
+                !event.isAllDay && isSameDay(new Date(event.startTime), day)
+            );
+            const dayBlocks = blocks.filter((block) =>
+              isSameDay(new Date(block.startTime), day)
+            );
+            const nowTop = isToday(day)
+              ? (minutesFromTop(day, new Date()) / 60) * HOUR_HEIGHT
+              : null;
+
+            return (
+              <div
+                key={day.toISOString()}
+                className={cn(
+                  "relative flex-1 border-r border-border/40 last:border-r-0",
+                  isToday(day) && "bg-primary/[0.03]"
+                )}
+              >
+                {hours.map((hour) => (
+                  <div
+                    key={hour}
+                    className="border-b border-border/30"
+                    style={{ height: HOUR_HEIGHT }}
+                  />
+                ))}
+
+                {dayBlocks.map((block) => {
+                  const { top, height } = chipStyle(
+                    day,
+                    new Date(block.startTime),
+                    new Date(block.endTime)
+                  );
+                  return (
+                    <button
+                      key={block.id}
+                      onClick={() => onBlockClick(block)}
+                      style={{ top, height }}
+                      className="absolute inset-x-0.5 z-10 overflow-hidden rounded border-l-2 border-primary bg-primary/15 px-1 text-left text-[10px] leading-tight text-foreground active:brightness-95"
+                    >
+                      <span className="line-clamp-2">{block.title}</span>
+                    </button>
+                  );
+                })}
+
+                {dayEvents.map((event) => {
+                  const { top, height } = chipStyle(
+                    day,
+                    new Date(event.startTime),
+                    new Date(event.endTime)
+                  );
+                  return (
+                    <button
+                      key={event.id}
+                      onClick={() => onEventClick(event)}
+                      style={{ top, height }}
+                      className="absolute inset-x-0.5 z-[9] overflow-hidden rounded border-l-2 border-muted-foreground/40 bg-muted/70 px-1 text-left text-[10px] leading-tight text-foreground active:brightness-95"
+                    >
+                      <span className="line-clamp-2">{event.title}</span>
+                    </button>
+                  );
+                })}
+
+                {nowTop !== null && (
+                  <div
+                    className="pointer-events-none absolute inset-x-0 z-20 flex items-center"
+                    style={{ top: nowTop }}
+                  >
+                    <div className="-ml-1 h-1.5 w-1.5 rounded-full bg-red-500" />
+                    <div className="h-px flex-1 bg-red-500" />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/web/src/components/mobile/mobile-tasks-view.tsx
+++ b/apps/web/src/components/mobile/mobile-tasks-view.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { MobileTaskListView } from "./task-list-view";
+import { MobileBoardView } from "./mobile-board-view";
+import type { MobileTasksViewMode } from "./mobile-view-controls";
+import { useSortPreference } from "@/components/kanban/kanban-board-toolbar";
+
+const VIEW_MODE_KEY = "open-sunsama-mobile-tasks-view";
+
+/**
+ * The mobile Tasks tab. Owns the two things the phone layout was missing —
+ * the list/board switch and the sort order — and hands them to whichever view
+ * is showing. The sort preference is the same DB-free localStorage preference
+ * the desktop board uses, so switching devices keeps the chosen order.
+ */
+export function MobileTasksView() {
+  const [viewMode, setViewMode] = React.useState<MobileTasksViewMode>(() => {
+    if (typeof window === "undefined") return "list";
+    return localStorage.getItem(VIEW_MODE_KEY) === "board" ? "board" : "list";
+  });
+  const [sortBy, setSortBy] = useSortPreference();
+
+  const changeViewMode = React.useCallback((mode: MobileTasksViewMode) => {
+    setViewMode(mode);
+    localStorage.setItem(VIEW_MODE_KEY, mode);
+  }, []);
+
+  if (viewMode === "board") {
+    return (
+      <MobileBoardView
+        viewMode={viewMode}
+        onViewModeChange={changeViewMode}
+        sortBy={sortBy}
+        onSortChange={setSortBy}
+      />
+    );
+  }
+
+  return (
+    <MobileTaskListView
+      viewMode={viewMode}
+      onViewModeChange={changeViewMode}
+      sortBy={sortBy}
+      onSortChange={setSortBy}
+    />
+  );
+}

--- a/apps/web/src/components/mobile/mobile-view-controls.tsx
+++ b/apps/web/src/components/mobile/mobile-view-controls.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+import { LayoutGrid, List, ArrowUpDown, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui";
+import type { SortOption } from "@/components/kanban/kanban-board-toolbar";
+
+export type MobileTasksViewMode = "list" | "board";
+
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: "position", label: "Manual" },
+  { value: "priority-desc", label: "Priority (P0 → P3)" },
+  { value: "priority-asc", label: "Priority (P3 → P0)" },
+  { value: "createdAt-desc", label: "Date (Newest first)" },
+  { value: "createdAt-asc", label: "Date (Oldest first)" },
+];
+
+interface MobileViewControlsProps {
+  viewMode: MobileTasksViewMode;
+  onViewModeChange: (mode: MobileTasksViewMode) => void;
+  sortBy: SortOption;
+  onSortChange: (sort: SortOption) => void;
+  className?: string;
+}
+
+/**
+ * The list/board switch and sort menu for the mobile Tasks tab — the two
+ * controls the phone layout was missing entirely next to its desktop
+ * counterpart. Kept to icon-sized targets so it fits beside the date header.
+ */
+export function MobileViewControls({
+  viewMode,
+  onViewModeChange,
+  sortBy,
+  onSortChange,
+  className,
+}: MobileViewControlsProps) {
+  return (
+    <div className={cn("flex items-center gap-1.5", className)}>
+      {/* Segmented list / board switch */}
+      <div className="flex items-center rounded-lg bg-muted/60 p-0.5">
+        {(
+          [
+            { mode: "list" as const, icon: List, label: "List view" },
+            { mode: "board" as const, icon: LayoutGrid, label: "Board view" },
+          ]
+        ).map(({ mode, icon: Icon, label }) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => onViewModeChange(mode)}
+            aria-label={label}
+            aria-pressed={viewMode === mode}
+            className={cn(
+              "flex h-7 w-8 items-center justify-center rounded-md transition-colors",
+              viewMode === mode
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground"
+            )}
+          >
+            <Icon className="h-4 w-4" />
+          </button>
+        ))}
+      </div>
+
+      {/* Sort order */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="Sort order"
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+              sortBy !== "position" && "bg-muted text-foreground"
+            )}
+          >
+            <ArrowUpDown className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          {SORT_OPTIONS.map((option) => (
+            <DropdownMenuItem
+              key={option.value}
+              onClick={() => onSortChange(option.value)}
+              className="flex items-center justify-between text-sm"
+            >
+              <span>{option.label}</span>
+              {sortBy === option.value && <Check className="h-3.5 w-3.5" />}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/web/src/components/mobile/task-list-view.tsx
+++ b/apps/web/src/components/mobile/task-list-view.tsx
@@ -32,6 +32,14 @@ import {
 } from "@dnd-kit/sortable";
 import { cn, formatDuration } from "@/lib/utils";
 import { ViewSearch } from "@/components/ui";
+import {
+  parseSortOption,
+  type SortOption,
+} from "@/components/kanban/kanban-board-toolbar";
+import {
+  MobileViewControls,
+  type MobileTasksViewMode,
+} from "./mobile-view-controls";
 import { useTasks, useReorderTasks } from "@/hooks/useTasks";
 import { MobileTaskCardWithActualTime } from "./mobile-task-card";
 import { SortableMobileTaskCard } from "./sortable-mobile-task-card";
@@ -41,17 +49,32 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
+/** P0 first — matches the desktop day column's ordering. */
+const PRIORITY_RANK: Record<string, number> = { P0: 0, P1: 1, P2: 2, P3: 3 };
+
 interface MobileTaskListViewProps {
   /** The date to show tasks for (defaults to today) */
   date?: Date;
   className?: string;
+  /** List/board switch + sort order, rendered in the header when provided. */
+  viewMode?: MobileTasksViewMode;
+  onViewModeChange?: (mode: MobileTasksViewMode) => void;
+  sortBy?: SortOption;
+  onSortChange?: (sort: SortOption) => void;
 }
 
 /**
  * Mobile-optimized task list view matching Sunsama mobile design.
  * Features sticky header, progress bar, and scrollable task list.
  */
-export function MobileTaskListView({ date, className }: MobileTaskListViewProps) {
+export function MobileTaskListView({
+  date,
+  className,
+  viewMode,
+  onViewModeChange,
+  sortBy = "position",
+  onSortChange,
+}: MobileTaskListViewProps) {
   // Open the backlog sheet when arriving via `/app/tasks?backlog=1`
   // (mobile "More → Backlog"). Initialize the open state straight from the
   // param — clearing the param via navigate would remount this view and
@@ -141,10 +164,28 @@ export function MobileTaskListView({ date, className }: MobileTaskListViewProps)
         notes.toLowerCase().includes(query)
       );
     });
-    const pending = all.filter((task) => !task.completedAt).sort((a, b) => a.position - b.position);
+    // Same sort options as the desktop board; "Manual" keeps drag order.
+    const { field, direction } = parseSortOption(sortBy);
+    const pending = all
+      .filter((task) => !task.completedAt)
+      .sort((a, b) => {
+        if (field === "priority") {
+          const rank = (t: typeof a) => PRIORITY_RANK[t.priority] ?? 2;
+          const diff =
+            direction === "desc" ? rank(a) - rank(b) : rank(b) - rank(a);
+          if (diff !== 0) return diff;
+          return a.position - b.position;
+        }
+        if (field === "createdAt") {
+          const diff =
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          return direction === "desc" ? -diff : diff;
+        }
+        return a.position - b.position;
+      });
     const completed = all.filter((task) => task.completedAt);
     return { pendingTasks: pending, completedTasks: completed };
-  }, [tasks, searchQuery]);
+  }, [tasks, searchQuery, sortBy]);
   
   // Calculate progress statistics
   const stats = React.useMemo(() => {
@@ -187,6 +228,7 @@ export function MobileTaskListView({ date, className }: MobileTaskListViewProps)
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
+    if (sortBy !== "position") return; // reordering only means something in manual order
     const oldIndex = pendingTasks.findIndex((t) => t.id === active.id);
     const newIndex = pendingTasks.findIndex((t) => t.id === over.id);
     
@@ -245,7 +287,15 @@ export function MobileTaskListView({ date, className }: MobileTaskListViewProps)
               onChange={setSearchQuery}
               placeholder="Search tasks…"
             />
-            {!searchQuery && (
+            {!searchQuery && viewMode && onViewModeChange && onSortChange && (
+              <MobileViewControls
+                viewMode={viewMode}
+                onViewModeChange={onViewModeChange}
+                sortBy={sortBy}
+                onSortChange={onSortChange}
+              />
+            )}
+            {!searchQuery && !viewMode && (
               <span className="text-sm tabular-nums text-muted-foreground">
                 {stats.totalEstimatedMins > 0
                   ? formatDuration(stats.totalEstimatedMins)

--- a/apps/web/src/routes/app/tasks.tsx
+++ b/apps/web/src/routes/app/tasks.tsx
@@ -25,7 +25,7 @@ import {
 import { sortableKeyboardCoordinates, arrayMove } from "@dnd-kit/sortable";
 import { TaskRow } from "@/components/tasks/task-row";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { MobileTaskListView } from "@/components/mobile";
+import { MobileTasksView } from "@/components/mobile";
 
 type StatusFilter = "active" | "all" | "completed";
 
@@ -97,7 +97,7 @@ export default function TasksListPage() {
   const isMobile = useIsMobile();
 
   if (isMobile) {
-    return <MobileTaskListView />;
+    return <MobileTasksView />;
   }
 
   return <TasksListPageDesktop />;


### PR DESCRIPTION
Three things, all reported from the phone layout.

## Mobile Tasks tab: list/board switch + sort
The mobile Tasks tab had neither control the desktop has.

- **List ⇄ Board** segmented switch in the header. Board mode is a horizontal snap-scroller of day columns — one day per screen, the same shape as the Ideas board — built from the existing `DayColumn`, which already sizes itself to the viewport below `sm`. That means cards, inline add, drag-to-reorder and cross-day drops behave exactly like the desktop board rather than being reimplemented.
- **Sort menu** with the desktop's options (Manual, Priority P0→P3 / P3→P0, Date newest / oldest), sharing the same stored preference. The list view honours it too, and drag-to-reorder is skipped unless the order is Manual — reordering a priority-sorted list would just snap back.
- The mode is remembered per device.

## Mobile Calendar: Day / 3 days / Week
Standard phone-calendar treatment. 3-day and week render a compact multi-column overview: one shared hour gutter, a column per day, tappable chips for both events and time blocks, today's now-line and date pill. Tapping a day header drops into the 1-day timeline, which keeps the editing gestures (drag to reschedule, tap an empty slot to create). Prev/next step by the visible span, and the choice is remembered.

## Calendar auto-sync recovery
Root cause of "connected but not synced": the 5-minute sync check only selected accounts whose `syncStatus` was `idle` or null. An account that errored once (expired token, provider 5xx) stayed `error` forever, and one interrupted mid-sync (deploy, crash, lost pg-boss job) stayed `syncing` forever — either way the check skipped it permanently.

The check now also queues:
- accounts stuck in `syncing` for more than 30 minutes (dead job — self-heal), and
- accounts in `error` untouched for more than 30 minutes (transient failure — retry),

and logs how many it recovered.

Verified at 375×812: list header shows search + list/board + sort; board mode shows day columns with counts, totals and priority badges, next day peeking for the swipe; the calendar shows Day/3 days/Week with correct ranges (`Aug 25 – Aug 27`, `Aug 24 – Aug 30`), today highlighted, and events placed per day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)