### PR TITLE
fix(cards): completing a card no longer hides its fields

### DIFF
--- a/apps/web/src/components/ideas/idea-card.tsx
+++ b/apps/web/src/components/ideas/idea-card.tsx
@@ -350,7 +350,9 @@ export function IdeaCard({
       </div>
 
       {/* Optional notes preview (rich text) */}
-      {hasNotes && !isCompleted && (
+      {/* Notes preview stays after completion — checking a card off changes
+          the checkbox and strikes the title, nothing else. */}
+      {hasNotes && (
         <HtmlContent
           html={idea.notes!}
           className="pl-6 text-xs leading-snug text-muted-foreground line-clamp-2 [&_p]:m-0 [&_img]:hidden"

--- a/apps/web/src/components/kanban/task-card-content.tsx
+++ b/apps/web/src/components/kanban/task-card-content.tsx
@@ -173,7 +173,7 @@ export function TaskCardContent({
       }}
     >
       {/* Time row (if scheduled) - above checkbox/title like Sunsama */}
-      {formattedTime && !isCompleted && (
+      {formattedTime && (
         <span className="text-[11px] text-muted-foreground">
           {formattedTime}
         </span>
@@ -226,10 +226,8 @@ export function TaskCardContent({
                   "shrink-0 flex items-center gap-0.5 rounded px-1.5 py-0.5",
                   "bg-muted/50",
                   "text-[11px] tabular-nums text-muted-foreground",
-                  "hover:bg-muted transition-colors cursor-pointer",
-                  isCompleted && "opacity-50"
+                  "hover:bg-muted transition-colors cursor-pointer"
                 )}
-                disabled={isCompleted}
               >
                 {formatDuration(task.estimatedMins)}
               </button>
@@ -335,7 +333,6 @@ export function TaskCardContent({
       {/* Subtasks preview - inline with small checkboxes */}
       {subtasksPreview &&
         subtasksPreview.length > 0 &&
-        !isCompleted &&
         !subtasksHidden && (
           <div className="pl-6 space-y-1 mt-0.5">
             {subtasksPreview.map((subtask) => (
@@ -383,7 +380,7 @@ export function TaskCardContent({
         )}
 
       {/* Bottom row: Tag/Project (right-aligned) */}
-      {tag && !isCompleted && (
+      {tag && (
         <div className="flex justify-end">
           <span
             className="text-[11px] px-1.5 py-0.5 rounded"

--- a/apps/web/src/components/mobile/mobile-task-card.tsx
+++ b/apps/web/src/components/mobile/mobile-task-card.tsx
@@ -226,15 +226,12 @@ export function MobileTaskCard({ task, onTaskClick }: MobileTaskCardProps) {
     <MobileTaskCardBase
       task={task}
       onTaskClick={onTaskClick}
-      renderTimeDisplay={({ isCompleted, estimatedMins }) => {
+      renderTimeDisplay={({ estimatedMins }) => {
         if (estimatedMins == null || estimatedMins <= 0) return null;
         
         return (
           <div
-            className={cn(
-              "shrink-0 text-xs tabular-nums text-muted-foreground",
-              isCompleted && "opacity-50"
-            )}
+            className="shrink-0 text-xs tabular-nums text-muted-foreground"
           >
             {formatDuration(estimatedMins)}
           </div>
@@ -263,17 +260,16 @@ export function MobileTaskCardWithActualTime({
     <MobileTaskCardBase
       task={task}
       onTaskClick={onTaskClick}
-      renderTimeDisplay={({ isCompleted }) => {
+      renderTimeDisplay={() => {
         if (!displayText) return null;
-        
+
         return (
           <div
             className={cn(
               "shrink-0 flex items-center gap-1 text-xs tabular-nums whitespace-nowrap",
               isTimerRunning
                 ? "text-emerald-600 dark:text-emerald-400"
-                : "text-muted-foreground",
-              isCompleted && "opacity-50"
+                : "text-muted-foreground"
             )}
           >
             {isTimerRunning && (


### PR DESCRIPTION
Completing a card was dropping content unrelated to completion, so checking something off changed what the card told you.

**What was hidden on completion**
- **Ideas cards**: the notes preview.
- **Board / task cards**: the scheduled-time row, the subtask preview, the tag/project chip — and the estimate badge was dimmed *and* `disabled`, so you couldn't change it.
- **Mobile task cards**: the time / estimate was dimmed.

**Now** completion changes exactly two things: the checkbox fills in and the title is struck through. The card still mutes as a whole (unchanged, and consistent between tasks and ideas). Notes, priority, estimate, subtasks, scheduled time and tag all stay exactly where they were, and the estimate stays editable.

Verified on the Ideas board: completed cards keep their notes and priority badges, with only the checkbox and strikethrough differing from their pending state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)